### PR TITLE
fix: make appselect clear button optional

### DIFF
--- a/docs/components/select/AppSelectPlayground.vue
+++ b/docs/components/select/AppSelectPlayground.vue
@@ -36,6 +36,11 @@ const controls = createControls({
     label: 'Is Loading',
     type: 'switch',
   },
+  hasClearButton: {
+    default: true,
+    label: 'Has Clear Button',
+    type: 'switch',
+  },
 })
 
 const userItems: SelectItem<User>[] = [

--- a/docs/components/select/app-select.md
+++ b/docs/components/select/app-select.md
@@ -11,27 +11,28 @@ import AppSelectPlayground from './AppSelectPlayground.vue'
 
 ## Props
 
-| Prop                      | Type                   | Description                                               | Default     |
-| ------------------------- | ---------------------- | --------------------------------------------------------- | -------     |
-| items*                    | `SelectItem<T>[]`      | The items to display in the select.                       |             |
-| displayFn*                | `(value: T) => string` | Display function for the selected value.                  |             |
-| id                        | `string \| null`       | The id of the select                                      | `null`      |
-| isDisabled                | `boolean`              | Whether the select is disabled.                           | `false`     |
-| isInvalid                 | `boolean`              | Whether the select is in an invalid state.                | `false`     |
-| isLoading                 | `boolean`              | Whether the select is loading.                            | `false`     |
-| iconLeft                  | `Icon`                 | The icon to display on the left side of the select.       | `undefined` |
-| placeholder               | `null` \| `string`     | The placeholder text to display when the select is empty. | `null`      |
+| Prop           | Type                   | Description                                               | Default     |
+|----------------|------------------------|-----------------------------------------------------------|-------------|
+| items*         | `SelectItem<T>[]`      | The items to display in the select.                       |             |
+| displayFn*     | `(value: T) => string` | Display function for the selected value.                  |             |
+| id             | `string \| null`       | The id of the select                                      | `null`      |
+| isDisabled     | `boolean`              | Whether the select is disabled.                           | `false`     |
+| isInvalid      | `boolean`              | Whether the select is in an invalid state.                | `false`     |
+| isLoading      | `boolean`              | Whether the select is loading.                            | `false`     |
+| iconLeft       | `Icon`                 | The icon to display on the left side of the select.       | `undefined` |
+| placeholder    | `null` \| `string`     | The placeholder text to display when the select is empty. | `null`      |
+| hasClearButton | `boolean`              | Whether the select has a clear button.                    | `true`      |
 
 ## v-model
 
 | Prop                   | Type                   | Description              |
-| ---------------------- | ---------------------- | ------------------------ |
+|------------------------|------------------------|--------------------------|
 | v-model **(required)** | `SelectItem` \| `null` | The value of the select. |
 
 ## Events
 
 | Event Name | Description                                                  |
-| ---------- | ------------------------------------------------------------ |
+|------------|--------------------------------------------------------------|
 | blur       | Emitted when the select loses focus.                         |
 | filter     | Emitted when the select filters options based on user input. |
 

--- a/docs/components/select/form-select.md
+++ b/docs/components/select/form-select.md
@@ -6,30 +6,31 @@ sidebar: auto
 
 ## Props
 
-| Prop       | Type                      | Description                                                  | Default          |
-|------------|---------------------------|--------------------------------------------------------------|------------------|
-| label **(required)**      | `string`                  | The label of the select.                                   |                 |
-| items **(required)**    | `SelectItem<T>[]`           | The items of the select.                                 |                 |
-| displayFn  **(required)**      | `(value: T) => string` | Display function for the selected value.                           |                                  |
-| isTouched **(required)**  | `boolean`                 | Whether the select has been touched (focused and blurred). | `false`          |
-| errors **(required)**     | `FormFieldErrors`         | The errors associated with the select.                     |                 |
-| isDisabled | `boolean`                 | Whether the select is disabled.                            | `false`          |
-| isLoading  | `boolean`                 | Whether the select is loading.                             | `false`          |
-| isRequired | `boolean`                 | Whether the select is required.                            | `false`          |
-| placeholder| `null` \| `string`          | The placeholder of the select.                             | `null`           |
+| Prop                      | Type                   | Description                                                | Default |
+|---------------------------|------------------------|------------------------------------------------------------|---------|
+| label **(required)**      | `string`               | The label of the select.                                   |         |
+| items **(required)**      | `SelectItem<T>[]`      | The items of the select.                                   |         |
+| displayFn  **(required)** | `(value: T) => string` | Display function for the selected value.                   |         |
+| isTouched **(required)**  | `boolean`              | Whether the select has been touched (focused and blurred). | `false` |
+| errors **(required)**     | `FormFieldErrors`      | The errors associated with the select.                     |         |
+| isDisabled                | `boolean`              | Whether the select is disabled.                            | `false` |
+| isLoading                 | `boolean`              | Whether the select is loading.                             | `false` |
+| isRequired                | `boolean`              | Whether the select is required.                            | `false` |
+| placeholder               | `null` \| `string`     | The placeholder of the select.                             | `null`  |
+| hasClearButton            | `boolean`              | Whether the select has a clear button.                     | `true`  |
 
 ## v-model
 
-| Prop       | Type           | Description                                          |
-|------------|----------------|------------------------------------------------------|
-| v-model    | `T` \| `null` | The value of the select.                           |
+| Prop    | Type          | Description              |
+|---------|---------------|--------------------------|
+| v-model | `T` \| `null` | The value of the select. |
 
 ## Events
 
-| Event Name  | Description                                          |
-|-------------|------------------------------------------------------|
-| blur        | Emitted when the select loses focus.               |
-| filter      | Emitted when the select is filtered.              |
+| Event Name | Description                          |
+|------------|--------------------------------------|
+| blur       | Emitted when the select loses focus. |
+| filter     | Emitted when the select is filtered. |
 
 ## Example Usage
 

--- a/packages/components/src/components/input/phone-number/FormPhoneNumberInput.vue
+++ b/packages/components/src/components/input/phone-number/FormPhoneNumberInput.vue
@@ -208,6 +208,7 @@ watch(model, (value) => {
         :display-fn="() => ''"
         :is-disabled="props.isDisabled"
         :is-required="props.isRequired"
+        :has-clear-button="false"
         class="w-16"
         select-trigger-class="rounded-r-none focus-within:z-[1] relative"
       >

--- a/packages/components/src/components/select/AppSelect.vue
+++ b/packages/components/src/components/select/AppSelect.vue
@@ -28,6 +28,11 @@ const props = withDefaults(
      */
     id?: null | string
     /**
+     * Whether the select has a clear button.
+     * @default true
+     */
+    hasClearButton?: boolean
+    /**
      * Whether the select chevron is hidden.
      */
     isChevronHidden?: boolean
@@ -71,6 +76,7 @@ const props = withDefaults(
   }>(),
   {
     id: null,
+    hasClearButton: true,
     isChevronHidden: false,
     isDisabled: false,
     isInvalid: false,
@@ -161,7 +167,7 @@ const popoverContainerClasses = computed<string>(() => selectStyle.popoverContai
             class="mr-3"
           >
             <AppIcon
-              :class="[triggerIconClasses, { 'ml-4': model !== null }]"
+              :class="[triggerIconClasses, { 'ml-4': model !== null && props.hasClearButton }]"
               icon="chevronDown"
               size="sm"
             />
@@ -169,7 +175,7 @@ const popoverContainerClasses = computed<string>(() => selectStyle.popoverContai
         </AppSelectTrigger>
 
         <AppUnstyledButton
-          v-if="model !== null"
+          v-if="model !== null && props.hasClearButton"
           class="relative right-14 flex w-0 items-center"
           @click.stop="onClearButtonClick"
         >

--- a/packages/components/src/components/select/FormSelect.vue
+++ b/packages/components/src/components/select/FormSelect.vue
@@ -11,6 +11,11 @@ import type {
 const props = withDefaults(
   defineProps<{
     /**
+     * Whether the select has a clear button.
+     * @default true
+     */
+    hasClearButton?: boolean
+    /**
      * Whether the select is disabled.
      */
     isDisabled?: boolean
@@ -56,12 +61,15 @@ const props = withDefaults(
      */
     tooltip?: string
   }>(),
-  { isDisabled: false,
+  {
+    hasClearButton: true,
+    isDisabled: false,
     isLoading: false,
     isRequired: false,
     isTouched: false,
     iconLeft: undefined,
-    placeholder: null },
+    placeholder: null,
+  },
 )
 
 const emit = defineEmits<{
@@ -97,6 +105,7 @@ function onBlur(): void {
       :is-disabled="props.isDisabled"
       :is-required="props.isRequired"
       :is-loading="props.isLoading"
+      :has-clear-button="props.hasClearButton"
       :placeholder="props.placeholder"
       @blur="onBlur"
     >


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Makes the clear button optional on the AppSelect & FormSelect
- Removes clear button from FormPhoneNumberInput

### 📸 Screenshots (if appropriate)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.