### PR TITLE
Don't trigger `build` during `postinstall` (improves CI perf.)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "build": "rimraf packages/vue-core/dist && pnpm run -r build",
     "docs:dev": "pnpm run -r docs:dev",
-    "postinstall": "pnpm build",
     "docs:build": "pnpm run -r cli:generate && pnpm run -r docs:build",
     "pub:release": "cd packages/components && pnpm pub:release --no-git-checks",
     "pub:release-query": "cd packages/query && pnpm pub:release --no-git-checks",


### PR DESCRIPTION
I don't think there's any need for this? Any developer will build whatever they need during development.

Additionally, it's "dumb": it builds every package after an installation, with no way to control what should be built.