### PR TITLE
feat(opentelemetry): reduce trace noise

### DIFF
--- a/.changeset/itchy-seas-like.md
+++ b/.changeset/itchy-seas-like.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/opentelemetry": patch
+---
+
+Reduce trace noise by requiring parent trace for redis, and ignoring pg-connect for postgres.

--- a/packages/api/opentelemetry/lib/register-instrumentation.ts
+++ b/packages/api/opentelemetry/lib/register-instrumentation.ts
@@ -15,7 +15,8 @@ export function registerInstrumentation (
     instrumentations: [
       new PgInstrumentation({
         enhancedDatabaseReporting: true,
-        requireParentSpan: true
+        requireParentSpan: true,
+        ignoreConnectSpans: true
       }),
       new HttpInstrumentation({
         requestHook: (span: Span, request: ClientRequest | IncomingMessage): void => {
@@ -52,7 +53,8 @@ export function registerInstrumentation (
           })
 
           return `${cmdName} ${args.join(' ')}`
-        }
+        },
+        requireParentSpan: true
       }),
       ...extraInstrumentations
     ]


### PR DESCRIPTION
Reduces trace noise by:

- Requiring parent span for Redis, so PING will no longer show
<img width="154" height="61" alt="CleanShot 2026-04-11 at 08 53 51@2x" src="https://github.com/user-attachments/assets/9de77cf0-d639-4a97-a181-bc134fa254a6" />

- Ignoring pg-pool.connect and pg.connect traces
<img width="688" height="216" alt="CleanShot 2026-04-11 at 08 57 07@2x" src="https://github.com/user-attachments/assets/bf2b3ca9-a0d5-485a-82c0-36a41edeb8eb" />
