### PR TITLE
fix(Select): fix blur not being emitted when dropdown is closed with `isDropdownHidden`

### DIFF
--- a/.changeset/easy-hands-sin.md
+++ b/.changeset/easy-hands-sin.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/vue-core-components": patch
+---
+
+Select: Closing the dropdown with `isDropdownHidden` now correctly triggers the blur event.

--- a/packages/components-next/src/components/select/parts/SelectRoot.vue
+++ b/packages/components-next/src/components/select/parts/SelectRoot.vue
@@ -216,7 +216,7 @@ function onRootFocusOut(): void {
   setTimeout(() => {
     const isFocusInsideRoot = rootRef.value?.$el.contains(document.activeElement)
 
-    if (!isFocusInsideRoot && !isDropdownVisible.value) {
+    if (!isFocusInsideRoot && (!isDropdownVisible.value || props.isDropdownHidden)) {
       hasSelectRootFocusIn.value = false
 
       onBlur()


### PR DESCRIPTION
### Description

### Checklist
- [ ] Have you added tests for new features?
- [ ] Have you updated the documentation?
- [ ] Have you linked an issue or discussion (if applicable)?