### PR TITLE
[FIX] - Change blur location on DatePickers

### DIFF
--- a/packages/components/src/components/date/AppDatePicker.vue
+++ b/packages/components/src/components/date/AppDatePicker.vue
@@ -156,12 +156,12 @@ function onYearSelect(number: number): void {
       :max-value="maxDate"
       :locale="locale"
       :disabled="props.isDisabled"
-      @blur="onBlur"
     >
       <AppDatePickerField
         :is-invalid="props.isInvalid"
         type="date"
         @date-click="onTriggerClick"
+        @blur="onBlur"
       />
 
       <AppDateCalendarPickerContent

--- a/packages/components/src/components/date/AppDatePickerField.vue
+++ b/packages/components/src/components/date/AppDatePickerField.vue
@@ -16,6 +16,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
+  blur: []
   dateClick: []
 }>()
 
@@ -39,6 +40,10 @@ function formatMonth(month: null | string | undefined): string {
   return new Date(`2021-${month}-01`).toLocaleString(locale.value, {
     month: 'long',
   })
+}
+
+function onBlur(): void {
+  emit('blur')
 }
 </script>
 
@@ -65,6 +70,7 @@ function formatMonth(month: null | string | undefined): string {
             v-if="item.part === 'month'"
             :part="item.part"
             class="rounded-md p-0.5 focus:shadow-[0_0_0_2px] focus:shadow-primary focus:outline-none data-[placeholder]:text-input-placeholder"
+            @blur="onBlur"
           >
             {{ formatMonth(item.value) }}
           </DatePickerInput>
@@ -73,6 +79,7 @@ function formatMonth(month: null | string | undefined): string {
           <DatePickerInput
             v-if="item.part === 'literal'"
             :part="item.part"
+            @blur="onBlur"
           >
             {{ item.value }}
           </DatePickerInput>
@@ -80,6 +87,7 @@ function formatMonth(month: null | string | undefined): string {
             v-else
             :part="item.part"
             class="rounded-md p-0.5 focus:shadow-[0_0_0_2px] focus:shadow-primary focus:outline-none data-[placeholder]:text-input-placeholder"
+            @blur="onBlur"
           >
             {{ item.value }}
           </DatePickerInput>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

blur on <Datepickers/> were on the wrong component.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.