### PR TITLE
[Feature] Add prevent click outside prop

### DIFF
--- a/packages/components/src/components/dialog/AppDialog.vue
+++ b/packages/components/src/components/dialog/AppDialog.vue
@@ -30,10 +30,16 @@ const props = withDefaults(defineProps<{
    * @default false
    */
   hideCloseButton?: boolean
+  /**
+   * Prevent clicks outside the dialog content to close the dialog
+   * @default false
+   */
+  shouldPreventClickOutside?: boolean
 }>(), {
   triggerId: null,
   animateFromTrigger: false,
   hideCloseButton: false,
+  shouldPreventClickOutside: false,
 })
 
 const emit = defineEmits<{
@@ -200,6 +206,7 @@ watch(isActuallyOpen, () => {
           <AppDialogContent
             v-if="isActuallyOpen"
             :hide-close-button="props.hideCloseButton"
+            :should-prevent-click-outside="props.shouldPreventClickOutside"
           >
             <slot />
           </AppDialogContent>

--- a/packages/components/src/components/dialog/AppDialogContent.vue
+++ b/packages/components/src/components/dialog/AppDialogContent.vue
@@ -5,11 +5,17 @@ import AppDialogCloseButton from '@/components/dialog/AppDialogCloseButton.vue'
 
 const props = defineProps<{
   hideCloseButton: boolean
+  shouldPreventClickOutside: boolean
 }>()
 
 function onInteractOutside(e: CustomEvent): void {
-  const target = e.target as HTMLElement
+  if (props.shouldPreventClickOutside) {
+    e.preventDefault()
 
+    return
+  }
+
+  const target = e.target as HTMLElement
   const isOverlay = target.classList.contains('dialog-overlay')
 
   if (!isOverlay) {


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Allow a prop on AppDialog to prevent clicks outside the content to close the dialog.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.