### PR TITLE
[Feature] Add hideTop prop to AppTable to hide the top part

### DIFF
--- a/docs/components/table/AppTablePlayground.vue
+++ b/docs/components/table/AppTablePlayground.vue
@@ -30,7 +30,7 @@ const controls = createControls({
     default: false,
     label: 'Is loading',
   },
-  hideTop: {
+  isTopHidden: {
     type: 'switch',
     default: false,
     label: 'Hide top',

--- a/docs/components/table/app-table.md
+++ b/docs/components/table/app-table.md
@@ -24,7 +24,7 @@ import AppTablePlayground from './AppTablePlayground.vue'
 | rowClick             | `((row: TSchema) => void)` \| `null`                  | Returns the row as a button.                      | `null`     |
 | rowTo                | `((row: TSchema) => RouteLocationNamedRaw)` \| `null` | Returns the row as a RouterLink                   | `null`     |
 | rowTarget            | `string` \| `undefined`                               | Adds a target to the RouterLink when using row-to | `undefined` |
-| hideTop              | `boolean` \| `undefined`                              | Hides the top of the table when set to true       | `false`    |
+| isTopHidden          | `boolean` \| `undefined`                              | Hides the top of the table when set to true       | `false`    |
 | shouldPinFirstColumn | `boolean` \| `undefined`                              | Whether the first column of the table is pinned.  | `false`    |
 | shouldPinLastColumn  | `boolean` \| `undefined`                              | Whether the last column of the table is pinned.   | `false`    |
 

--- a/packages/components/src/components/table/AppTable.vue
+++ b/packages/components/src/components/table/AppTable.vue
@@ -26,10 +26,10 @@ import type { TableColumn } from '@/types/table.type'
 const props = withDefaults(
   defineProps<{
     isLoading: boolean
+    isTopHidden?: boolean
     columns: TableColumn<TSchema>[]
     data: PaginatedData<TSchema> | null
     filters: PaginationFilter<TFilters>[]
-    hideTop?: boolean
     pagination: Pagination<TFilters>
     rowClick?: ((row: TSchema) => void) | null
     rowTarget?: string
@@ -39,7 +39,7 @@ const props = withDefaults(
     title: string
   }>(),
   {
-    hideTop: false,
+    isTopHidden: false,
     rowClick: null,
     rowTo: null,
     shouldPinFirstColumn: false,
@@ -145,7 +145,7 @@ onBeforeUnmount(() => {
 <template>
   <div class="relative flex h-full flex-1 flex-col overflow-hidden rounded-xl border border-solid border-border bg-background">
     <AppTableTop
-      v-if="props.hideTop !== true"
+      v-if="!isTopHidden"
       :is-loading="props.isLoading"
       :title="props.title"
       :total="props.data?.total ?? null"


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add `hideTop` to AppTable to hide the top part when set to true

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.