### PR TITLE
feat(design-system): lean button skill

### DIFF
--- a/packages/web/design-system/skills/_index/SKILL.md
+++ b/packages/web/design-system/skills/_index/SKILL.md
@@ -6,7 +6,6 @@ description: >
   with a decision tree for component selection.
 type: index
 library: vue-core-design-system
-library_version: "0.8.0"
 ---
 
 # @wisemen/vue-core-design-system — Skill Index

--- a/packages/web/design-system/skills/_index/SKILL.md
+++ b/packages/web/design-system/skills/_index/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: design-system-index
+description: >
+  Master index for @wisemen/vue-core-design-system. Read this first to find the
+  right skill for any component or pattern. Lists all skills organized by category
+  with a decision tree for component selection.
+type: index
+library: vue-core-design-system
+library_version: "0.8.0"
+---
+
+# @wisemen/vue-core-design-system — Skill Index
+
+Read this skill first to route to the correct component or foundation skill.
+
+## Foundations
+
+Load these before working with components in their category.
+
+| Skill | Path | Load When |
+|-------|------|-----------|
+| Architecture | `foundations/architecture/` | Understanding parts pattern, context system, file conventions |
+| Styling | `foundations/styling/` | Customizing styles, design tokens, dark mode, tv() |
+| Input System | `foundations/input-system/` | Working with any input/form component |
+| Overlay System | `foundations/overlay-system/` | Working with dialogs, popovers, tooltips |
+| Layout System | `foundations/layout-system/` | Building page layouts, sidebars, dashboard pages |
+
+## Component Quick Reference
+
+### Buttons
+
+| Component | Skill | Use When |
+|-----------|-------|----------|
+| `UIButton` | `components/button/` | Primary action trigger with label |
+| `UIIconButton` | `components/button/` | Icon-only action (toolbars, compact UI) |
+| `UILink` | `components/button/` | Navigation-styled button or anchor |
+
+### Inputs
+
+| Component | Skill | Use When |
+|-----------|-------|----------|
+| `UITextField` | `components/text-field/` | Single-line text: name, email, password, search, URL |
+| `UITextareaField` | `components/textarea-field/` | Multi-line text input |
+| `UINumberField` | `components/number-field/` | Numeric value with +/- controls |
+| `UIAutocomplete` | `components/autocomplete/` | Searchable single-value selection with custom items |
+| `UISelect` | `components/select/` | Single or multi-select from a list of options |
+
+### Form Controls
+
+| Component | Skill | Use When |
+|-----------|-------|----------|
+| `UICheckbox` | `components/checkbox/` | Single boolean toggle |
+| `UICheckboxGroup` | `components/checkbox-group/` | Multiple checkboxes with array binding |
+| `UIRadioGroup` | `components/radio-group/` | Exclusive choice from a set |
+| `UISwitch` | `components/switch/` | Toggle on/off state |
+
+### Navigation
+
+| Component | Skill | Use When |
+|-----------|-------|----------|
+| `UIBreadcrumbs` | `components/breadcrumbs/` | Page hierarchy trail |
+| `UIMenuItem` | `components/menu-item/` | Row item in a menu or list |
+| `UIDropdownMenu` | `components/dropdown-menu/` | Contextual action menu |
+| `UITabs` | `components/tabs/` | Tabbed content navigation |
+
+### Layout
+
+| Component | Skill | Use When |
+|-----------|-------|----------|
+| `UIRowLayout` | `components/row-layout/` | Horizontal flex container |
+| `UIColumnLayout` | `components/column-layout/` | Vertical flex container |
+| `UILayout` | `components/layout/` | Top-level app shell |
+| `UIDashboardPage` | `components/page/` | Full dashboard page with header, actions, detail pane |
+| `UIMainSidebar` | `components/sidebar/` | Main navigation sidebar |
+
+### Overlays
+
+| Component | Skill | Use When |
+|-----------|-------|----------|
+| `UIDialog` | `components/dialog/` | Modal dialog with custom content |
+| `UIConfirmDialog` | `components/confirm-dialog/` | Yes/no confirmation prompt |
+| `UIFormDialog` | `components/form-dialog/` | Dialog with integrated form (internal, not in main export) |
+| `UIPopover` | `components/popover/` | Floating panel anchored to trigger |
+| `UITooltip` | `components/tooltip/` | Hover text tooltip |
+| `UIActionTooltip` | `components/action-tooltip/` | Tooltip with label + keyboard shortcut |
+
+### Display
+
+| Component | Skill | Use When |
+|-----------|-------|----------|
+| `UIBadge` | `components/badge/` | Colored label tag |
+| `UINumberBadge` | `components/number-badge/` | Numeric count indicator |
+| `UIDot` | `components/dot/` | Small colored status circle |
+| `UIText` | `components/text/` | Typography with truncation detection |
+| `UIAvatar` | `components/avatar/` | User avatar (image or initials) |
+| `UILoader` | `components/loader/` | Loading spinner |
+| `UICard` | `components/card/` | Bordered container |
+| `UISeparator` | `components/separator/` | Horizontal/vertical divider |
+| `UITimeline` | `components/timeline/` | Vertical activity timeline |
+| `UISkeletonItem` | `components/skeleton-item/` | Loading placeholder |
+| `UIAdaptiveContent` | `components/adaptive-content/` | Space-adaptive container |
+| `UIScrollable` | `components/scrollable/` | Managed scroll wrapper (internal, not in main export) |
+| `UIKeyboardShortcut` | `components/keyboard-shortcut/` | Keyboard key combo display |
+
+### Infrastructure
+
+| Component | Skill | Use When |
+|-----------|-------|----------|
+| `UIConfigProvider` | `components/config-provider/` | App-level config (locale, maps key, teleport) |
+| `UIThemeProvider` | `components/theme-provider/` | Light/dark/system theme |
+| `UIForm` | `components/form/` | Form wrapper with unsaved changes (internal, not in main export) |
+| `UIClickableElement` | `components/clickable-element/` | Base clickable primitive |
+| `UIInteractable` | `components/interactable/` | Base interactive wrapper |
+
+## Decision Tree
+
+**"I need the user to input..."**
+- Text (single line) -> `text-field`
+- Text (multi-line) -> `textarea-field`
+- A number -> `number-field`
+- A selection from a list -> `select`
+- A searchable selection -> `autocomplete` (single value) or `select` (with search)
+- Yes/no (inline) -> `checkbox` or `switch`
+- One of several options -> `radio-group`
+- Multiple of several options -> `checkbox-group`
+
+**"I need to show..."**
+- A modal -> `dialog`, `confirm-dialog`, or `form-dialog`
+- A floating panel -> `popover`
+- Hover help text -> `tooltip` or `action-tooltip`
+- A menu of actions -> `dropdown-menu`
+- A status indicator -> `dot` or `badge`
+- A count -> `number-badge`
+- User identity -> `avatar`
+- Loading state -> `loader` or `skeleton-item`
+
+**"I need to lay out..."**
+- Items horizontally -> `row-layout`
+- Items vertically -> `column-layout`
+- A full page -> `page` (DashboardPage)
+- App navigation -> `sidebar`
+- Tabbed sections -> `tabs`
+
+## Foundation Prerequisites
+
+| Component Category | Required Foundation |
+|---|---|
+| Any input or form control | `input-system` |
+| Dialog, ConfirmDialog, FormDialog | `overlay-system` |
+| DashboardPage, Sidebar | `layout-system` |
+| Custom styling or theming | `styling` |
+| Building new components | `architecture` |

--- a/packages/web/design-system/skills/components/action-tooltip/SKILL.md
+++ b/packages/web/design-system/skills/components/action-tooltip/SKILL.md
@@ -6,7 +6,6 @@ description: >
   skill when you need a standardized tooltip for buttons or actions with shortcut hints.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: overlay
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/action-tooltip/SKILL.md
+++ b/packages/web/design-system/skills/components/action-tooltip/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: action-tooltip
+description: >
+  A pre-built tooltip that displays a text label and an optional keyboard shortcut badge.
+  Wraps UITooltip with UITooltipText and UIKeyboardShortcut in a row layout. Load this
+  skill when you need a standardized tooltip for buttons or actions with shortcut hints.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: overlay
+requires: []
+exports:
+  - UIActionTooltip
+---
+
+# UIActionTooltip
+
+A pre-built tooltip that displays a text label and an optional keyboard shortcut indicator, designed for action buttons and toolbar items.
+
+## When to Use
+
+- Adding a tooltip with a keyboard shortcut hint to an icon button (e.g., "Save" with shortcut badge)
+- Providing a standardized label tooltip for any interactive element
+- Showing a tooltip on toolbar buttons with both a description and shortcut key
+
+**Use instead:** `UITooltip` for fully custom tooltip content, `UIPopover` for interactive floating panels.
+
+## Import
+
+```ts
+import { UIActionTooltip } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIActionTooltip, UIIconButton } from '@wisemen/vue-core-design-system'
+import { SearchMdIcon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIActionTooltip label="Search" keyboard-shortcut="⌘K">
+    <UIIconButton :icon="SearchMdIcon" label="Search" />
+  </UIActionTooltip>
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string \| null` | `null` | The text displayed in the tooltip. |
+| `keyboardShortcut` | `string \| null` | `null` | Visual keyboard shortcut text (e.g., "⌘K", "Ctrl+S"). |
+| `isDisabled` | `boolean` | `false` | When true, the tooltip is hidden. |
+| `disableCloseOnTriggerClick` | `boolean` | `false` | When true, clicking the trigger will not close the tooltip. |
+| `popoverAlign` | `'center' \| 'start' \| 'end'` | `'center'` | Alignment relative to the trigger. |
+| `popoverSide` | `'top' \| 'right' \| 'bottom' \| 'left'` | `'top'` | Which side the tooltip appears on. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | The trigger element that activates the tooltip on hover/focus. Must be a single root element. |
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+This component has no size/variant options. It always renders with a fixed side offset of 4px and `disableHoverableContent` set to true.
+
+## Examples
+
+### Label Only
+
+```vue
+<script setup lang="ts">
+import { UIActionTooltip, UIIconButton } from '@wisemen/vue-core-design-system'
+import { Trash01Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIActionTooltip label="Delete">
+    <UIIconButton :icon="Trash01Icon" label="Delete" />
+  </UIActionTooltip>
+</template>
+```
+
+### With Keyboard Shortcut
+
+```vue
+<UIActionTooltip label="Save" keyboard-shortcut="⌘S">
+  <UIIconButton :icon="SaveIcon" label="Save" />
+</UIActionTooltip>
+```
+
+### Shortcut Only
+
+```vue
+<UIActionTooltip keyboard-shortcut="���Z">
+  <UIButton label="Undo" />
+</UIActionTooltip>
+```
+
+### Bottom Placement
+
+```vue
+<UIActionTooltip label="Settings" popover-side="bottom">
+  <UIIconButton :icon="SettingsIcon" label="Settings" />
+</UIActionTooltip>
+```
+
+### Disabled
+
+```vue
+<UIActionTooltip label="Not shown" :is-disabled="true">
+  <UIButton label="No tooltip" />
+</UIActionTooltip>
+```
+
+## Anatomy
+
+```
+UIActionTooltip
+└── UITooltip (disableHoverableContent, popoverSideOffset=4)
+    ├── #trigger
+    │   └── <slot /> (default slot)
+    └── #content
+        └── UITooltipContent
+            └── UIRowLayout (gap="sm")
+                ├── UITooltipText (if label is not null)
+                └── UIKeyboardShortcut (if keyboardShortcut is not null)
+```
+
+## Styling
+
+**Style file:** No separate style file. Uses UITooltipContent and UITooltipText for styling.
+The tooltip content renders in a row layout with `gap="sm"` between the label and the keyboard shortcut badge.
+
+## Common Mistakes
+
+### LOW: Providing neither label nor keyboardShortcut
+
+If both `label` and `keyboardShortcut` are null, the tooltip renders an empty panel. Always provide at least one.
+
+### LOW: Using for interactive content
+
+UIActionTooltip is non-interactive (`disableHoverableContent` is forced to true). Use `UIPopover` for content that the user needs to interact with.
+
+## Accessibility
+
+- Inherits all accessibility features from UITooltip (ARIA attributes, keyboard focus activation, Escape to dismiss).
+- The label text is exposed to screen readers via `aria-describedby`.
+- Keyboard shortcuts shown in the tooltip are purely visual hints and do not register actual keyboard bindings.
+
+## See Also
+
+- [tooltip](../tooltip/SKILL.md) -- For fully custom tooltip content
+- [popover](../popover/SKILL.md) -- For interactive floating content
+- [keyboard-shortcut](../keyboard-shortcut/SKILL.md) -- The keyboard shortcut badge component used internally

--- a/packages/web/design-system/skills/components/adaptive-content/SKILL.md
+++ b/packages/web/design-system/skills/components/adaptive-content/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: adaptive-content
+description: >
+  A container that conditionally renders child blocks based on available horizontal space
+  and an explicit priority order. Lower-priority blocks are progressively hidden when the
+  container overflows, exposing a hidden-block count for building overflow indicators.
+type: component
+category: display
+library: vue-core-design-system
+library_version: "0.8.0"
+requires: []
+exports:
+  - UIAdaptiveContent
+  - UIAdaptiveContentBlock
+---
+
+# UIAdaptiveContent
+
+A responsive container that measures its width and progressively hides lower-priority child blocks until the remaining content fits, exposing a count of hidden blocks for building overflow UIs.
+
+## When to Use
+
+- Displaying a row of items (tabs, badges, tags, toolbar actions) that must gracefully collapse when horizontal space is limited
+- Building responsive tab bars where hidden tabs overflow into a dropdown menu
+- Showing a badge group with a "+N" overflow indicator
+
+**Use instead:** CSS `overflow: hidden` with `text-overflow: ellipsis` for single-line text truncation. Use a scroll container when all items should remain accessible via scrolling.
+
+## Import
+
+```ts
+import { UIAdaptiveContent, UIAdaptiveContentBlock } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIAdaptiveContent, UIAdaptiveContentBlock } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIAdaptiveContent v-slot="{ hiddenBlockCount }">
+    <div style="display: flex; gap: 8px; overflow: hidden;">
+      <UIAdaptiveContentBlock :priority="0">
+        <span>Most important</span>
+      </UIAdaptiveContentBlock>
+
+      <UIAdaptiveContentBlock :priority="1">
+        <span>Second</span>
+      </UIAdaptiveContentBlock>
+
+      <UIAdaptiveContentBlock :priority="2">
+        <span>Third</span>
+      </UIAdaptiveContentBlock>
+
+      <span v-if="hiddenBlockCount > 0">+{{ hiddenBlockCount }} more</span>
+    </div>
+  </UIAdaptiveContent>
+</template>
+```
+
+## API
+
+### UIAdaptiveContent
+
+#### Props
+
+This component has no props. It renders as a Reka UI `Primitive` with `as-child` set to true, meaning it does not produce a wrapper DOM element -- it delegates to the single root element in its default slot.
+
+#### Slots
+
+| Slot | Slot Props | Description |
+|------|------------|-------------|
+| `default` | `{ hiddenBlockCount: number }` | The container content. Must contain a single root element. `hiddenBlockCount` is the number of blocks currently hidden due to overflow. |
+
+#### Emits
+
+This component has no custom events.
+
+### UIAdaptiveContentBlock
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `priority` | `number` | **required** | Display priority. **Lower values = higher priority** (shown first when space is limited). Blocks sharing the same priority are shown or hidden as a group. |
+
+#### Slots
+
+| Slot | Slot Props | Description |
+|------|------------|-------------|
+| `default` | -- | The block content. Must be a single root element (rendered via `as-child`). |
+| `fallback` | -- | Rendered when this block is hidden due to overflow. Useful for providing an alternative compact representation. |
+
+#### Emits
+
+This component has no custom events.
+
+## Variants
+
+These components have no visual variant or size options. They are purely behavioral -- they control visibility, not appearance.
+
+## Examples
+
+### Badge Group with Overflow Count
+
+```vue
+<script setup lang="ts">
+import { UIAdaptiveContent, UIAdaptiveContentBlock } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIAdaptiveContent v-slot="{ hiddenBlockCount }">
+    <div class="flex gap-1 overflow-hidden">
+      <UIAdaptiveContentBlock
+        v-for="(badge, index) in badges"
+        :key="badge.label"
+        :priority="index"
+      >
+        <Badge :label="badge.label" />
+      </UIAdaptiveContentBlock>
+
+      <Badge v-if="hiddenBlockCount > 0" :label="`+${hiddenBlockCount}`" />
+    </div>
+  </UIAdaptiveContent>
+</template>
+```
+
+### Equal Priority Groups
+
+Blocks with the same priority are shown or hidden as a group. If a priority group causes overflow, the entire group is removed.
+
+```vue
+<template>
+  <UIAdaptiveContent v-slot="{ hiddenBlockCount }">
+    <div class="flex gap-2 overflow-hidden">
+      <!-- These two always appear or disappear together -->
+      <UIAdaptiveContentBlock :priority="0">
+        <span>Primary A</span>
+      </UIAdaptiveContentBlock>
+      <UIAdaptiveContentBlock :priority="0">
+        <span>Primary B</span>
+      </UIAdaptiveContentBlock>
+
+      <!-- Lower priority, hidden first -->
+      <UIAdaptiveContentBlock :priority="1">
+        <span>Secondary</span>
+      </UIAdaptiveContentBlock>
+
+      <span v-if="hiddenBlockCount > 0">{{ hiddenBlockCount }} hidden</span>
+    </div>
+  </UIAdaptiveContent>
+</template>
+```
+
+### Using the Fallback Slot
+
+```vue
+<template>
+  <UIAdaptiveContent>
+    <div class="flex gap-2 overflow-hidden">
+      <UIAdaptiveContentBlock :priority="0">
+        <span>Full label text</span>
+
+        <template #fallback>
+          <span>FL</span>
+        </template>
+      </UIAdaptiveContentBlock>
+    </div>
+  </UIAdaptiveContent>
+</template>
+```
+
+### Tabs Integration (Internal Pattern)
+
+The tabs component uses `UIAdaptiveContent` internally to collapse tabs into a dropdown on non-touch devices:
+
+```vue
+<UIAdaptiveContent>
+  <template #default="{ hiddenBlockCount }">
+    <div>
+      <TabsList>
+        <!-- Each TabsItem wraps itself in UIAdaptiveContentBlock -->
+        <TabsItem label="Tab 1" value="tab1" />
+        <TabsItem label="Tab 2" value="tab2" />
+        <TabsItem label="Tab 3" value="tab3" />
+
+        <OverflowDropdown v-if="hiddenBlockCount > 0" />
+      </TabsList>
+    </div>
+  </template>
+</UIAdaptiveContent>
+```
+
+## Anatomy
+
+```
+UIAdaptiveContent (Primitive as-child, no wrapper element)
+├── ResizeObserver (watches container width)
+└── <slot> (single root element required)
+    ├── UIAdaptiveContentBlock (Primitive as-child, v-show toggled)
+    │   └── <slot /> (default — the block content)
+    │   └── <slot name="fallback" /> (shown when block is hidden)
+    ├── UIAdaptiveContentBlock ...
+    └── overflow indicator (consumer-provided, uses hiddenBlockCount)
+```
+
+## Styling
+
+**Style file:** None. These components are purely behavioral and produce no wrapper DOM elements (`as-child` is always true). All visual styling is the consumer's responsibility via the slot content.
+
+The container element (provided by the consumer in the default slot) should typically have:
+- `display: flex` (or similar horizontal layout)
+- `overflow: hidden` (so `scrollWidth > clientWidth` can be detected)
+- No `flex-wrap` (wrapping defeats the overflow measurement)
+
+## Common Mistakes
+
+### HIGH: Omitting overflow:hidden on the container element
+
+The layout algorithm compares `scrollWidth` against `clientWidth` on the slot's root element. If the container does not have `overflow: hidden`, scrollWidth will never exceed clientWidth and no blocks will be hidden.
+
+```vue
+<!-- Wrong: no overflow hidden -->
+<UIAdaptiveContent v-slot="{ hiddenBlockCount }">
+  <div class="flex gap-2">...</div>
+</UIAdaptiveContent>
+
+<!-- Correct -->
+<UIAdaptiveContent v-slot="{ hiddenBlockCount }">
+  <div class="flex gap-2 overflow-hidden">...</div>
+</UIAdaptiveContent>
+```
+
+### HIGH: Providing multiple root elements in the slot
+
+Both `UIAdaptiveContent` and `UIAdaptiveContentBlock` use Reka UI `Primitive` with `as-child`, which requires exactly one root element in the slot. Multiple roots will cause unexpected behavior.
+
+### MEDIUM: Using flex-wrap on the container
+
+If the container wraps items to a second line, items never overflow horizontally, so the algorithm never hides anything. Use `flex-nowrap` (or omit `flex-wrap`).
+
+### LOW: Confusing priority direction
+
+Lower numbers mean **higher** priority (shown first). A block with `priority="0"` is kept visible longer than `priority="5"`.
+
+## Accessibility
+
+- Blocks hidden by the adaptive layout use `v-show` (CSS `display: none`), so hidden content is removed from the accessibility tree.
+- The `fallback` slot on `UIAdaptiveContentBlock` allows providing an accessible alternative when the full content is hidden.
+- Consumers are responsible for making the overflow indicator (e.g., "+3 more" badge, dropdown menu) keyboard-accessible and screen-reader friendly.
+- The tabs component's built-in integration provides a fully accessible dropdown menu for hidden tabs.
+
+## See Also
+
+- [badge](../badge/SKILL.md) -- BadgeGroupTruncate uses UIAdaptiveContent internally for badge overflow
+- [tabs](../tabs/SKILL.md) -- TabsList uses UIAdaptiveContent internally to collapse tabs into an overflow dropdown

--- a/packages/web/design-system/skills/components/adaptive-content/SKILL.md
+++ b/packages/web/design-system/skills/components/adaptive-content/SKILL.md
@@ -7,7 +7,6 @@ description: >
 type: component
 category: display
 library: vue-core-design-system
-library_version: "0.8.0"
 requires: []
 exports:
   - UIAdaptiveContent

--- a/packages/web/design-system/skills/components/autocomplete/SKILL.md
+++ b/packages/web/design-system/skills/components/autocomplete/SKILL.md
@@ -6,7 +6,6 @@ description: >
   input-system foundation for labels, errors, and field wrappers.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: input
 requires:
   - input-system

--- a/packages/web/design-system/skills/components/autocomplete/SKILL.md
+++ b/packages/web/design-system/skills/components/autocomplete/SKILL.md
@@ -1,0 +1,364 @@
+---
+name: autocomplete
+description: >
+  Typeahead input that filters a dropdown list as the user types. Supports local
+  client-side filtering and remote server-side search with debouncing. Uses the
+  input-system foundation for labels, errors, and field wrappers.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: input
+requires:
+  - input-system
+exports:
+  - UIAutocomplete
+  - UIAutocompleteContent
+  - UIAutocompleteOption
+  - UIAutocompleteProps
+  - AutocompleteValue
+  - AutocompleteItem
+  - AutocompleteOptionItem
+  - AutocompleteSeparatorItem
+  - createAutocompleteOptions
+---
+
+# UIAutocomplete
+
+A combobox-style input that opens a filterable dropdown as the user types, powered by Reka UI's ComboboxRoot.
+
+## When to Use
+
+- When the user must select a single value from a large list by typing to narrow results
+- When search results come from a remote API and need debounced fetching
+- When you need avatar/icon/status decoration on each option via `getItemConfig`
+
+**Use instead:** `UISelect` when the user should pick from a fixed list without typing; a plain `UITextField` when free-form text is acceptable.
+
+## Import
+
+```ts
+import { UIAutocomplete, createAutocompleteOptions } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIAutocomplete, createAutocompleteOptions } from '@wisemen/vue-core-design-system'
+
+const items = createAutocompleteOptions(['Apple', 'Banana', 'Cherry', 'Mango'])
+const selected = ref<string | null>(null)
+
+function displayFn(value: string): string {
+  return value
+}
+</script>
+
+<template>
+  <UIAutocomplete
+    v-model="selected"
+    :display-fn="displayFn"
+    :items="items"
+    label="Fruit"
+    placeholder="Search a fruit..."
+    class="w-72"
+  />
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `modelValue` | `TValue \| null` | required | The selected value (v-model). |
+| `displayFn` | `(item: NonNullable<TValue>) => string` | required | Returns the display label for a value. Used in the input and dropdown. |
+| `items` | `AutocompleteItem<TValue>[]` | required | The items to show in the dropdown. Use `createAutocompleteOptions()` to build this array. |
+| `searchMode` | `'local' \| 'remote'` | `'remote'` | `local` filters client-side using case-insensitive `contains`; `remote` emits `update:search` for server-side filtering. |
+| `size` | `'sm' \| 'md'` | `'md'` | Controls input height and padding. |
+| `getItemConfig` | `((value: NonNullable<TValue>) => MenuItemConfig \| null) \| null` | `null` | Maps a value to visual config (avatar, icon, dot, description, right content) for each dropdown option. |
+| `isDisabled` | `boolean` | `false` | Disables the input. |
+| `isReadonly` | `boolean` | `false` | Makes the input read-only. |
+| `isRequired` | `boolean` | `false` | Marks the input as required (shows asterisk on label). |
+| `isLoading` | `boolean` | `false` | Shows a loading spinner in the field wrapper and skeleton items in the dropdown when there are no results. |
+| `label` | `string \| null` | `null` | The label displayed above the input. |
+| `placeholder` | `string \| null` | `null` | Placeholder text shown when no value is selected. |
+| `errorMessage` | `string \| null` | `null` | Error message displayed below the input. |
+| `hideErrorMessage` | `boolean` | `false` | Hides the error message visually while keeping the error styling. |
+| `hint` | `string \| null` | `null` | Hint text shown next to the label. |
+| `helpText` | `string \| null` | `null` | Help text shown in a tooltip next to the label. |
+| `iconLeft` | `Component \| null` | `null` | Icon displayed on the left side of the input. |
+| `iconRight` | `Component \| null` | `ChevronDownIcon` | Icon displayed on the right side of the input. |
+| `autocomplete` | `string` | `'off'` | The HTML autocomplete attribute. |
+| `name` | `string \| null` | `null` | The name attribute for the input. |
+| `disabledReason` | `string \| null` | `null` | Tooltip text explaining why the input is disabled. |
+| `popoverSide` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'bottom'` | Side where the dropdown appears. |
+| `popoverAlign` | `'start' \| 'center' \| 'end'` | `'center'` | Alignment of the dropdown relative to the input. |
+| `popoverSideOffset` | `number` | `4` | Pixel offset between the input and dropdown. |
+| `popoverCollisionPadding` | `number` | `8` | Padding from viewport edges for collision detection. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Not used directly. |
+| `label-left` | Content rendered to the left of the label text. |
+| `label-right` | Content rendered to the right of the label text. |
+| `left` | Content rendered inside the field wrapper, to the left of the input. |
+| `right` | Content rendered inside the field wrapper, to the right of the input (before the icon). |
+
+### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `update:modelValue` | `TValue \| null` | Fired when the selected value changes. |
+| `update:search` | `string` | Fired when the debounced search term changes (remote mode only). |
+| `blur` | none | Fired when the dropdown closes. |
+| `nextPage` | none | Fired when the user scrolls near the bottom of the dropdown (for infinite scroll / pagination). |
+
+## Variants
+
+### Size
+
+- `md` (default) -- Standard input height with `px-md` padding.
+- `sm` -- Compact input height with `px-sm` padding.
+
+## Examples
+
+### Local Search (String Values)
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIAutocomplete, createAutocompleteOptions } from '@wisemen/vue-core-design-system'
+
+const items = createAutocompleteOptions([
+  'Apple', 'Banana', 'Cherry', 'Mango', 'Orange', 'Strawberry',
+])
+const selected = ref<string | null>(null)
+
+function displayFn(value: string): string {
+  return value
+}
+</script>
+
+<template>
+  <UIAutocomplete
+    v-model="selected"
+    :display-fn="displayFn"
+    :items="items"
+    search-mode="local"
+    label="Fruit"
+    placeholder="Search a fruit..."
+    class="w-72"
+  />
+</template>
+```
+
+### Remote Search (Complex Objects)
+
+```vue
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { UIAutocomplete, createAutocompleteOptions } from '@wisemen/vue-core-design-system'
+import type { AutocompleteItem } from '@wisemen/vue-core-design-system'
+
+interface User {
+  id: string
+  name: string
+}
+
+const selected = ref<User | null>(null)
+const items = ref<AutocompleteItem<User>[]>([])
+const isLoading = ref(false)
+
+function displayFn(user: User): string {
+  return user.name
+}
+
+async function onSearch(search: string): Promise<void> {
+  isLoading.value = true
+  try {
+    const response = await fetchUsers({ search })
+    items.value = createAutocompleteOptions(response.data)
+  } finally {
+    isLoading.value = false
+  }
+}
+</script>
+
+<template>
+  <UIAutocomplete
+    v-model="selected"
+    :display-fn="displayFn"
+    :items="items"
+    :is-loading="isLoading"
+    search-mode="remote"
+    label="User"
+    placeholder="Search users..."
+    class="w-72"
+    @update:search="onSearch"
+  />
+</template>
+```
+
+### With Item Config (Avatar and Description)
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIAutocomplete, createAutocompleteOptions } from '@wisemen/vue-core-design-system'
+import type { MenuItemConfig } from '@wisemen/vue-core-design-system'
+
+interface User {
+  id: string
+  name: string
+  email: string
+  avatarSrc?: string
+}
+
+const users: User[] = [
+  { id: '1', name: 'Alice Johnson', email: 'alice@example.com', avatarSrc: 'https://i.pravatar.cc/150?u=alice' },
+  { id: '2', name: 'Bob Smith', email: 'bob@example.com' },
+]
+
+const items = createAutocompleteOptions(users)
+const selected = ref<User | null>(null)
+
+function displayFn(user: User): string {
+  return user.name
+}
+
+function getItemConfig(user: User): MenuItemConfig {
+  return {
+    avatar: { name: user.name, src: user.avatarSrc ?? null },
+    description: user.email,
+  }
+}
+</script>
+
+<template>
+  <UIAutocomplete
+    v-model="selected"
+    :display-fn="displayFn"
+    :items="items"
+    :get-item-config="getItemConfig"
+    search-mode="local"
+    label="User"
+    placeholder="Search users..."
+    class="w-72"
+  />
+</template>
+```
+
+## Anatomy
+
+```
+UIAutocomplete
+  InputWrapper (label, hint, error)
+    RekaComboboxRoot
+      RekaComboboxAnchor
+        FieldWrapper (iconLeft, iconRight, loading)
+          RekaComboboxInput (the text input)
+      AutocompleteContent (portal)
+        ThemeProvider
+          RekaComboboxContent (positioned popover)
+            Scrollable (scroll + infinite-scroll)
+              AutocompleteOption (per item)
+                RekaComboboxItem
+                  UIMenuItem (avatar/icon/dot + label + check indicator)
+              UISeparator (for separator items)
+              AutocompleteLoading (skeleton, shown when loading + empty)
+              "No results found" text (shown when not loading + empty)
+```
+
+## Styling
+
+**Style file:** `autocomplete.style.ts` -- uses Tailwind Variants (`tv`).
+
+| Slot | Classes |
+|------|---------|
+| `input` | `size-full truncate bg-transparent text-xs text-primary outline-none` + placeholder/readonly/disabled styles |
+
+**Size variants:**
+- `md`: `px-md`
+- `sm`: `px-sm`
+
+The dropdown uses inline Tailwind classes: `rounded-md border border-secondary bg-primary shadow-lg`, max height clamped to `min(--reka-combobox-content-available-height, 32rem)`.
+
+## Common Mistakes
+
+### HIGH: Using local mode with remote data
+
+Wrong:
+```vue
+<UIAutocomplete
+  :items="remoteItems"
+  search-mode="local"
+  @update:search="fetchFromApi"
+/>
+```
+
+Correct:
+```vue
+<UIAutocomplete
+  :items="remoteItems"
+  search-mode="remote"
+  @update:search="fetchFromApi"
+/>
+```
+
+When `searchMode` is `local`, the component filters items client-side and ignores `update:search`. Use `remote` when items come from an API so the search term is emitted and you control the filtering.
+
+### MEDIUM: Forgetting displayFn for complex objects
+
+Wrong:
+```vue
+<!-- This will show "[object Object]" in the input -->
+<UIAutocomplete
+  v-model="selected"
+  :display-fn="(v) => v"
+  :items="userItems"
+/>
+```
+
+Correct:
+```vue
+<UIAutocomplete
+  v-model="selected"
+  :display-fn="(user) => user.name"
+  :items="userItems"
+/>
+```
+
+`displayFn` must return a string. For objects, extract the human-readable property.
+
+### MEDIUM: Not wrapping items with createAutocompleteOptions
+
+Wrong:
+```vue
+<UIAutocomplete :items="['Apple', 'Banana']" />
+```
+
+Correct:
+```vue
+<UIAutocomplete :items="createAutocompleteOptions(['Apple', 'Banana'])" />
+```
+
+Items must be `AutocompleteItem<TValue>[]` with a `type: 'option'` discriminator. Use `createAutocompleteOptions()` to wrap plain values.
+
+## Accessibility
+
+- Built on Reka UI's `ComboboxRoot`, which implements the WAI-ARIA Combobox pattern.
+- The input has `role="combobox"` with `aria-expanded`, `aria-required`, `aria-invalid`, `aria-busy`, and `aria-describedby` attributes.
+- Keyboard navigation: Arrow keys highlight options, Enter selects, Escape closes.
+- Selected option shows a check icon indicator.
+- When disabled, the input is not focusable (`disabled` attribute).
+- Error and hint messages are linked via `aria-describedby`.
+
+## See Also
+
+- [UISelect](../select/) -- For dropdown selection without free-text typing
+- [input-system](../../foundations/input-system/) -- Shared input infrastructure (InputWrapper, FieldWrapper, error/label/hint)

--- a/packages/web/design-system/skills/components/avatar/SKILL.md
+++ b/packages/web/design-system/skills/components/avatar/SKILL.md
@@ -1,0 +1,439 @@
+---
+name: avatar
+description: >
+  Avatar system with four components: UIAvatar (image or initials), UIAvatarGroup (stacked
+  row with overflow), UIAvatarGroupAddButton (dashed add action), and UIAvatarLabel (avatar
+  with name and supporting text). Load this skill when displaying user profile pictures,
+  grouped users, or labeled identity elements.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UIAvatar
+  - UIAvatarGroup
+  - UIAvatarGroupAddButton
+  - UIAvatarLabel
+---
+
+# UIAvatar
+
+An avatar system for displaying user profile pictures with initials fallback, status indicators, and logo overlays. Includes group and labeled variants.
+
+## When to Use
+
+- Displaying user profile pictures or identity indicators
+- Showing a group of users with an overflow count
+- Presenting user information with name and supporting text alongside an avatar
+- Any place where a person or entity needs a visual representation
+
+**Use instead:** `UIBadge` with the `avatar` prop for inline avatar-with-text badges. Plain `<img>` when you do not need fallback initials or status indicators.
+
+## Import
+
+```ts
+import {
+  UIAvatar,
+  UIAvatarGroup,
+  UIAvatarGroupAddButton,
+  UIAvatarLabel,
+} from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIAvatar } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIAvatar name="Olivia Rhye" src="https://example.com/photo.jpg" />
+</template>
+```
+
+---
+
+## UIAvatar
+
+Displays a circular avatar with an image, falling back to initials derived from the `name` prop. Optionally shows a status dot or a logo overlay.
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `name` | `string` | **(required)** | The name used to generate fallback initials. |
+| `imageAlt` | `string \| null` | `null` | Alt text for the avatar image. Defaults to `"Avatar"` when not provided. |
+| `logo` | `string \| null` | `null` | Image URL for a logo overlay shown at the bottom-right corner. |
+| `logoAlt` | `string \| null` | `null` | Alt text for the logo image. Defaults to `"Avatar Logo"` when not provided. |
+| `size` | `'2xl' \| 'lg' \| 'md' \| 'sm' \| 'xl' \| 'xs' \| 'xxs'` | `'md'` | The size of the avatar. |
+| `src` | `string \| null` | `null` | Image URL for the avatar. Falls back to initials when not provided or loading fails. |
+| `status` | `'away' \| 'busy' \| 'offline' \| 'online' \| null` | `null` | Online status indicator shown as a colored dot at the bottom-right. Mutually exclusive with `logo`. |
+
+### Slots
+
+This component has no slots.
+
+### Emits
+
+This component has no custom events.
+
+### Sizes
+
+| Size | Dimensions | Initials (count) | Status dot | Logo |
+|------|-----------|-------------------|------------|------|
+| `xxs` | 16x16 | 1 initial | `size-1.5` | `size-1.5` |
+| `xs` | 24x24 | 2 initials | `size-2` | `size-2` |
+| `sm` | 32x32 | 2 initials | `size-2.5` | `size-2.5` |
+| `md` | 40x40 | 2 initials | `size-3` | `size-3` |
+| `lg` | 48x48 | 2 initials | `size-3.5` | `size-3.5` |
+| `xl` | 56x56 | 2 initials | `size-3.5` | `size-3.5` |
+| `2xl` | 64x64 | 2 initials | `size-4` | `size-4` |
+
+### Status Colors
+
+| Status | Color |
+|--------|-------|
+| `online` | `bg-success-500` (green) |
+| `away` | `bg-warning-500` (yellow) |
+| `busy` | `bg-error-500` (red) |
+| `offline` | `bg-gray-400` (gray) |
+
+### Example: Avatar with Status
+
+```vue
+<script setup lang="ts">
+import { UIAvatar } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIAvatar
+    name="Olivia Rhye"
+    src="https://example.com/photo.jpg"
+    status="online"
+    size="lg"
+  />
+</template>
+```
+
+### Example: Avatar with Logo
+
+```vue
+<script setup lang="ts">
+import { UIAvatar } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIAvatar
+    name="Olivia Rhye"
+    src="https://example.com/photo.jpg"
+    logo="https://example.com/company-logo.png"
+    logo-alt="Wisemen"
+    size="md"
+  />
+</template>
+```
+
+### Example: Fallback Initials
+
+```vue
+<script setup lang="ts">
+import { UIAvatar } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <!-- Shows "OR" as fallback when no src is provided -->
+  <UIAvatar name="Olivia Rhye" />
+</template>
+```
+
+---
+
+## UIAvatarGroup
+
+Displays a horizontal stack of overlapping avatars with a "+X" overflow indicator when the count exceeds `max`.
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `avatars` | `AvatarProps[]` | **(required)** | Array of avatar prop objects (each with `name`, `src`, `logo`, etc.). |
+| `max` | `number` | `10` | Maximum number of avatars to display before showing the overflow count. |
+| `size` | `'md' \| 'sm' \| 'xs'` | `'sm'` | Size of all avatars in the group. |
+
+### Slots
+
+This component has no slots.
+
+### Emits
+
+This component has no custom events.
+
+### Example: Avatar Group
+
+```vue
+<script setup lang="ts">
+import { UIAvatarGroup } from '@wisemen/vue-core-design-system'
+
+const users = [
+  { name: 'Alice', src: 'https://example.com/alice.jpg' },
+  { name: 'Bob', src: 'https://example.com/bob.jpg' },
+  { name: 'Charlie', src: 'https://example.com/charlie.jpg' },
+  { name: 'Diana', src: 'https://example.com/diana.jpg' },
+  { name: 'Eve', src: 'https://example.com/eve.jpg' },
+]
+</script>
+
+<template>
+  <UIAvatarGroup :avatars="users" :max="3" size="sm" />
+</template>
+```
+
+---
+
+## UIAvatarGroupAddButton
+
+A circular dashed-border button placed next to a `UIAvatarGroup` for adding new members. Shows a "+" icon (or a loader when loading).
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | **(required)** | Accessible text label for the button (used as `aria-label`). |
+| `disabledReason` | `string \| null` | `null` | Tooltip text shown when the button is disabled. |
+| `form` | `string \| null` | `null` | The form ID the button is associated with. |
+| `isDisabled` | `boolean` | `false` | Disables the button. |
+| `isLoading` | `boolean` | `false` | Shows a loading spinner and prevents interaction. |
+| `isTooltipDisabled` | `boolean` | `false` | Disables the tooltip. When disabled and `disabledReason` is set, the tooltip still shows. |
+| `keyboardShortcut` | `string \| null` | `null` | Visual keyboard shortcut shown in the tooltip. |
+| `size` | `'md' \| 'sm' \| 'xs'` | `'sm'` | Button size. Should match the `UIAvatarGroup` size. |
+| `tooltipLabel` | `string \| null` | `null` | Custom tooltip text. Defaults to the `label` prop value. |
+| `type` | `'button' \| 'reset' \| 'submit'` | `'button'` | Native button type attribute. |
+
+### Slots
+
+This component has no slots.
+
+### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `click` | `MouseEvent` | Emitted when the button is clicked (not emitted while loading). |
+
+### Example: Group with Add Button
+
+```vue
+<script setup lang="ts">
+import { UIAvatarGroup, UIAvatarGroupAddButton } from '@wisemen/vue-core-design-system'
+
+const users = [
+  { name: 'Alice', src: 'https://example.com/alice.jpg' },
+  { name: 'Bob', src: 'https://example.com/bob.jpg' },
+]
+
+function onAddUser(): void {
+  // open user picker
+}
+</script>
+
+<template>
+  <div class="flex items-center gap-md">
+    <UIAvatarGroup :avatars="users" size="sm" />
+    <UIAvatarGroupAddButton label="Add user" size="sm" @click="onAddUser" />
+  </div>
+</template>
+```
+
+---
+
+## UIAvatarLabel
+
+Displays an avatar alongside a name and optional supporting text. Useful in user lists, profiles, and mentions.
+
+### Props
+
+Inherits all `UIAvatar` props, plus:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `name` | `string` | **(required)** | The user's name, shown as text and used for avatar initials. |
+| `supportingText` | `string \| null` | `null` | Secondary text displayed below the name (e.g., email, role). |
+| `size` | `'2xl' \| 'lg' \| 'md' \| 'sm' \| 'xl' \| 'xs' \| 'xxs'` | `'md'` | Controls both the avatar size and the text sizing. |
+| `src` | `string \| null` | `null` | Avatar image URL. |
+| `logo` | `string \| null` | `null` | Logo overlay URL. |
+| `logoAlt` | `string \| null` | `null` | Alt text for the logo. |
+| `status` | `'away' \| 'busy' \| 'offline' \| 'online' \| null` | `null` | Status indicator on the avatar. |
+
+### Slots
+
+This component has no slots.
+
+### Emits
+
+This component has no custom events.
+
+### Size-specific Text Sizing
+
+| Size | Name font | Supporting text font | Gap |
+|------|-----------|---------------------|-----|
+| `xxs` | `text-xs` | `text-xs` | `gap-md` |
+| `xs` | `text-xs` | `text-xs` | `gap-md` |
+| `sm` | `text-sm` | `text-xs` | `gap-md` |
+| `md` | `text-sm` | `text-sm` | `gap-md` |
+| `lg` | `text-md` | `text-md` | `gap-lg` |
+| `xl` | `text-lg` | `text-md` | `gap-xl` |
+| `2xl` | `text-lg` | `text-md` | `gap-xl` |
+
+### Example: User Profile Row
+
+```vue
+<script setup lang="ts">
+import { UIAvatarLabel } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIAvatarLabel
+    name="Olivia Rhye"
+    src="https://example.com/photo.jpg"
+    supporting-text="olivia@wisemen.digital"
+    size="md"
+    status="online"
+  />
+</template>
+```
+
+### Example: With Logo
+
+```vue
+<script setup lang="ts">
+import { UIAvatarLabel } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIAvatarLabel
+    name="Olivia Rhye"
+    src="https://example.com/photo.jpg"
+    logo="https://example.com/company-logo.png"
+    supporting-text="olivia@wisemen.digital"
+    size="md"
+  />
+</template>
+```
+
+---
+
+## Anatomy
+
+```
+UIAvatar
+  div.relative.inline-block       (root)
+    AvatarRoot[as-child]           (Reka UI)
+      AvatarImage                  (shown when src loads)
+      AvatarFallback               (initials when no image)
+    span.statusDot?                (when status is set)
+    img.logo?                      (when logo is set, mutually exclusive with status)
+
+UIAvatarGroup
+  div.flex                         (root)
+    Avatar * N                     (overlapping, negative margin)
+    div.overflow?                  ("+X" count when avatars.length > max)
+
+UIAvatarGroupAddButton
+  ActionTooltip
+    button.rounded-full.border-dashed
+      Loader | PlusIcon
+
+UIAvatarLabel
+  div.flex.items-center            (root)
+    Avatar                         (avatar)
+    ColumnLayout                   (text container)
+      Text                         (name)
+      Text?                        (supportingText)
+```
+
+## Styling
+
+**Style files:**
+- `src/ui/avatar/avatar/avatar.style.ts` -- UIAvatar
+- `src/ui/avatar/avatar-group/avatarGroup.style.ts` -- UIAvatarGroup
+- `src/ui/avatar/avatar-group/avatarGroupAddButton.style.ts` -- UIAvatarGroupAddButton
+- `src/ui/avatar/avatar-label/avatarLabel.style.ts` -- UIAvatarLabel
+
+**UIAvatar tv() slots:** `base`, `fallBack`, `logo`, `root`, `statusDot`
+**UIAvatarGroup tv() slots:** `avatar`, `overflow`, `root`
+**UIAvatarGroupAddButton tv() slots:** `icon`, `root`
+**UIAvatarLabel tv() slots:** `name`, `root`, `supportingText`, `textContainer`
+
+## Common Mistakes
+
+### HIGH: Using status and logo simultaneously
+
+Wrong:
+```vue
+<UIAvatar
+  name="Jane"
+  status="online"
+  logo="https://example.com/logo.png"
+/>
+```
+
+Correct:
+```vue
+<!-- Use one or the other -->
+<UIAvatar name="Jane" status="online" />
+<UIAvatar name="Jane" logo="https://example.com/logo.png" />
+```
+
+The status dot and logo both render at the bottom-right corner. Only one can be displayed at a time. The template uses `v-if/v-else-if` so `status` takes priority.
+
+### MEDIUM: Mismatched sizes between AvatarGroup and AvatarGroupAddButton
+
+Wrong:
+```vue
+<div class="flex items-center gap-md">
+  <UIAvatarGroup :avatars="users" size="sm" />
+  <UIAvatarGroupAddButton label="Add" size="md" />
+</div>
+```
+
+Correct:
+```vue
+<div class="flex items-center gap-md">
+  <UIAvatarGroup :avatars="users" size="sm" />
+  <UIAvatarGroupAddButton label="Add" size="sm" />
+</div>
+```
+
+The `size` prop on `UIAvatarGroupAddButton` should match the `UIAvatarGroup` size for visual consistency.
+
+### LOW: Not providing imageAlt for accessible avatars
+
+Wrong:
+```vue
+<UIAvatar name="Jane" src="https://example.com/photo.jpg" />
+```
+
+Correct:
+```vue
+<UIAvatar
+  name="Jane"
+  src="https://example.com/photo.jpg"
+  image-alt="Jane's profile picture"
+/>
+```
+
+When `imageAlt` is not provided, it defaults to the generic `"Avatar"`. Provide a descriptive alt text for better accessibility.
+
+## Accessibility
+
+- `UIAvatar` uses Reka UI's `AvatarRoot`, `AvatarImage`, and `AvatarFallback` which handle image loading states and fallback accessibility.
+- The avatar image receives an `alt` attribute from `imageAlt` (defaulting to `"Avatar"`).
+- The logo image receives an `alt` attribute from `logoAlt` (defaulting to `"Avatar Logo"`).
+- `UIAvatarGroupAddButton` sets `aria-label` from the `label` prop, and uses `aria-busy` and `aria-disabled` during loading.
+- `UIAvatarGroup` overflow count is announced via i18n-translated text (`component.avatar_group.overflow`).
+
+## See Also
+
+- [UIBadge](../badge/) -- Badge with optional avatar for inline tagged representations
+- [UINumberBadge](../number-badge/) -- Numeric badge for counts

--- a/packages/web/design-system/skills/components/avatar/SKILL.md
+++ b/packages/web/design-system/skills/components/avatar/SKILL.md
@@ -7,7 +7,6 @@ description: >
   grouped users, or labeled identity elements.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/badge/SKILL.md
+++ b/packages/web/design-system/skills/components/badge/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: badge
+description: >
+  Versatile badge component with support for labels, icons, dots, avatars, and separators.
+  Includes BadgeGroup for wrapping collections and BadgeGroupTruncate for overflow handling.
+  Load this skill when displaying status indicators, tags, or categorization labels.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UIBadge
+  - UIBadgeProps
+  - UIBadgeColor
+  - UIBadgeAvatarConfig
+  - UIBadgeDotConfig
+  - UIBadgeDot
+  - UIBadgeGroup
+  - UIBadgeGroupTruncate
+  - UIBadgeIcon
+  - UIBadgeLabel
+  - UIBadgeSeparator
+---
+
+# UIBadge
+
+A versatile badge component for displaying status labels, tags, and categorization indicators. Supports text labels, icons, dots, and avatars. Use `UIBadgeGroup` to arrange multiple badges and `UIBadgeGroupTruncate` for overflow with a "+X" indicator.
+
+## When to Use
+
+- Showing status labels (e.g., "Active", "Pending", "Error")
+- Displaying tags or categories on items
+- Indicating a state with a colored dot, icon, or avatar alongside text
+- Grouping multiple badges in a wrapping or truncated row
+
+**Use instead:** `UINumberBadge` for numeric-only badges. `UIDot` for a standalone status dot without a label.
+
+## Import
+
+```ts
+import {
+  UIBadge,
+  UIBadgeGroup,
+  UIBadgeGroupTruncate,
+  UIBadgeDot,
+  UIBadgeIcon,
+  UIBadgeLabel,
+  UIBadgeSeparator,
+} from '@wisemen/vue-core-design-system'
+
+import type {
+  UIBadgeProps,
+  UIBadgeColor,
+  UIBadgeAvatarConfig,
+  UIBadgeDotConfig,
+} from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIBadge } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIBadge label="Active" color="success" />
+</template>
+```
+
+## API
+
+### UIBadge Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `ariaLabel` | `string \| null` | `null` | Accessible label for screen readers. Use when the badge content alone is not descriptive enough. |
+| `avatar` | `BadgeAvatarConfig \| null` | `null` | An avatar config object `{ name: string, src?: string \| null }`. When provided, renders a tiny (xxs) avatar inside the badge. |
+| `color` | `BadgeColor` | `'gray'` | Background color theme. One of: `'blue'`, `'brand'`, `'error'`, `'gray'`, `'pink'`, `'purple'`, `'success'`, `'warning'`. |
+| `dot` | `BadgeDotConfig \| null` | `null` | Dot config object. Pass `{}` for a dot that inherits the badge color, or `{ color: 'error' }` to override. |
+| `icon` | `Component \| null` | `null` | A Vue icon component to display inside the badge. |
+| `label` | `string \| null` | `null` | The text label displayed inside the badge. |
+| `rounded` | `'default' \| 'full'` | `'default'` | Border radius. `'default'` = `rounded-sm`, `'full'` = `rounded-full` (pill). |
+| `size` | `'lg' \| 'md' \| 'sm'` | `'md'` | Badge size controlling height, icon size, and font size. |
+| `variant` | `'outline' \| 'solid' \| 'translucent'` | `'translucent'` | Visual style variant. |
+
+### UIBadge Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Overrides the entire badge content (avatar, icon, label). When provided, the `avatar`, `icon`, and `label` props are ignored. Use sub-components (`UIBadgeIcon`, `UIBadgeLabel`, `UIBadgeDot`, `UIBadgeSeparator`) for custom layouts. |
+
+### UIBadge Emits
+
+This component has no custom events.
+
+### UIBadgeGroup Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `noWrap` | `boolean` | `false` | When `true`, prevents badges from wrapping to the next line. |
+
+### UIBadgeGroup Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | `UIBadge` components to arrange in a row with `gap-xs`. |
+
+### UIBadgeGroupTruncate Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `badges` | `BadgeData[]` | **(required)** | Array of badge data objects: `{ label: string, avatar?: { name, src? }, dot?: { color }, icon?: Component }`. |
+| `color` | `BadgeColor` | **(required)** | Color applied to all badges in the group. |
+| `maxVisibleCount` | `number \| null` | `null` | Maximum badges to show before truncating. When `null`, all badges are shown (adaptive overflow only). |
+| `size` | `BadgeProps['size']` | **(required)** | Size applied to all badges. |
+| `variant` | `BadgeProps['variant']` | **(required)** | Variant applied to all badges. |
+
+### Sub-components
+
+These are used inside UIBadge's default slot for custom content layouts. They automatically consume the badge context (color, size, variant).
+
+| Component | Props | Description |
+|-----------|-------|-------------|
+| `UIBadgeIcon` | `icon: Component` | Renders an icon with badge-context styling. |
+| `UIBadgeLabel` | `label: string` | Renders a text label with badge-context styling. |
+| `UIBadgeDot` | *(none)* | Renders a dot indicator using the badge's effective dot color. |
+| `UIBadgeSeparator` | *(none)* | Renders a vertical separator line between badge content sections. |
+
+## Variants
+
+### Sizes
+
+| Size | Height | Icon size | Font size |
+|------|--------|-----------|-----------|
+| `sm` | `h-5` (20px) | `size-3` | `text-xxs` |
+| `md` | `h-6` (24px) | `size-3` | `text-xxs` |
+| `lg` | `h-7` (28px) | `size-4` | `text-xs` |
+
+### Visual Variants
+
+| Variant | Description |
+|---------|-------------|
+| `translucent` | Tinted background with colored border and text |
+| `outline` | Transparent background with colored border and text |
+| `solid` | Filled background with white text |
+
+### Colors
+
+All `BadgeColor` values: `gray`, `brand`, `blue`, `pink`, `error`, `success`, `warning`, `purple`.
+
+## Examples
+
+### Badge with Dot
+
+```vue
+<script setup lang="ts">
+import { UIBadge } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIBadge
+    label="Online"
+    color="success"
+    :dot="{}"
+  />
+</template>
+```
+
+### Badge with Icon
+
+```vue
+<script setup lang="ts">
+import { UIBadge } from '@wisemen/vue-core-design-system'
+import { Settings01Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIBadge
+    :icon="Settings01Icon"
+    label="Settings"
+    color="brand"
+  />
+</template>
+```
+
+### Badge with Avatar
+
+```vue
+<script setup lang="ts">
+import { UIBadge } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIBadge
+    :avatar="{ name: 'John Doe', src: 'https://example.com/photo.jpg' }"
+    label="John Doe"
+    color="brand"
+  />
+</template>
+```
+
+### Badge Group
+
+```vue
+<script setup lang="ts">
+import { UIBadge, UIBadgeGroup } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIBadgeGroup>
+    <UIBadge label="Vue" color="success" />
+    <UIBadge label="TypeScript" color="blue" />
+    <UIBadge label="Tailwind" color="purple" />
+  </UIBadgeGroup>
+</template>
+```
+
+### Truncated Badge Group
+
+```vue
+<script setup lang="ts">
+import { UIBadgeGroupTruncate } from '@wisemen/vue-core-design-system'
+
+const badges = [
+  { label: 'Design' },
+  { label: 'Engineering' },
+  { label: 'Marketing' },
+  { label: 'Sales' },
+  { label: 'Support' },
+]
+</script>
+
+<template>
+  <UIBadgeGroupTruncate
+    :badges="badges"
+    :max-visible-count="3"
+    color="gray"
+    size="md"
+    variant="translucent"
+  />
+</template>
+```
+
+### Custom Content with Sub-components
+
+```vue
+<script setup lang="ts">
+import {
+  UIBadge,
+  UIBadgeIcon,
+  UIBadgeLabel,
+  UIBadgeSeparator,
+} from '@wisemen/vue-core-design-system'
+import { CheckCircleIcon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIBadge color="success">
+    <UIBadgeIcon :icon="CheckCircleIcon" />
+    <UIBadgeLabel label="Approved" />
+    <UIBadgeSeparator />
+    <UIBadgeLabel label="v2.1" />
+  </UIBadge>
+</template>
+```
+
+## Anatomy
+
+```
+UIBadge
+  UIRowLayout.inline-flex.border  (base)
+    BadgeDot?                      (when dot prop is set)
+    <slot>                         (default content)
+      BadgeAvatar?                 (when avatar prop is set)
+      BadgeIcon?                   (when icon prop is set)
+      BadgeLabel?                  (when label prop is set)
+    </slot>
+
+UIBadgeGroup
+  UIRowLayout.flex-wrap.gap-xs
+    <slot />                       (UIBadge children)
+
+UIBadgeGroupTruncate
+  AdaptiveContent
+    BadgeGroup[no-wrap]
+      AdaptiveContentBlock * N     (visible badges)
+      ActionTooltip                (overflow "+X" badge with tooltip)
+```
+
+## Styling
+
+**Style file:** `src/ui/badge/badge.style.ts`
+**tv() slots:** `base`, `dot`, `icon`, `label`, `separator`
+
+The `base` slot controls the badge container (height, padding, border, background). Color-variant combinations are defined as `compoundVariants` for all 8 colors x 3 variants. The `dot`, `icon`, `label`, and `separator` slots are styled per color/variant.
+
+## Common Mistakes
+
+### HIGH: Using the default slot AND prop-based content
+
+Wrong:
+```vue
+<UIBadge label="Status" color="success">
+  <UIBadgeLabel label="Override" />
+</UIBadge>
+```
+
+Correct:
+```vue
+<UIBadge color="success">
+  <UIBadgeLabel label="Override" />
+</UIBadge>
+```
+
+When a default slot is provided, the `label`, `icon`, and `avatar` props are ignored (they are inside the fallback slot content). Use either props or slot content, not both.
+
+### MEDIUM: Passing an empty object for dot color override
+
+Wrong:
+```vue
+<UIBadge label="Status" :dot="{ color: undefined }" />
+```
+
+Correct:
+```vue
+<!-- Dot inherits badge color -->
+<UIBadge label="Status" :dot="{}" />
+
+<!-- Dot with explicit color override -->
+<UIBadge label="Status" :dot="{ color: 'error' }" />
+```
+
+Pass `{}` to inherit the badge color, or provide an explicit `color` value. Do not pass `undefined` as the color.
+
+### MEDIUM: Using UIBadgeSeparator outside of UIBadge
+
+Wrong:
+```vue
+<UIBadgeSeparator />
+```
+
+Correct:
+```vue
+<UIBadge color="gray">
+  <UIBadgeLabel label="Left" />
+  <UIBadgeSeparator />
+  <UIBadgeLabel label="Right" />
+</UIBadge>
+```
+
+Sub-components (`UIBadgeIcon`, `UIBadgeLabel`, `UIBadgeDot`, `UIBadgeSeparator`) must be used inside a `UIBadge` because they inject the badge context for styling.
+
+## Accessibility
+
+- `UIBadge` renders with `role="status"` so screen readers announce changes.
+- Accepts an `ariaLabel` prop for custom screen reader text.
+- `UIBadgeGroupTruncate` shows a tooltip on the overflow badge listing the hidden badge labels.
+
+## See Also
+
+- [UINumberBadge](../number-badge/) -- Compact numeric-only badge
+- [UIDot](../dot/) -- Standalone status dot indicator
+- [UIAvatar](../avatar/) -- Full avatar component used inside badge avatars

--- a/packages/web/design-system/skills/components/badge/SKILL.md
+++ b/packages/web/design-system/skills/components/badge/SKILL.md
@@ -6,7 +6,6 @@ description: >
   Load this skill when displaying status indicators, tags, or categorization labels.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/breadcrumbs/SKILL.md
+++ b/packages/web/design-system/skills/components/breadcrumbs/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: breadcrumbs
+description: >
+  UIBreadcrumbs is a composite navigation component built from UIBreadcrumbRoot,
+  UIBreadcrumbItems, UIBreadcrumbItem, and UIBreadcrumbSeparator parts. It renders
+  a horizontal breadcrumb trail with optional icons, router links, and accessible
+  label-hiding for icon-only items.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: navigation
+requires: []
+exports:
+  - UIBreadcrumbRoot
+  - UIBreadcrumbItems
+  - UIBreadcrumbItem
+  - UIBreadcrumbItemProps
+  - UIBreadcrumbSeparator
+  - UIBreadcrumbSelect
+  - UIBreadcrumbDateSelect
+---
+
+# UIBreadcrumbs
+
+A multi-part breadcrumb navigation component for showing hierarchical page location.
+
+## When to Use
+
+- Display the user's current location within a page hierarchy.
+- Provide navigable links back to parent pages.
+- Show icon-only breadcrumb segments with accessible hidden labels.
+
+**Use instead:** For tab-based navigation within a page, use `UITabs`. For primary app navigation, use `UISidebar`.
+
+## Import
+
+```ts
+import {
+  UIBreadcrumbRoot,
+  UIBreadcrumbItems,
+  UIBreadcrumbItem,
+  UIBreadcrumbSeparator,
+} from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import {
+  UIBreadcrumbRoot,
+  UIBreadcrumbItems,
+  UIBreadcrumbItem,
+  UIBreadcrumbSeparator,
+} from '@wisemen/vue-core-design-system'
+import { Users01Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIBreadcrumbRoot>
+    <UIBreadcrumbItems>
+      <UIBreadcrumbItem :icon="Users01Icon" label="Users" to="/" />
+      <UIBreadcrumbSeparator />
+      <UIBreadcrumbItem label="Jeroen" to="/users/jeroen" />
+      <UIBreadcrumbSeparator />
+      <UIBreadcrumbItem label="Projects" />
+    </UIBreadcrumbItems>
+  </UIBreadcrumbRoot>
+</template>
+```
+
+## API
+
+### UIBreadcrumbItem Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | **(required)** | The text label for the breadcrumb item. |
+| `to` | `RouteLocationRaw` | `undefined` | Route to navigate to on click. When omitted, renders as plain text (current page). |
+| `icon` | `Component` | `undefined` | Optional icon displayed before the label. |
+| `isLabelHidden` | `boolean` | `false` | Visually hides the label (sr-only) while keeping it accessible. Useful for icon-only items. |
+
+### UIBreadcrumbRoot Props
+
+No props. Renderless wrapper that passes through its default slot content.
+
+### UIBreadcrumbItems Props
+
+No props. Wraps children in a `<nav>` element containing a horizontal `RowLayout`.
+
+### UIBreadcrumbSeparator Props
+
+No props. Renders a `ChevronRightIcon` separator.
+
+### UIBreadcrumbSelect / UIBreadcrumbDateSelect
+
+Placeholder components (currently render empty `<div>`). Reserved for future use with dropdown or date-picker breadcrumb segments.
+
+### Slots
+
+| Component | Slot | Description |
+|-----------|------|-------------|
+| `UIBreadcrumbRoot` | `default` | Content -- typically `UIBreadcrumbItems`. |
+| `UIBreadcrumbItems` | `default` | Breadcrumb items and separators. |
+
+### Emits
+
+No custom events.
+
+## Variants
+
+No variant props. Styling is fixed: items use `text-xs text-quaternary`, icons are `size-4 text-quaternary`, and linked items show `text-primary` + underline on hover.
+
+## Examples
+
+### With icon-only breadcrumb segment
+
+```vue
+<script setup lang="ts">
+import {
+  UIBreadcrumbRoot,
+  UIBreadcrumbItems,
+  UIBreadcrumbItem,
+  UIBreadcrumbSeparator,
+} from '@wisemen/vue-core-design-system'
+import { NotificationMessageIcon, Users01Icon, User01Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIBreadcrumbRoot>
+    <UIBreadcrumbItems>
+      <UIBreadcrumbItem :icon="Users01Icon" label="Users" to="/" />
+      <UIBreadcrumbSeparator />
+      <UIBreadcrumbItem
+        :icon="NotificationMessageIcon"
+        :is-label-hidden="true"
+        label="Messages"
+        to="/messages"
+      />
+      <UIBreadcrumbSeparator />
+      <UIBreadcrumbItem :icon="User01Icon" label="Jeroen" to="/users/jeroen" />
+      <UIBreadcrumbSeparator />
+      <UIBreadcrumbItem label="Projects" />
+    </UIBreadcrumbItems>
+  </UIBreadcrumbRoot>
+</template>
+```
+
+### Non-navigable current page
+
+```vue
+<template>
+  <UIBreadcrumbRoot>
+    <UIBreadcrumbItems>
+      <UIBreadcrumbItem label="Home" to="/" />
+      <UIBreadcrumbSeparator />
+      <UIBreadcrumbItem label="Current Page" />
+    </UIBreadcrumbItems>
+  </UIBreadcrumbRoot>
+</template>
+```
+
+The last item omits `to`, rendering it as plain text to indicate the current page.
+
+## Anatomy
+
+```
+UIBreadcrumbRoot (<slot /> passthrough)
+  UIBreadcrumbItems (<nav> + RowLayout)
+    UIBreadcrumbItem (ClickableElement > RouterLink | <span>)
+      RowLayout
+        ActionTooltip (for icon-only items)
+          Icon (optional)
+        UIText (label, may be sr-only)
+    UIBreadcrumbSeparator (ChevronRightIcon)
+    UIBreadcrumbItem ...
+```
+
+## Styling
+
+**Style file:** No dedicated `.style.ts` file. Styles are inline Tailwind classes in the Vue templates.
+
+**Key classes:**
+- Item label: `text-xs text-quaternary` (hover: `text-primary` + `underline` when linked)
+- Icon: `size-4 shrink-0 text-quaternary` (hover: `text-primary` when linked)
+- Separator: `size-4 shrink-0 text-fg-quaternary`
+- BreadcrumbItems nav has `min-w-0` for truncation support
+
+## Common Mistakes
+
+### WARNING: Forgetting separators between items
+
+```vue
+<!-- WRONG: no separators -->
+<UIBreadcrumbItems>
+  <UIBreadcrumbItem label="Home" to="/" />
+  <UIBreadcrumbItem label="Page" />
+</UIBreadcrumbItems>
+
+<!-- CORRECT -->
+<UIBreadcrumbItems>
+  <UIBreadcrumbItem label="Home" to="/" />
+  <UIBreadcrumbSeparator />
+  <UIBreadcrumbItem label="Page" />
+</UIBreadcrumbItems>
+```
+
+Separators are explicit components, not auto-inserted.
+
+### WARNING: Icon-only item without isLabelHidden
+
+```vue
+<!-- WRONG: renders both icon and label, looks cluttered when only the icon is desired -->
+<UIBreadcrumbItem :icon="NotificationMessageIcon" label="Messages" to="/" />
+
+<!-- CORRECT: hides label visually, shows tooltip on icon hover -->
+<UIBreadcrumbItem
+  :icon="NotificationMessageIcon"
+  :is-label-hidden="true"
+  label="Messages"
+  to="/"
+/>
+```
+
+When you want an icon-only breadcrumb, set `isLabelHidden` to `true`. The label remains accessible to screen readers and appears in a tooltip on hover.
+
+## Accessibility
+
+- `UIBreadcrumbItems` renders a `<nav>` element for landmark navigation.
+- Linked items render as `<RouterLink>` (proper `<a>` elements) for keyboard navigation and right-click support.
+- Non-linked items render as `<span>` to indicate the current (non-navigable) page.
+- When `isLabelHidden` is true, the label gets the `sr-only` class and a tooltip appears on the icon for sighted users.
+
+## See Also
+
+- [tabs](../tabs/SKILL.md) -- For in-page navigation between sibling content panels
+- [dropdown-menu](../dropdown-menu/SKILL.md) -- Can be combined for breadcrumb overflow patterns

--- a/packages/web/design-system/skills/components/breadcrumbs/SKILL.md
+++ b/packages/web/design-system/skills/components/breadcrumbs/SKILL.md
@@ -7,7 +7,6 @@ description: >
   label-hiding for icon-only items.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: navigation
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/button/SKILL.md
+++ b/packages/web/design-system/skills/components/button/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: button
+description: >
+  UIButton, UIIconButton, and UILink -- the three action trigger variants.
+  UIButton renders a labeled button, UIIconButton renders an icon-only button
+  with an accessible label, and UILink renders a navigation element styled
+  like a button using either Vue Router or a plain anchor.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: button
+requires: []
+exports:
+  - UIButton
+  - UIButtonProps
+  - UIIconButton
+  - UIIconButtonProps
+  - UILink
+  - UILinkProps
+---
+
+# UIButton / UIIconButton / UILink
+
+Three variants of the button primitive: labeled button, icon-only button, and navigation link styled as a button.
+
+## When to Use
+
+- **UIButton** -- Primary action trigger with a visible text label (forms, dialogs, toolbars).
+- **UIIconButton** -- Compact icon-only action (toolbar buttons, close buttons, inline actions).
+- **UILink** -- Navigation that should look like a button (external links, router links).
+
+**Use instead:** Use `UILink` over a raw `<a>` or `<RouterLink>` when you want button styling. Use `UIIconButton` instead of `UIButton` when space is tight and the icon is universally understood.
+
+## Import
+
+```ts
+import { UIButton, UIIconButton, UILink } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIButton, UIIconButton, UILink } from '@wisemen/vue-core-design-system'
+import { Settings01Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIButton label="Save" variant="primary" @click="onSave" />
+
+  <UIIconButton :icon="Settings01Icon" label="Settings" variant="secondary" />
+
+  <UILink label="Learn More" :link="{ href: 'https://example.com', target: '_blank' }" />
+</template>
+```
+
+## API
+
+### UIButton Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | **(required)** | Text label displayed inside the button. |
+| `variant` | `'primary' \| 'secondary' \| 'tertiary' \| 'destructive-primary' \| 'destructive-secondary' \| 'destructive-tertiary' \| 'minimal-color'` | `'primary'` | Visual style variant. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` | Controls the button size. |
+| `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | Native button type attribute. |
+| `isDisabled` | `boolean` | `false` | Disables the button, preventing interaction. |
+| `disabledReason` | `string \| null` | `null` | Tooltip text explaining why the button is disabled. |
+| `isLoading` | `boolean` | `false` | Shows a loading spinner and disables interaction. |
+| `iconLeft` | `Component \| null` | `null` | Icon displayed before the label. |
+| `iconRight` | `Component \| null` | `null` | Icon displayed after the label. |
+| `tooltipLabel` | `string \| null` | `null` | Tooltip text shown on hover or focus. |
+| `tooltipSide` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` | Position of the tooltip relative to the button. |
+| `keyboardShortcut` | `string \| null` | `null` | Visual keyboard shortcut badge (e.g. "meta_k"). Presentational only. |
+| `form` | `string \| null` | `null` | Associates button with a form by ID. |
+
+### UIButton Slots
+
+| Slot | Description |
+|------|-------------|
+| `left` | Content rendered before the left icon position. |
+
+### UIButton Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `click` | `MouseEvent` | Fired on click. Suppressed when `isLoading` is true. |
+
+---
+
+### UIIconButton Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `icon` | `Component` | **(required)** | Icon displayed inside the button. |
+| `label` | `string` | **(required)** | Accessible label (used as `aria-label` and tooltip text). |
+| `variant` | `'primary' \| 'secondary' \| 'tertiary' \| 'destructive-primary' \| 'destructive-tertiary'` | `'primary'` | Visual style variant. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` | Controls the button size. |
+| `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | Native button type attribute. |
+| `isDisabled` | `boolean` | `false` | Disables the button, preventing interaction. |
+| `disabledReason` | `string \| null` | `null` | Tooltip text explaining why the button is disabled. |
+| `isLoading` | `boolean` | `false` | Shows a loading spinner and disables interaction. |
+| `isTooltipDisabled` | `boolean` | `false` | Disables tooltip display. |
+| `tooltipLabel` | `string \| null` | `null` | Custom tooltip text (overrides `label`). |
+| `keyboardShortcut` | `string \| null` | `null` | Visual keyboard shortcut badge. Presentational only. |
+| `form` | `string \| null` | `null` | Associates button with a form by ID. |
+
+### UIIconButton Slots
+
+No slots.
+
+### UIIconButton Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `click` | `MouseEvent` | Fired on click. Suppressed when `isLoading` is true. |
+
+---
+
+### UILink Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | **(required)** | Text label displayed inside the link. |
+| `to` | `RouteLocationRaw \| null` | `null` | Vue Router destination. Renders a `<RouterLink>`. |
+| `link` | `{ href: string; target?: '_blank' \| '_self' \| '_parent' \| '_top'; rel?: string } \| null` | `null` | Native anchor attributes. Renders an `<a>` tag. |
+| `variant` | `'primary' \| 'secondary' \| 'tertiary' \| 'destructive-primary' \| 'destructive-tertiary'` | `'primary'` | Visual style variant. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` | Controls the link size. |
+| `iconLeft` | `Component \| null` | `null` | Icon displayed before the label. |
+| `iconRight` | `Component \| null` | `null` | Icon displayed after the label. |
+| `tooltipLabel` | `string \| null` | `null` | Tooltip text shown on hover or focus. |
+| `tooltipSide` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` | Position of the tooltip. |
+| `keyboardShortcut` | `string \| null` | `null` | Visual keyboard shortcut badge. Presentational only. |
+
+### UILink Slots
+
+No slots.
+
+### UILink Emits
+
+No custom events.
+
+## Variants
+
+### Visual variants
+
+| Variant | UIButton | UIIconButton | UILink | Description |
+|---------|----------|--------------|--------|-------------|
+| `primary` | Yes | Yes | Yes | Filled brand-colored background. Dark mode uses glassy effect. |
+| `secondary` | Yes | Yes | Yes | Bordered with subtle background. |
+| `tertiary` | Yes | Yes | Yes | Borderless, hover reveals background. |
+| `destructive-primary` | Yes | Yes | Yes | Filled red background for dangerous actions. |
+| `destructive-secondary` | Yes | No | No | Bordered red variant. UIButton only. |
+| `destructive-tertiary` | Yes | Yes | Yes | Borderless red text. |
+| `minimal-color` | Yes | No | No | Borderless brand-colored text. UIButton only. |
+
+### Sizes
+
+| Size | Button height | Icon size | Text |
+|------|---------------|-----------|------|
+| `xs` | `h-5.5` | `size-3.5` | `text-xs` |
+| `sm` | `h-6` | `size-3.5` | `text-xs` |
+| `md` | `h-7` | `size-3.5` | `text-xs` |
+| `lg` | `h-8` | `size-4` | `text-sm` |
+
+UIIconButton uses square dimensions (`size-5.5` through `size-8`).
+
+## Examples
+
+### Button with icons
+
+```vue
+<script setup lang="ts">
+import { UIButton } from '@wisemen/vue-core-design-system'
+import { PlusIcon, ArrowRightIcon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIButton
+    :icon-left="PlusIcon"
+    label="Add Item"
+    variant="primary"
+  />
+
+  <UIButton
+    :icon-right="ArrowRightIcon"
+    label="Next Step"
+    variant="secondary"
+  />
+</template>
+```
+
+### Loading and disabled states
+
+```vue
+<script setup lang="ts">
+import { UIButton } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIButton
+    :is-loading="true"
+    label="Saving..."
+    variant="primary"
+  />
+
+  <UIButton
+    :is-disabled="true"
+    disabled-reason="You do not have permission."
+    label="Delete"
+    variant="destructive-primary"
+  />
+</template>
+```
+
+### Icon button with custom tooltip
+
+```vue
+<script setup lang="ts">
+import { UIIconButton } from '@wisemen/vue-core-design-system'
+import { Settings01Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIIconButton
+    :icon="Settings01Icon"
+    label="Open settings"
+    tooltip-label="Project settings"
+    keyboard-shortcut="meta_comma"
+    variant="tertiary"
+    size="sm"
+  />
+</template>
+```
+
+### Link with Vue Router
+
+```vue
+<script setup lang="ts">
+import { UILink } from '@wisemen/vue-core-design-system'
+import { ExternalLinkIcon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <!-- Vue Router link -->
+  <UILink
+    label="Go to Dashboard"
+    :to="{ name: 'dashboard' }"
+    variant="primary"
+  />
+
+  <!-- External anchor link -->
+  <UILink
+    label="Documentation"
+    :icon-right="ExternalLinkIcon"
+    :link="{ href: 'https://docs.example.com', target: '_blank', rel: 'noopener' }"
+    variant="tertiary"
+  />
+</template>
+```
+
+## Anatomy
+
+```
+UIButton
+  ActionTooltip
+    <button>
+      container (grid stack)
+        Loader (grid area: stack, visible when isLoading)
+        RowLayout (grid area: stack, hidden when isLoading)
+          slot[left]
+          ButtonIcon (iconLeft)
+          <span> label
+          ButtonIcon (iconRight)
+
+UIIconButton
+  ActionTooltip
+    <button aria-label="...">
+      container (grid stack)
+        Loader (grid area: stack, visible when isLoading)
+        RowLayout (grid area: stack, hidden when isLoading)
+          IconButtonIcon (icon)
+
+UILink
+  ActionTooltip
+    <RouterLink|a>
+      container (grid stack)
+        RowLayout (grid area: stack)
+          LinkIcon (iconLeft)
+          <span> label
+          LinkIcon (iconRight)
+```
+
+## Styling
+
+**Style files:**
+- `src/ui/button/button/button.style.ts` -- UIButton
+- `src/ui/button/icon/iconButton.style.ts` -- UIIconButton
+- `src/ui/button/link/link.style.ts` -- UILink
+
+**tv() slots (UIButton):** `root`, `container`, `rowLayout`, `label`, `icon`, `loader`
+
+**tv() slots (UIIconButton):** `root`, `container`, `rowLayout`, `icon`, `loader`
+
+**tv() slots (UILink):** `root`, `container`, `rowLayout`, `label`, `icon`
+
+Dark mode: The `primary` variant uses a `glassy` / `glassy-inner-content` utility for a glass-morphism effect. Compound variants adjust border-radius and padding per size.
+
+## Common Mistakes
+
+### ERROR: UILink without `to` or `link`
+
+```vue
+<!-- WRONG: throws at runtime -->
+<UILink label="Click me" />
+
+<!-- CORRECT: provide either `to` or `link` -->
+<UILink label="Click me" :link="{ href: '/page' }" />
+<UILink label="Click me" :to="{ name: 'page' }" />
+```
+
+UILink requires exactly one of `to` (Vue Router) or `link` (native anchor). Omitting both throws: `"Either 'link' or 'to' must be provided."`
+
+### WARNING: Using UIButton for navigation
+
+```vue
+<!-- WRONG -->
+<UIButton label="Go to page" @click="router.push({ name: 'page' })" />
+
+<!-- CORRECT -->
+<UILink label="Go to page" :to="{ name: 'page' }" />
+```
+
+Use `UILink` for navigation so the rendered element is a proper `<a>` or `<RouterLink>`, enabling right-click, middle-click, and accessibility.
+
+### WARNING: IconButton without descriptive label
+
+```vue
+<!-- WRONG: label="X" is not descriptive -->
+<UIIconButton :icon="XCloseIcon" label="X" />
+
+<!-- CORRECT -->
+<UIIconButton :icon="XCloseIcon" label="Close dialog" />
+```
+
+The `label` prop is used as `aria-label` and tooltip text. It must describe the action, not the icon.
+
+## Accessibility
+
+- **UIButton**: Renders a native `<button>` with `disabled`, `aria-disabled` (when loading), and `aria-busy` (when loading).
+- **UIIconButton**: Renders a native `<button>` with `aria-label` set to the `label` prop. Tooltip displays by default with the label text.
+- **UILink**: Renders either a `<RouterLink>` or `<a>` tag for proper link semantics.
+- All three variants support keyboard navigation (Tab to focus, Enter/Space to activate).
+- Disabled buttons show a `disabledReason` tooltip on hover when the reason is provided.
+- The `data-interactive` attribute is set only when the button is both enabled and not loading, preventing pointer events on non-interactive states.
+
+## See Also
+
+- [dropdown-menu](../dropdown-menu/SKILL.md) -- Often triggered by a button
+- [menu-item](../menu-item/SKILL.md) -- Content layout inside dropdown menus
+- [tabs](../tabs/SKILL.md) -- Tab triggers share similar styling patterns

--- a/packages/web/design-system/skills/components/button/SKILL.md
+++ b/packages/web/design-system/skills/components/button/SKILL.md
@@ -11,11 +11,8 @@ category: button
 requires: []
 exports:
   - UIButton
-  - UIButtonProps
   - UIIconButton
-  - UIIconButtonProps
   - UILink
-  - UILinkProps
 ---
 
 # UIButton / UIIconButton / UILink
@@ -53,116 +50,11 @@ import { Settings01Icon } from '@wisemen/vue-core-icons'
 </template>
 ```
 
-## API
+## Source Files
 
-### UIButton Props
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `label` | `string` | **(required)** | Text label displayed inside the button. |
-| `variant` | `'primary' \| 'secondary' \| 'tertiary' \| 'destructive-primary' \| 'destructive-secondary' \| 'destructive-tertiary' \| 'minimal-color'` | `'primary'` | Visual style variant. |
-| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` | Controls the button size. |
-| `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | Native button type attribute. |
-| `isDisabled` | `boolean` | `false` | Disables the button, preventing interaction. |
-| `disabledReason` | `string \| null` | `null` | Tooltip text explaining why the button is disabled. |
-| `isLoading` | `boolean` | `false` | Shows a loading spinner and disables interaction. |
-| `iconLeft` | `Component \| null` | `null` | Icon displayed before the label. |
-| `iconRight` | `Component \| null` | `null` | Icon displayed after the label. |
-| `tooltipLabel` | `string \| null` | `null` | Tooltip text shown on hover or focus. |
-| `tooltipSide` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` | Position of the tooltip relative to the button. |
-| `keyboardShortcut` | `string \| null` | `null` | Visual keyboard shortcut badge (e.g. "meta_k"). Presentational only. |
-| `form` | `string \| null` | `null` | Associates button with a form by ID. |
-
-### UIButton Slots
-
-| Slot | Description |
-|------|-------------|
-| `left` | Content rendered before the left icon position. |
-
-### UIButton Emits
-
-| Event | Payload | Description |
-|-------|---------|-------------|
-| `click` | `MouseEvent` | Fired on click. Suppressed when `isLoading` is true. |
-
----
-
-### UIIconButton Props
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `icon` | `Component` | **(required)** | Icon displayed inside the button. |
-| `label` | `string` | **(required)** | Accessible label (used as `aria-label` and tooltip text). |
-| `variant` | `'primary' \| 'secondary' \| 'tertiary' \| 'destructive-primary' \| 'destructive-tertiary'` | `'primary'` | Visual style variant. |
-| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` | Controls the button size. |
-| `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | Native button type attribute. |
-| `isDisabled` | `boolean` | `false` | Disables the button, preventing interaction. |
-| `disabledReason` | `string \| null` | `null` | Tooltip text explaining why the button is disabled. |
-| `isLoading` | `boolean` | `false` | Shows a loading spinner and disables interaction. |
-| `isTooltipDisabled` | `boolean` | `false` | Disables tooltip display. |
-| `tooltipLabel` | `string \| null` | `null` | Custom tooltip text (overrides `label`). |
-| `keyboardShortcut` | `string \| null` | `null` | Visual keyboard shortcut badge. Presentational only. |
-| `form` | `string \| null` | `null` | Associates button with a form by ID. |
-
-### UIIconButton Slots
-
-No slots.
-
-### UIIconButton Emits
-
-| Event | Payload | Description |
-|-------|---------|-------------|
-| `click` | `MouseEvent` | Fired on click. Suppressed when `isLoading` is true. |
-
----
-
-### UILink Props
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `label` | `string` | **(required)** | Text label displayed inside the link. |
-| `to` | `RouteLocationRaw \| null` | `null` | Vue Router destination. Renders a `<RouterLink>`. |
-| `link` | `{ href: string; target?: '_blank' \| '_self' \| '_parent' \| '_top'; rel?: string } \| null` | `null` | Native anchor attributes. Renders an `<a>` tag. |
-| `variant` | `'primary' \| 'secondary' \| 'tertiary' \| 'destructive-primary' \| 'destructive-tertiary'` | `'primary'` | Visual style variant. |
-| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` | Controls the link size. |
-| `iconLeft` | `Component \| null` | `null` | Icon displayed before the label. |
-| `iconRight` | `Component \| null` | `null` | Icon displayed after the label. |
-| `tooltipLabel` | `string \| null` | `null` | Tooltip text shown on hover or focus. |
-| `tooltipSide` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` | Position of the tooltip. |
-| `keyboardShortcut` | `string \| null` | `null` | Visual keyboard shortcut badge. Presentational only. |
-
-### UILink Slots
-
-No slots.
-
-### UILink Emits
-
-No custom events.
-
-## Variants
-
-### Visual variants
-
-| Variant | UIButton | UIIconButton | UILink | Description |
-|---------|----------|--------------|--------|-------------|
-| `primary` | Yes | Yes | Yes | Filled brand-colored background. Dark mode uses glassy effect. |
-| `secondary` | Yes | Yes | Yes | Bordered with subtle background. |
-| `tertiary` | Yes | Yes | Yes | Borderless, hover reveals background. |
-| `destructive-primary` | Yes | Yes | Yes | Filled red background for dangerous actions. |
-| `destructive-secondary` | Yes | No | No | Bordered red variant. UIButton only. |
-| `destructive-tertiary` | Yes | Yes | Yes | Borderless red text. |
-| `minimal-color` | Yes | No | No | Borderless brand-colored text. UIButton only. |
-
-### Sizes
-
-| Size | Button height | Icon size | Text |
-|------|---------------|-----------|------|
-| `xs` | `h-5.5` | `size-3.5` | `text-xs` |
-| `sm` | `h-6` | `size-3.5` | `text-xs` |
-| `md` | `h-7` | `size-3.5` | `text-xs` |
-| `lg` | `h-8` | `size-4` | `text-sm` |
-
-UIIconButton uses square dimensions (`size-5.5` through `size-8`).
+- Props: `src/ui/button/button/button.props.ts`, `src/ui/button/icon/iconButton.props.ts`, `src/ui/button/link/link.props.ts`
+- Styles: `src/ui/button/button/button.style.ts`, `src/ui/button/icon/iconButton.style.ts`, `src/ui/button/link/link.style.ts`
+- Components: `src/ui/button/button/Button.vue`, `src/ui/button/icon/IconButton.vue`, `src/ui/button/link/Link.vue`
 
 ## Examples
 
@@ -212,26 +104,6 @@ import { UIButton } from '@wisemen/vue-core-design-system'
 </template>
 ```
 
-### Icon button with custom tooltip
-
-```vue
-<script setup lang="ts">
-import { UIIconButton } from '@wisemen/vue-core-design-system'
-import { Settings01Icon } from '@wisemen/vue-core-icons'
-</script>
-
-<template>
-  <UIIconButton
-    :icon="Settings01Icon"
-    label="Open settings"
-    tooltip-label="Project settings"
-    keyboard-shortcut="meta_comma"
-    variant="tertiary"
-    size="sm"
-  />
-</template>
-```
-
 ### Link with Vue Router
 
 ```vue
@@ -257,53 +129,6 @@ import { ExternalLinkIcon } from '@wisemen/vue-core-icons'
   />
 </template>
 ```
-
-## Anatomy
-
-```
-UIButton
-  ActionTooltip
-    <button>
-      container (grid stack)
-        Loader (grid area: stack, visible when isLoading)
-        RowLayout (grid area: stack, hidden when isLoading)
-          slot[left]
-          ButtonIcon (iconLeft)
-          <span> label
-          ButtonIcon (iconRight)
-
-UIIconButton
-  ActionTooltip
-    <button aria-label="...">
-      container (grid stack)
-        Loader (grid area: stack, visible when isLoading)
-        RowLayout (grid area: stack, hidden when isLoading)
-          IconButtonIcon (icon)
-
-UILink
-  ActionTooltip
-    <RouterLink|a>
-      container (grid stack)
-        RowLayout (grid area: stack)
-          LinkIcon (iconLeft)
-          <span> label
-          LinkIcon (iconRight)
-```
-
-## Styling
-
-**Style files:**
-- `src/ui/button/button/button.style.ts` -- UIButton
-- `src/ui/button/icon/iconButton.style.ts` -- UIIconButton
-- `src/ui/button/link/link.style.ts` -- UILink
-
-**tv() slots (UIButton):** `root`, `container`, `rowLayout`, `label`, `icon`, `loader`
-
-**tv() slots (UIIconButton):** `root`, `container`, `rowLayout`, `icon`, `loader`
-
-**tv() slots (UILink):** `root`, `container`, `rowLayout`, `label`, `icon`
-
-Dark mode: The `primary` variant uses a `glassy` / `glassy-inner-content` utility for a glass-morphism effect. Compound variants adjust border-radius and padding per size.
 
 ## Common Mistakes
 
@@ -343,15 +168,6 @@ Use `UILink` for navigation so the rendered element is a proper `<a>` or `<Route
 ```
 
 The `label` prop is used as `aria-label` and tooltip text. It must describe the action, not the icon.
-
-## Accessibility
-
-- **UIButton**: Renders a native `<button>` with `disabled`, `aria-disabled` (when loading), and `aria-busy` (when loading).
-- **UIIconButton**: Renders a native `<button>` with `aria-label` set to the `label` prop. Tooltip displays by default with the label text.
-- **UILink**: Renders either a `<RouterLink>` or `<a>` tag for proper link semantics.
-- All three variants support keyboard navigation (Tab to focus, Enter/Space to activate).
-- Disabled buttons show a `disabledReason` tooltip on hover when the reason is provided.
-- The `data-interactive` attribute is set only when the button is both enabled and not loading, preventing pointer events on non-interactive states.
 
 ## See Also
 

--- a/packages/web/design-system/skills/components/button/SKILL.md
+++ b/packages/web/design-system/skills/components/button/SKILL.md
@@ -7,7 +7,6 @@ description: >
   like a button using either Vue Router or a plain anchor.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: button
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/card/SKILL.md
+++ b/packages/web/design-system/skills/components/card/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: card
+description: >
+  Simple bordered container with rounded corners for grouping related content.
+  Has no props -- content goes in the default slot. Load this skill when you need
+  a visual card or panel wrapper.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UICard
+---
+
+# UICard
+
+A minimal bordered container with rounded corners for visually grouping related content.
+
+## When to Use
+
+- Wrapping a section of content in a visual card (e.g., settings panel, detail section)
+- Creating bordered containers for dashboard widgets or info blocks
+- Grouping form fields or related items into a distinct visual area
+
+**Use instead:** A plain `<div>` with custom border classes for non-standard card designs, or `UIDialog` for modal content.
+
+## Import
+
+```ts
+import { UICard } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UICard } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UICard>
+    <p>Card content goes here</p>
+  </UICard>
+</template>
+```
+
+## API
+
+### Props
+
+This component has no props.
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | The content rendered inside the card container. |
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+This component has no variants. It renders a single styled container.
+
+## Examples
+
+### Basic Card with Content
+
+```vue
+<script setup lang="ts">
+import { UICard } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UICard>
+    <div class="p-xl">
+      <h3 class="text-lg font-semibold text-primary">Card Title</h3>
+      <p class="mt-sm text-sm text-secondary">
+        This is some descriptive content inside a card.
+      </p>
+    </div>
+  </UICard>
+</template>
+```
+
+### Card with Sections Separated by Dividers
+
+```vue
+<script setup lang="ts">
+import { UICard } from '@wisemen/vue-core-design-system'
+import { UISeparator } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UICard>
+    <div class="p-xl">
+      <h3 class="text-lg font-semibold text-primary">Header</h3>
+    </div>
+    <UISeparator />
+    <div class="p-xl">
+      <p class="text-sm text-secondary">Body content</p>
+    </div>
+    <UISeparator />
+    <div class="flex justify-end p-xl">
+      <span class="text-sm text-tertiary">Footer</span>
+    </div>
+  </UICard>
+</template>
+```
+
+## Anatomy
+
+```
+UICard
+└── <div class="rounded-lg border border-secondary">
+    └── <slot />  (default slot)
+```
+
+## Styling
+
+**Style file:** None (styles are inline Tailwind classes)
+**tv() slots:** None
+**Customization:** UICard applies `rounded-lg border border-secondary` to its root `<div>`. To customize, pass a `class` attribute to override or extend styles. Note that UICard has no padding -- you must add padding to the slot content yourself (e.g., `p-xl`).
+
+## Common Mistakes
+
+### MEDIUM: Expecting built-in padding
+
+Wrong:
+```vue
+<!-- Content touches the card border with no spacing -->
+<UICard>
+  <p>Content without padding</p>
+</UICard>
+```
+
+Correct:
+```vue
+<UICard>
+  <div class="p-xl">
+    <p>Content with padding</p>
+  </div>
+</UICard>
+```
+
+UICard intentionally has no padding so you can compose sections with different padding or use separators edge-to-edge. Always add padding to your slot content.
+
+## Accessibility
+
+UICard renders a plain `<div>` with no ARIA attributes. It is a purely visual container. If the card represents a distinct region, add `role="region"` and `aria-label` on the card or its content for screen reader context.
+
+## See Also
+
+- [UISeparator](../separator/SKILL.md) -- For dividing sections within a card
+- [UIColumnLayout](../column-layout/SKILL.md) -- For stacking content vertically inside a card

--- a/packages/web/design-system/skills/components/card/SKILL.md
+++ b/packages/web/design-system/skills/components/card/SKILL.md
@@ -6,7 +6,6 @@ description: >
   a visual card or panel wrapper.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/checkbox-group/SKILL.md
+++ b/packages/web/design-system/skills/components/checkbox-group/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: checkbox-group
+description: >
+  A group of checkboxes for multi-value selection with an optional
+  indeterminate "select all" checkbox. Built on Reka UI CheckboxGroupRoot
+  with a context-based registration system. Supports vertical and horizontal
+  orientations and disabled state with reason tooltip.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: form-control
+requires:
+  - input-system
+exports:
+  - UICheckboxGroup
+  - UICheckboxGroupCheckbox
+  - UICheckboxGroupIndeterminateCheckbox
+  - UICheckboxGroupProps
+---
+
+# UICheckboxGroup
+
+A group of checkboxes for selecting multiple values from a set, with an optional "select all" indeterminate checkbox.
+
+## When to Use
+
+- Selecting multiple items from a predefined list (tags, permissions, features)
+- When you need a "select all / deselect all" toggle for the entire group
+- Multi-value form fields that need array-based v-model
+
+**Use instead:** [UICheckbox](../checkbox/SKILL.md) for a single boolean, [UIRadioGroup](../radio-group/SKILL.md) for single-selection from multiple options, [UISelect](../select/SKILL.md) for multi-select in a dropdown.
+
+## Import
+
+```ts
+import {
+  UICheckboxGroup,
+  UICheckboxGroupCheckbox,
+  UICheckboxGroupIndeterminateCheckbox,
+} from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  UICheckboxGroup,
+  UICheckboxGroupCheckbox,
+} from '@wisemen/vue-core-design-system'
+
+const selected = ref<string[]>([])
+</script>
+
+<template>
+  <UICheckboxGroup v-model="selected">
+    <UICheckboxGroupCheckbox value="option1" label="Option 1" />
+    <UICheckboxGroupCheckbox value="option2" label="Option 2" />
+    <UICheckboxGroupCheckbox value="option3" label="Option 3" />
+  </UICheckboxGroup>
+</template>
+```
+
+## API
+
+### UICheckboxGroup (Root) Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isDisabled` | `boolean` | `false` | Disables all checkboxes in the group. |
+| `disabledReason` | `string \| null` | `null` | Tooltip text shown on hover when the group is disabled. |
+| `orientation` | `'horizontal' \| 'vertical'` | `'vertical'` | Controls the keyboard navigation direction of the group. |
+
+### UICheckboxGroup v-model
+
+| Model | Type | Required | Description |
+|-------|------|----------|-------------|
+| `modelValue` | `TValue[]` | Yes | Array of selected values. Generic type `TValue` extends `AcceptableValue` (string, number, etc.). |
+
+### UICheckboxGroupCheckbox Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `AcceptableInputValue` | **required** | The value this checkbox represents. Added to/removed from the group's modelValue array. |
+| `label` | `string` | `undefined` | Label text displayed next to the checkbox. |
+| `isLabelHidden` | `boolean` | `false` | Visually hides the label (sr-only). |
+| `isDisabled` | `boolean` | `false` | Disables this individual checkbox. |
+| `disabledReason` | `string \| null` | `null` | Tooltip text shown on hover when this checkbox is disabled. |
+
+### UICheckboxGroupIndeterminateCheckbox Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string \| null` | `null` | Label text for the "select all" checkbox. |
+
+### Slots
+
+| Component | Slot | Description |
+|-----------|------|-------------|
+| UICheckboxGroup | `default` | Place UICheckboxGroupCheckbox and UICheckboxGroupIndeterminateCheckbox here. |
+
+### Emits
+
+No custom events beyond `update:modelValue` on the root.
+
+## Variants
+
+### Orientation
+
+| Value | Behavior |
+|-------|----------|
+| `vertical` | Keyboard navigation uses Up/Down arrow keys. Default. |
+| `horizontal` | Keyboard navigation uses Left/Right arrow keys. |
+
+Note: The `orientation` prop controls keyboard navigation direction only -- visual layout (flex-row vs flex-col) is your responsibility via CSS on a wrapper element.
+
+## Examples
+
+### Basic Usage
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  UICheckboxGroup,
+  UICheckboxGroupCheckbox,
+} from '@wisemen/vue-core-design-system'
+
+const fruits = ref<string[]>([])
+</script>
+
+<template>
+  <UICheckboxGroup v-model="fruits">
+    <div class="flex flex-col gap-sm">
+      <UICheckboxGroupCheckbox value="apple" label="Apple" />
+      <UICheckboxGroupCheckbox value="banana" label="Banana" />
+      <UICheckboxGroupCheckbox value="cherry" label="Cherry" />
+    </div>
+  </UICheckboxGroup>
+</template>
+```
+
+### With Formango
+
+```vue
+<script setup lang="ts">
+import { useForm } from '@wisemen/formango'
+import {
+  UICheckboxGroup,
+  UICheckboxGroupCheckbox,
+} from '@wisemen/vue-core-design-system'
+import { z } from 'zod'
+
+const { form } = useForm({
+  schema: z.object({
+    permissions: z.array(z.string()).min(1, 'Select at least one permission'),
+  }),
+  onSubmit(values) {
+    console.log(values)
+  },
+})
+
+const permissions = form.register('permissions')
+</script>
+
+<template>
+  <UICheckboxGroup v-model="permissions.modelValue.value">
+    <div class="flex flex-col gap-sm">
+      <UICheckboxGroupCheckbox value="read" label="Read" />
+      <UICheckboxGroupCheckbox value="write" label="Write" />
+      <UICheckboxGroupCheckbox value="delete" label="Delete" />
+    </div>
+  </UICheckboxGroup>
+</template>
+```
+
+### With Select All (Indeterminate)
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  UICheckboxGroup,
+  UICheckboxGroupCheckbox,
+  UICheckboxGroupIndeterminateCheckbox,
+} from '@wisemen/vue-core-design-system'
+
+const selected = ref<string[]>([])
+</script>
+
+<template>
+  <UICheckboxGroup v-model="selected">
+    <div class="flex flex-col gap-sm">
+      <UICheckboxGroupIndeterminateCheckbox label="Select All" />
+      <UICheckboxGroupCheckbox value="option1" label="Option 1" />
+      <UICheckboxGroupCheckbox value="option2" label="Option 2" />
+      <UICheckboxGroupCheckbox value="option3" label="Option 3" />
+    </div>
+  </UICheckboxGroup>
+</template>
+```
+
+### Horizontal Layout
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  UICheckboxGroup,
+  UICheckboxGroupCheckbox,
+} from '@wisemen/vue-core-design-system'
+
+const tags = ref<string[]>([])
+</script>
+
+<template>
+  <UICheckboxGroup v-model="tags" orientation="horizontal">
+    <div class="flex items-center gap-lg">
+      <UICheckboxGroupCheckbox value="vue" label="Vue" />
+      <UICheckboxGroupCheckbox value="react" label="React" />
+      <UICheckboxGroupCheckbox value="svelte" label="Svelte" />
+    </div>
+  </UICheckboxGroup>
+</template>
+```
+
+### Custom Card Layout
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  UICheckboxGroup,
+  UICheckboxGroupCheckbox,
+  UICheckboxGroupIndeterminateCheckbox,
+} from '@wisemen/vue-core-design-system'
+
+const selected = ref<string[]>([])
+
+const options = [
+  { title: 'Basic plan', description: 'Up to 10 users', value: 'basic' },
+  { title: 'Business plan', description: 'Up to 50 users', value: 'business' },
+]
+</script>
+
+<template>
+  <UICheckboxGroup v-model="selected">
+    <UICheckboxGroupIndeterminateCheckbox label="Select All" />
+    <label
+      v-for="option in options"
+      :key="option.value"
+      :for="`id-${option.value}`"
+    >
+      <div class="flex items-center justify-between rounded-md border p-md">
+        <div>
+          <p class="font-medium">{{ option.title }}</p>
+          <p class="text-sm text-gray-500">{{ option.description }}</p>
+        </div>
+        <UICheckboxGroupCheckbox
+          :id="`id-${option.value}`"
+          :value="option.value"
+          :is-label-hidden="true"
+        />
+      </div>
+    </label>
+  </UICheckboxGroup>
+</template>
+```
+
+## Anatomy
+
+```
+ActionTooltip                      (shows disabledReason when group is disabled)
+└── RekaCheckboxGroupRoot          (Reka UI, manages array v-model)
+    └── slot#default
+        ├── UICheckboxGroupIndeterminateCheckbox  (optional "select all")
+        │   └── BaseCheckbox (isIndeterminate=true when partial)
+        └── UICheckboxGroupCheckbox (one per option)
+            └── BaseCheckbox
+                └── InputWrapper (isHorizontal=true)
+                    ├── RekaCheckboxRoot
+                    │   └── div.control > CheckboxIndicator
+                    ├── Label
+                    └── Hint / ErrorMessage
+```
+
+## Styling
+
+The UICheckboxGroup root has no style file of its own. Individual checkboxes use the BaseCheckbox styles from `src/ui/checkbox/base/baseCheckbox.style.ts` (see [checkbox](../checkbox/SKILL.md)).
+
+## Common Mistakes
+
+### CRITICAL: Forgetting to register checkboxes by not using UICheckboxGroupCheckbox
+
+Wrong:
+```vue
+<UICheckboxGroup v-model="selected">
+  <UICheckbox v-model="someBool" label="Option" />
+  <!-- UICheckbox is NOT registered with the group! -->
+</UICheckboxGroup>
+```
+
+Correct:
+```vue
+<UICheckboxGroup v-model="selected">
+  <UICheckboxGroupCheckbox value="option" label="Option" />
+</UICheckboxGroup>
+```
+
+UICheckboxGroupCheckbox internally calls `registerCheckbox` on mount and `unRegisterCheckbox` on unmount. Using plain UICheckbox inside a group will not update the group's modelValue.
+
+### HIGH: Not wrapping checkboxes in a layout container
+
+The UICheckboxGroup provides no default layout -- it renders a bare `<slot />`. You must wrap the checkboxes in a flex or grid container yourself:
+
+```vue
+<UICheckboxGroup v-model="selected">
+  <!-- No gap/layout without a wrapper! -->
+  <div class="flex flex-col gap-sm">
+    <UICheckboxGroupCheckbox value="a" label="A" />
+    <UICheckboxGroupCheckbox value="b" label="B" />
+  </div>
+</UICheckboxGroup>
+```
+
+### MEDIUM: Using wrong v-model type
+
+Wrong:
+```vue
+const selected = ref<string>('')  // Wrong! Should be an array
+```
+
+Correct:
+```vue
+const selected = ref<string[]>([])
+```
+
+The v-model must be an array matching the type of the `value` props on the checkboxes.
+
+## Accessibility
+
+- Reka UI CheckboxGroupRoot handles `role="group"` semantics
+- Individual checkboxes handle `role="checkbox"`, `aria-checked`, Space key toggling
+- The indeterminate checkbox shows a dash icon and toggles all/none
+- `orientation` controls arrow key navigation direction (Up/Down for vertical, Left/Right for horizontal)
+- Disabled state on the group propagates to all child checkboxes
+
+## See Also
+
+- [input-system](../../foundations/input-system/SKILL.md) -- Inherited props and architecture
+- [checkbox](../checkbox/SKILL.md) -- Single boolean checkbox
+- [radio-group](../radio-group/SKILL.md) -- Single selection from multiple options

--- a/packages/web/design-system/skills/components/checkbox-group/SKILL.md
+++ b/packages/web/design-system/skills/components/checkbox-group/SKILL.md
@@ -7,7 +7,6 @@ description: >
   orientations and disabled state with reason tooltip.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: form-control
 requires:
   - input-system

--- a/packages/web/design-system/skills/components/checkbox/SKILL.md
+++ b/packages/web/design-system/skills/components/checkbox/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: checkbox
+description: >
+  A single boolean checkbox with label, hint, error message, and animated check
+  indicator. Built on Reka UI CheckboxRoot with InputWrapper in horizontal
+  layout. Integrates with formango for form validation and with UICheckboxGroup
+  for multi-select scenarios.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: form-control
+requires:
+  - input-system
+exports:
+  - UICheckbox
+  - UICheckboxProps
+---
+
+# UICheckbox
+
+A single boolean checkbox with animated check indicator, label, hint, and error message support.
+
+## When to Use
+
+- Capturing a single boolean value (agree to terms, opt-in, enable feature)
+- Individual on/off toggles with a text label
+- Inside a form where you need validation on a required boolean field
+
+**Use instead:** [UICheckboxGroup](../checkbox-group/SKILL.md) for selecting multiple values from a set, [UISwitch](../switch/SKILL.md) for on/off toggles that take effect immediately (settings), [UIRadioGroup](../radio-group/SKILL.md) for single selection from multiple options.
+
+## Import
+
+```ts
+import { UICheckbox } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UICheckbox } from '@wisemen/vue-core-design-system'
+
+const accepted = ref<boolean>(false)
+</script>
+
+<template>
+  <UICheckbox
+    v-model="accepted"
+    label="I agree to the terms and conditions"
+  />
+</template>
+```
+
+## API
+
+### Props
+
+> Inherits from: `Input`, `AutocompleteInput`, `InputWrapper` (see [input-system](../../foundations/input-system/SKILL.md))
+>
+> Note: UICheckbox inherits from BaseCheckboxProps (which extends Input, InputWrapper, AutocompleteInput) but omits `isIndeterminate`. The checkbox does NOT inherit FieldWrapper -- it has its own control rendering.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `AcceptableInputValue` | `undefined` | The value associated with this checkbox. Used when the checkbox is part of a CheckboxGroup. |
+
+Note: The `isHorizontal` prop from InputWrapper is forced to `true` internally -- the checkbox always renders with the control on the left and the label on the right.
+
+### v-model
+
+| Model | Type | Required | Description |
+|-------|------|----------|-------------|
+| `modelValue` | `boolean` | Yes | Whether the checkbox is checked. |
+
+### Slots
+
+This component has no custom slots.
+
+### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `blur` | none | Emitted when the checkbox loses focus. |
+
+## Variants
+
+This component has no size or visual variants.
+
+## Examples
+
+### Basic Usage
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UICheckbox } from '@wisemen/vue-core-design-system'
+
+const isEnabled = ref<boolean>(false)
+</script>
+
+<template>
+  <UICheckbox
+    v-model="isEnabled"
+    label="Enable notifications"
+    hint="You will receive email notifications"
+  />
+</template>
+```
+
+### With Formango
+
+```vue
+<script setup lang="ts">
+import { useForm } from '@wisemen/formango'
+import { UICheckbox } from '@wisemen/vue-core-design-system'
+import { z } from 'zod'
+
+const { form } = useForm({
+  schema: z.object({
+    acceptTerms: z.literal(true, {
+      errorMap: () => ({ message: 'You must accept the terms' }),
+    }),
+  }),
+  onSubmit(values) {
+    console.log(values)
+  },
+})
+
+const acceptTerms = form.register('acceptTerms')
+</script>
+
+<template>
+  <UICheckbox
+    v-model="acceptTerms.modelValue.value"
+    :error-message="acceptTerms.isTouched.value ? acceptTerms.errors.value?._errors?.[0] ?? null : null"
+    :is-required="true"
+    label="I accept the terms and conditions"
+    @blur="acceptTerms.setTouched()"
+  />
+</template>
+```
+
+### Disabled with Reason
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UICheckbox } from '@wisemen/vue-core-design-system'
+
+const premium = ref<boolean>(false)
+</script>
+
+<template>
+  <UICheckbox
+    v-model="premium"
+    :is-disabled="true"
+    disabled-reason="Upgrade to premium to enable this feature"
+    label="Premium feature"
+  />
+</template>
+```
+
+## Anatomy
+
+```
+InputWrapper (isHorizontal=true)
+├── RekaCheckboxRoot           (Reka UI checkbox root, handles state)
+│   └── div.control            (bordered checkbox square)
+│       └── CheckboxIndicator  (animated check/indeterminate SVG)
+├── InputWrapperLabel          (label text + asterisk)
+├── InputWrapperHint           (hint text)
+└── InputWrapperErrorMessage   (error text)
+```
+
+The checkbox uses the `isHorizontal` layout mode of InputWrapper, placing the control on the left and label + hint + error on the right.
+
+## Styling
+
+**Style file:** `src/ui/checkbox/base/baseCheckbox.style.ts`
+**tv() slots:**
+- `root` -- The clickable root element. Flex layout, cursor styles, disabled state.
+- `control` -- The 16x16 bordered checkbox square. Includes checked (brand color), disabled, error, and focus-visible states.
+- `indicator` -- The animated SVG check icon inside the control. White on brand background.
+
+The check animation uses Motion (motion-v) with spring-based path animation for the checkmark SVG.
+
+## Common Mistakes
+
+### CRITICAL: Using UICheckbox for multi-select instead of UICheckboxGroup
+
+Wrong:
+```vue
+<UICheckbox v-model="options.includes('a')" label="Option A" />
+<UICheckbox v-model="options.includes('b')" label="Option B" />
+```
+
+Correct:
+```vue
+<UICheckboxGroup v-model="selectedOptions">
+  <UICheckboxGroupCheckbox value="a" label="Option A" />
+  <UICheckboxGroupCheckbox value="b" label="Option B" />
+</UICheckboxGroup>
+```
+
+UICheckbox is for a single boolean. Use UICheckboxGroup for selecting multiple values from a set.
+
+### HIGH: Passing errorMessage without checking touched state
+
+Wrong:
+```vue
+<UICheckbox
+  v-model="field.modelValue.value"
+  :error-message="field.errors.value?._errors?.[0]"
+/>
+```
+
+Correct:
+```vue
+<UICheckbox
+  v-model="field.modelValue.value"
+  :error-message="field.isTouched.value ? field.errors.value?._errors?.[0] ?? null : null"
+  @blur="field.setTouched()"
+/>
+```
+
+### MEDIUM: Expecting v-model to be nullable
+
+The v-model type is `boolean`, not `boolean | null`. It must always be `true` or `false`.
+
+## Accessibility
+
+- Reka UI CheckboxRoot handles: `role="checkbox"`, `aria-checked`, keyboard toggling (Space key)
+- `useInput`-derived ARIA attributes are not used directly (no `useInput` call in checkbox), but InputWrapper handles error/hint associations
+- `data-invalid` attribute applied when `errorMessage` is present, driving error border styles
+- `disabled` attribute on the root prevents interaction and shows disabled-reason tooltip
+- Keyboard: Space to toggle, Tab to navigate between checkboxes
+- The animated check indicator SVGs have `aria-hidden="true"`
+
+## See Also
+
+- [input-system](../../foundations/input-system/SKILL.md) -- Inherited props and architecture
+- [checkbox-group](../checkbox-group/SKILL.md) -- Multi-select checkbox group
+- [switch](../switch/SKILL.md) -- Toggle for immediate on/off settings

--- a/packages/web/design-system/skills/components/checkbox/SKILL.md
+++ b/packages/web/design-system/skills/components/checkbox/SKILL.md
@@ -7,7 +7,6 @@ description: >
   for multi-select scenarios.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: form-control
 requires:
   - input-system

--- a/packages/web/design-system/skills/components/clickable-element/SKILL.md
+++ b/packages/web/design-system/skills/components/clickable-element/SKILL.md
@@ -6,7 +6,6 @@ description: >
   Load this skill when building custom clickable primitives or understanding the focus ring system.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: infrastructure
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/clickable-element/SKILL.md
+++ b/packages/web/design-system/skills/components/clickable-element/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: clickable-element
+description: >
+  Low-level wrapper that applies consistent focus-visible outline and cursor styles to any
+  interactive element. Uses Reka UI Primitive with as-child for zero extra DOM nodes.
+  Load this skill when building custom clickable primitives or understanding the focus ring system.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: infrastructure
+requires: []
+exports:
+  - UIClickableElement
+---
+
+# UIClickableElement
+
+A renderless wrapper that applies consistent interactive styles (focus ring, pointer cursor, disabled cursor) to its child element using Reka UI's `Primitive` with `as-child`.
+
+## When to Use
+
+- Building a custom interactive component that needs a consistent focus ring and cursor behavior
+- Wrapping a native element (button, anchor, etc.) that should follow the design system's focus-visible pattern
+- When you need a lightweight base for clickable areas without adding extra DOM nodes
+
+**Use instead:** `UIInteractable` for an alternative with slightly different outline behavior. `UIButton` or `UIIconButton` for fully styled action buttons.
+
+## Import
+
+```ts
+import { UIClickableElement } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIClickableElement } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIClickableElement>
+    <button>Click me</button>
+  </UIClickableElement>
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isDefaultCursor` | `boolean` | `false` | When `true`, uses the default cursor instead of `cursor-pointer`. Useful for elements that are interactive but should not visually suggest a click action. |
+| `class` | `string` | `''` | Additional CSS classes merged onto the child element via `twMerge`. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | A single interactive child element (button, anchor, div, etc.) that receives the merged styles. |
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+This component has no size/variant/color options.
+
+## Examples
+
+### Custom Card Link
+
+```vue
+<script setup lang="ts">
+import { UIClickableElement } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIClickableElement>
+    <a href="/details" class="block rounded-md border p-4">
+      <h3>Card Title</h3>
+      <p>Card description text</p>
+    </a>
+  </UIClickableElement>
+</template>
+```
+
+### Non-pointer Interactive Element
+
+```vue
+<script setup lang="ts">
+import { UIClickableElement } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIClickableElement :is-default-cursor="true">
+    <div tabindex="0" role="option">
+      Selectable item with default cursor
+    </div>
+  </UIClickableElement>
+</template>
+```
+
+## Anatomy
+
+```
+Primitive[as-child=true]   (no extra DOM node)
+  <slot />                 (child receives merged classes)
+```
+
+Because `as-child` is `true`, `UIClickableElement` does not render its own DOM element. It merges styles directly onto the child element.
+
+## Styling
+
+**Style file:** This component uses inline Tailwind classes (no separate style file).
+
+Applied classes:
+- `rounded-sm` -- Subtle border radius for the focus ring shape
+- `outline-2 outline-transparent` -- Invisible outline by default
+- `focus-visible:outline-fg-brand-primary` -- Brand-colored focus ring on keyboard focus
+- `disabled:cursor-not-allowed` -- Disabled state cursor
+- `cursor-pointer` -- Pointer cursor (unless `isDefaultCursor` is `true`)
+
+Classes are merged with any `class` prop value using `twMerge`.
+
+## Common Mistakes
+
+### HIGH: Passing multiple children
+
+Wrong:
+```vue
+<UIClickableElement>
+  <button>One</button>
+  <button>Two</button>
+</UIClickableElement>
+```
+
+Correct:
+```vue
+<UIClickableElement>
+  <button>One</button>
+</UIClickableElement>
+<UIClickableElement>
+  <button>Two</button>
+</UIClickableElement>
+```
+
+`as-child` mode from Reka UI merges props into a single child. Multiple children will cause unexpected behavior.
+
+### MEDIUM: Wrapping a non-interactive element without tabindex
+
+Wrong:
+```vue
+<UIClickableElement>
+  <div>Not focusable</div>
+</UIClickableElement>
+```
+
+Correct:
+```vue
+<UIClickableElement>
+  <div tabindex="0" role="button">Now focusable</div>
+</UIClickableElement>
+```
+
+The focus-visible outline only activates on elements that can receive focus. Non-interactive elements need `tabindex="0"` and an appropriate `role`.
+
+## Accessibility
+
+- Applies `focus-visible:outline-fg-brand-primary` for keyboard navigation -- the focus ring only appears on keyboard focus, not mouse clicks.
+- Sets `disabled:cursor-not-allowed` to visually indicate disabled state.
+- Does not add any ARIA attributes -- the child element must provide its own `role`, `aria-label`, etc.
+
+## See Also
+
+- [UIInteractable](../interactable/) -- Similar low-level wrapper with a slightly different outline approach
+- [UIButton](../button/) -- Fully styled button component for most action triggers

--- a/packages/web/design-system/skills/components/column-layout/SKILL.md
+++ b/packages/web/design-system/skills/components/column-layout/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: column-layout
+description: >
+  Vertical flex container with configurable gap, alignment, and justification using
+  design-token spacing. Renders as a customizable HTML element and provides a default
+  slot for child content. Use for any vertical stacking of elements.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: layout
+requires:
+  - layout-system
+exports:
+  - UIColumnLayout
+---
+
+# UIColumnLayout
+
+Vertical flex container with token-based gap, cross-axis alignment, and main-axis justification.
+
+## When to Use
+
+- Stacking form fields, cards, or sections vertically with consistent spacing
+- Building page content areas or sidebar sections
+- Any vertical arrangement where you need design-token spacing rather than raw Tailwind
+
+**Use instead:** `UIRowLayout` for horizontal arrangement. A plain `div` with `flex-col` when you need non-standard flex behavior.
+
+## Import
+
+```ts
+import { UIColumnLayout } from '@wisemen/vue-core-design-system'
+```
+
+The `LayoutGap` type is defined in `columnLayout.props.ts` and shared with `UIRowLayout`. It is not directly exported from the package, but the gap values are documented below for reference.
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIColumnLayout } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIColumnLayout gap="xl">
+    <div class="rounded-lg border p-4">Section 1</div>
+    <div class="rounded-lg border p-4">Section 2</div>
+    <div class="rounded-lg border p-4">Section 3</div>
+  </UIColumnLayout>
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `align` | `'center' \| 'end' \| 'start'` | `'start'` | Cross-axis (horizontal) alignment of items. |
+| `as` | `string` | `'div'` | The HTML element to render as the container. |
+| `gap` | `LayoutGap` | `'md'` | Spacing between items. See gap scale below. |
+| `justify` | `'between' \| 'center' \| 'end' \| 'start'` | `'start'` | Main-axis (vertical) distribution of items. |
+
+**`LayoutGap` values:** `'none'` | `'xxs'` | `'xs'` | `'sm'` | `'md'` | `'lg'` | `'xl'` | `'2xl'` | `'3xl'` | `'4xl'` | `'5xl'` | `'6xl'` | `'7xl'` | `'8xl'` | `'9xl'` | `'10xl'` | `'11xl'`
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Child elements stacked vertically. |
+
+### Emits
+
+No custom events.
+
+## Variants
+
+This component has no visual variants. All appearance is controlled via props (`gap`, `align`, `justify`).
+
+## Examples
+
+### Form Fields with Large Gap
+
+```vue
+<script setup lang="ts">
+import { UIColumnLayout, UITextField } from '@wisemen/vue-core-design-system'
+import { ref } from 'vue'
+
+const name = ref<string>('')
+const email = ref<string>('')
+</script>
+
+<template>
+  <UIColumnLayout gap="xl">
+    <UITextField v-model="name" label="Name" />
+    <UITextField v-model="email" label="Email" type="email" />
+  </UIColumnLayout>
+</template>
+```
+
+### Centered Content
+
+```vue
+<script setup lang="ts">
+import { UIColumnLayout } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIColumnLayout gap="lg" align="center" justify="center" class="h-full">
+    <h2>Centered Title</h2>
+    <p>Centered description text.</p>
+  </UIColumnLayout>
+</template>
+```
+
+### Rendered as a Navigation Element
+
+```vue
+<script setup lang="ts">
+import { UIColumnLayout } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIColumnLayout as="nav" gap="xs">
+    <a href="/home">Home</a>
+    <a href="/about">About</a>
+    <a href="/contact">Contact</a>
+  </UIColumnLayout>
+</template>
+```
+
+## Anatomy
+
+```
+Component[as] .flex.flex-col .[alignClass] .[justifyClass] .[gapClass]
+  <slot />
+```
+
+## Styling
+
+**Style file:** No separate style file. Uses inline Tailwind classes mapped from props.
+**CSS classes:** `flex flex-col` is always applied. Alignment, justification, and gap classes are computed from props (e.g., `items-start`, `justify-center`, `gap-xl`).
+
+## Common Mistakes
+
+### MEDIUM: Using raw Tailwind flex-col instead of UIColumnLayout
+
+Wrong:
+```html
+<div class="flex flex-col gap-4">
+  <div>Section 1</div>
+  <div>Section 2</div>
+</div>
+```
+
+Correct:
+```vue
+<UIColumnLayout gap="xl">
+  <div>Section 1</div>
+  <div>Section 2</div>
+</UIColumnLayout>
+```
+
+UIColumnLayout uses design-token spacing to ensure consistency across the application.
+
+### LOW: Confusing align in column vs row context
+
+In UIColumnLayout, `align` controls the **horizontal** (cross-axis) alignment, while in UIRowLayout, `align` controls the **vertical** (cross-axis) alignment. The prop name is the same, but the axis flips.
+
+## Accessibility
+
+- Renders a semantic HTML element (default `div`, customizable via `as`).
+- No ARIA attributes are added; rely on the semantic meaning of `as` (e.g., `nav`, `section`, `form`) when appropriate.
+- Keyboard navigation depends on the child elements, not the layout container.
+
+## See Also
+
+- [UIRowLayout](../row-layout/) -- Horizontal flex container with the same gap/align/justify API
+- [Layout System](../../foundations/layout-system/) -- Foundation overview of all layout primitives

--- a/packages/web/design-system/skills/components/column-layout/SKILL.md
+++ b/packages/web/design-system/skills/components/column-layout/SKILL.md
@@ -6,7 +6,6 @@ description: >
   slot for child content. Use for any vertical stacking of elements.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: layout
 requires:
   - layout-system

--- a/packages/web/design-system/skills/components/config-provider/SKILL.md
+++ b/packages/web/design-system/skills/components/config-provider/SKILL.md
@@ -6,7 +6,6 @@ description: >
   via Vue's provide/inject. Must wrap the entire application.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: infrastructure
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/config-provider/SKILL.md
+++ b/packages/web/design-system/skills/components/config-provider/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: config-provider
+description: >
+  Application-level configuration provider that supplies locale, number formatting,
+  hour cycle, teleport target, and Google Maps API key to all design system components
+  via Vue's provide/inject. Must wrap the entire application.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: infrastructure
+requires: []
+exports:
+  - UIConfigProvider
+  - ConfigProviderProps
+  - useInjectConfigContext
+---
+
+# UIConfigProvider
+
+Provides global configuration (locale, number formatting, hour cycle, teleport target, Google Maps API key) to all design system components via Vue's provide/inject.
+
+## When to Use
+
+- At the root of every application that uses the design system -- wrap your `App.vue` content in this component
+- When you need to change locale, number formatting, or hour cycle settings application-wide
+
+**Use instead:** Nothing -- this component is required for the design system to function correctly.
+
+## Import
+
+```ts
+import { UIConfigProvider } from '@wisemen/vue-core-design-system'
+import type { ConfigProviderProps } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIConfigProvider } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIConfigProvider locale="en-US">
+    <RouterView />
+  </UIConfigProvider>
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `locale` | `string` | required | The locale string used for localization across all components (e.g. `'en-US'`, `'nl-BE'`, `'fr-FR'`). |
+| `hourCycle` | `'12-hour' \| '24-hour'` | `undefined` | Controls time display in time-related components. When not set, the system locale's default is used. |
+| `numberSeparatorStyle` | `'comma-period' \| 'period-comma' \| 'space-comma' \| 'space-period' \| 'system'` | `'system'` | Controls thousands and decimal separator style in NumberField components. See below for examples. |
+| `teleportTargetSelector` | `string` | `'body'` | CSS selector for the teleport target used by overlays, popovers, and modals. |
+| `googleMapsApiKey` | `string \| null` | `null` | Google Maps API key used by the AddressAutocomplete component for address validation. |
+
+### Number Separator Styles
+
+| Value | Example | Common Locales |
+|-------|---------|----------------|
+| `'period-comma'` | `1.234.567,89` | de-DE, nl-NL, nl-BE |
+| `'comma-period'` | `1,234,567.89` | en-US, en-GB |
+| `'space-period'` | `1 234 567.89` | fr-CH |
+| `'space-comma'` | `1 234 567,89` | fr-FR |
+| `'system'` | Follows browser/OS locale | -- |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Your entire application. All design system components within this slot will receive the configuration. |
+
+### Emits
+
+This component has no events.
+
+## Variants
+
+This component has no visual variants.
+
+## Examples
+
+### Full Configuration
+
+```vue
+<script setup lang="ts">
+import { UIConfigProvider } from '@wisemen/vue-core-design-system'
+
+const googleMapsApiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY
+</script>
+
+<template>
+  <UIConfigProvider
+    locale="nl-BE"
+    hour-cycle="24-hour"
+    number-separator-style="period-comma"
+    teleport-target-selector="#app"
+    :google-maps-api-key="googleMapsApiKey"
+  >
+    <RouterView />
+  </UIConfigProvider>
+</template>
+```
+
+### Combined with ThemeProvider
+
+```vue
+<script setup lang="ts">
+import { UIConfigProvider, UIThemeProvider } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIConfigProvider locale="en-US">
+    <UIThemeProvider appearance="system">
+      <RouterView />
+    </UIThemeProvider>
+  </UIConfigProvider>
+</template>
+```
+
+### Accessing Config in Custom Components
+
+```vue
+<script setup lang="ts">
+import { useInjectConfigContext } from '@wisemen/vue-core-design-system'
+
+const config = useInjectConfigContext()
+
+// All properties are ComputedRefs:
+// config.locale.value        -> 'en-US'
+// config.hourCycle.value      -> '24-hour' | undefined
+// config.numberSeparatorStyle.value -> 'system'
+// config.teleportTargetSelector.value -> 'body'
+// config.googleMapsApiKey.value -> null | 'AIza...'
+</script>
+```
+
+## Anatomy
+
+```
+UIConfigProvider
+  TooltipProvider (wraps children with Reka UI tooltip provider)
+    <slot /> (application content)
+```
+
+## Styling
+
+This component has no visual styling. It is a provider-only wrapper.
+
+## Common Mistakes
+
+### HIGH: Forgetting to wrap the application
+
+Wrong:
+```vue
+<!-- App.vue -->
+<template>
+  <RouterView />
+</template>
+```
+
+Correct:
+```vue
+<!-- App.vue -->
+<template>
+  <UIConfigProvider locale="en-US">
+    <RouterView />
+  </UIConfigProvider>
+</template>
+```
+
+Without `UIConfigProvider`, components that inject the config context will fail or fall back to undefined values. Always wrap your application root.
+
+### MEDIUM: Placing ThemeProvider outside ConfigProvider
+
+Wrong:
+```vue
+<UIThemeProvider appearance="system">
+  <UIConfigProvider locale="en-US">
+    <RouterView />
+  </UIConfigProvider>
+</UIThemeProvider>
+```
+
+Correct:
+```vue
+<UIConfigProvider locale="en-US">
+  <UIThemeProvider appearance="system">
+    <RouterView />
+  </UIThemeProvider>
+</UIConfigProvider>
+```
+
+`UIConfigProvider` should be the outermost wrapper since it provides configuration that other providers and components may depend on.
+
+### LOW: Using locale string inconsistently
+
+Wrong:
+```vue
+<UIConfigProvider locale="en">
+```
+
+Correct:
+```vue
+<UIConfigProvider locale="en-US">
+```
+
+Use full BCP-47 locale strings (e.g. `en-US`, `nl-BE`, `fr-FR`) for consistent behavior across components that rely on `Intl` APIs.
+
+## Accessibility
+
+- This component has no direct accessibility impact. It is a configuration wrapper.
+- It wraps children in a `TooltipProvider` from Reka UI, which is required for tooltips to function with proper ARIA attributes.
+- The `locale` prop indirectly affects accessibility by controlling the language used in component labels and messages.
+
+## See Also
+
+- [UIThemeProvider](../theme-provider/) -- For appearance (light/dark/system) and theme switching

--- a/packages/web/design-system/skills/components/confirm-dialog/SKILL.md
+++ b/packages/web/design-system/skills/components/confirm-dialog/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: confirm-dialog
+description: >
+  A pre-built confirmation dialog with title, description, icon, cancel button, and
+  confirm button. Supports destructive styling and async confirm callbacks with automatic
+  loading state. Uses the dialog sub-components internally. Load this skill for yes/no
+  or delete confirmation prompts.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: overlay
+requires:
+  - overlay-system
+exports:
+  - UIConfirmDialog
+  - UIConfirmDialogProps
+---
+
+# UIConfirmDialog
+
+A pre-built confirmation dialog that combines UIDialog, UIDialogHeader, UIDialogFooter, and UIDialogFooterCancel into a single component with a standardized confirm/cancel flow.
+
+## When to Use
+
+- Confirming destructive actions (delete, remove, discard)
+- Asking the user for a simple yes/no decision
+- Showing a warning before an irreversible operation
+
+**Use instead:** `UIDialog` for custom dialog layouts with forms or complex content, `UIFormDialog` for dialogs with form validation.
+
+## Import
+
+```ts
+import { UIConfirmDialog } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIConfirmDialog } from '@wisemen/vue-core-design-system'
+import { Trash01Icon } from '@wisemen/vue-core-icons'
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+async function handleConfirm() {
+  await deleteItem()
+  emit('close')
+}
+</script>
+
+<template>
+  <UIConfirmDialog
+    :is-destructive="true"
+    :icon="Trash01Icon"
+    title="Delete item"
+    description="Are you sure you want to delete this item? This action cannot be undone."
+    confirm-label="Delete"
+    cancel-label="Cancel"
+    :on-confirm="handleConfirm"
+    @close="emit('close')"
+  />
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | -- (required) | The title displayed in the dialog header. |
+| `description` | `string` | -- (required) | The description text displayed below the title. |
+| `confirmLabel` | `string \| null` | `null` | Label for the confirm button. Falls back to i18n `component.unsaved_changes_dialog.confirm`. |
+| `cancelLabel` | `string \| null` | `null` | Label for the cancel button. Falls back to i18n `component.unsaved_changes_dialog.cancel`. |
+| `isDestructive` | `boolean` | `false` | When true, the confirm button uses `destructive-primary` variant and the icon uses `error` color. |
+| `icon` | `Component \| null` | `null` | Optional icon displayed in the header. |
+| `onConfirm` | `(() => Promise<void> \| void) \| null` | `null` | Callback when the confirm button is clicked. If it returns a Promise, the button shows a loading spinner until the Promise resolves. |
+| `preventClickOutside` | `boolean` | `false` | Prevents closing by clicking the backdrop. |
+| `preventEsc` | `boolean` | `false` | Prevents closing by pressing Escape. |
+
+### Slots
+
+This component has no slots. All content is driven by props.
+
+### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `close` | -- | Fired when the dialog should close (cancel clicked, backdrop clicked, or Escape pressed). |
+
+## Variants
+
+The dialog always renders at `size="xs"` with no close button. The only visual variant is `isDestructive`:
+
+| `isDestructive` | Confirm Button Variant | Icon Variant |
+|-----------------|----------------------|--------------|
+| `false` | `primary` | `brand` |
+| `true` | `destructive-primary` | `error` |
+
+## Examples
+
+### Template-Driven
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIConfirmDialog, UIButton } from '@wisemen/vue-core-design-system'
+import { Trash01Icon } from '@wisemen/vue-core-icons'
+
+const isOpen = ref(false)
+</script>
+
+<template>
+  <UIButton label="Delete" @click="isOpen = true" />
+
+  <UIConfirmDialog
+    v-if="isOpen"
+    :is-destructive="true"
+    :icon="Trash01Icon"
+    title="Delete item"
+    description="Are you sure? This cannot be undone."
+    confirm-label="Delete"
+    cancel-label="Cancel"
+    :on-confirm="() => { /* delete logic */ }"
+    @close="isOpen = false"
+  />
+</template>
+```
+
+### Imperative (useOverlay)
+
+**Step 1: Create the confirm dialog component**
+
+```vue
+<!-- ConfirmDeleteDialog.vue -->
+<script setup lang="ts">
+import { UIConfirmDialog } from '@wisemen/vue-core-design-system'
+import { Trash01Icon } from '@wisemen/vue-core-icons'
+
+const props = defineProps<{
+  itemName: string
+}>()
+
+const emit = defineEmits<{
+  close: [confirmed: boolean]
+}>()
+
+async function handleConfirm() {
+  // Perform the delete action
+  emit('close', true)
+}
+</script>
+
+<template>
+  <UIConfirmDialog
+    :is-destructive="true"
+    :icon="Trash01Icon"
+    title="Delete item"
+    :description="`Are you sure you want to delete '${itemName}'?`"
+    confirm-label="Delete"
+    cancel-label="Cancel"
+    :on-confirm="handleConfirm"
+    @close="emit('close', false)"
+  />
+</template>
+```
+
+**Step 2: Open imperatively**
+
+```vue
+<script setup lang="ts">
+import { useOverlay, UIButton } from '@wisemen/vue-core-design-system'
+import ConfirmDeleteDialog from './ConfirmDeleteDialog.vue'
+
+const overlay = useOverlay()
+const confirmDialog = overlay.create(ConfirmDeleteDialog)
+
+async function handleDelete(item: { id: string, name: string }) {
+  const confirmed = await confirmDialog.open({ itemName: item.name })
+
+  if (confirmed) {
+    await api.delete(item.id)
+  }
+}
+</script>
+
+<template>
+  <UIButton label="Delete" variant="destructive-primary" @click="handleDelete(item)" />
+</template>
+```
+
+### Async Confirm with Loading State
+
+```vue
+<UIConfirmDialog
+  title="Publish article"
+  description="This will make the article visible to all users."
+  confirm-label="Publish"
+  cancel-label="Cancel"
+  :on-confirm="async () => {
+    await publishArticle()  // Button shows spinner during this
+  }"
+  @close="emit('close')"
+/>
+```
+
+### Non-Destructive Confirmation
+
+```vue
+<UIConfirmDialog
+  :is-destructive="false"
+  title="Confirm changes"
+  description="Do you want to apply these changes?"
+  confirm-label="Apply"
+  cancel-label="Cancel"
+  :on-confirm="applyChanges"
+  @close="emit('close')"
+/>
+```
+
+## Anatomy
+
+```
+UIConfirmDialog
+└── UIDialog (size="xs", no close button)
+    ├── UIDialogHeader
+    │   ├── Icon circle (if icon prop, colored by isDestructive)
+    │   ├── Title (<h2>)
+    │   └── Description (<p>)
+    └── UIDialogFooter
+        └── #right
+            ├── UIDialogFooterCancel (emits close on click)
+            └── UIButton (primary or destructive-primary)
+```
+
+## Styling
+
+**Style file:** No separate style file. Uses UIDialog and sub-component styles.
+The dialog is fixed at `size="xs"` (max-width 400px on desktop). The close button is hidden.
+
+## Common Mistakes
+
+### HIGH: Forgetting to emit 'close' after onConfirm
+
+The `onConfirm` callback handles the action but does NOT close the dialog. You must emit `close` yourself after the action completes:
+
+```ts
+// Wrong: dialog stays open after confirm
+const onConfirm = async () => {
+  await deleteItem()
+  // Dialog is still open!
+}
+
+// Correct: emit close after action
+const onConfirm = async () => {
+  await deleteItem()
+  emit('close')
+}
+```
+
+Alternatively, handle closing in the `onConfirm` callback and emit `close` from there.
+
+### MEDIUM: Not providing confirmLabel/cancelLabel
+
+If you omit `confirmLabel` or `cancelLabel`, the dialog falls back to i18n keys `component.unsaved_changes_dialog.confirm` and `component.unsaved_changes_dialog.cancel`. Make sure these keys exist in your i18n config, or always provide explicit labels.
+
+### LOW: Using for complex forms
+
+UIConfirmDialog has no body slot. For anything beyond a title and description, use UIDialog with UIDialogBody.
+
+## Accessibility
+
+- Inherits all accessibility features from UIDialog (focus trap, Escape to close, ARIA roles).
+- The title is rendered as `<h2>` and description as `<p>` with proper ARIA associations.
+- The confirm button clearly communicates the action via its label.
+- When `isDestructive` is true, the visual styling communicates danger, but also consider using descriptive language in the title and description.
+
+## See Also
+
+- [dialog](../dialog/SKILL.md) -- Base dialog component with full customization
+- [form-dialog](../form-dialog/SKILL.md) -- Dialog with form integration
+- [overlay-system](../../foundations/overlay-system/SKILL.md) -- useOverlay API

--- a/packages/web/design-system/skills/components/confirm-dialog/SKILL.md
+++ b/packages/web/design-system/skills/components/confirm-dialog/SKILL.md
@@ -7,7 +7,6 @@ description: >
   or delete confirmation prompts.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: overlay
 requires:
   - overlay-system

--- a/packages/web/design-system/skills/components/dialog/SKILL.md
+++ b/packages/web/design-system/skills/components/dialog/SKILL.md
@@ -8,7 +8,6 @@ description: >
   helper. Load this skill for any modal dialog implementation.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: overlay
 requires:
   - overlay-system

--- a/packages/web/design-system/skills/components/dialog/SKILL.md
+++ b/packages/web/design-system/skills/components/dialog/SKILL.md
@@ -1,0 +1,638 @@
+---
+name: dialog
+description: >
+  Modal dialog system with header, body, footer, and close button sub-components.
+  Built on Reka UI DialogRoot with animated overlay, scroll-aware separators, and
+  a chin feature for contextual actions. Supports both template-driven (v-model) and
+  imperative (useOverlay) patterns. Also exports useOverlay composable and useDialogTriggerProps
+  helper. Load this skill for any modal dialog implementation.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: overlay
+requires:
+  - overlay-system
+exports:
+  - UIDialog
+  - UIDialogProps
+  - UIDialogBody
+  - UIDialogContainer
+  - UIDialogFooter
+  - UIDialogFooterCancel
+  - UIDialogFooterPrimary
+  - UIDialogFooterSecondary
+  - UIDialogFooterSubmit
+  - UIDialogHeader
+  - UIDialogHeaderProps
+  - UIDialogFooterButtonProps
+  - UIDialogTriggerProps
+  - useOverlay
+  - useDialogTriggerProps
+---
+
+# UIDialog
+
+A modal dialog with overlay backdrop, animated transitions, and a composable sub-component structure for header, scrollable body, and footer actions.
+
+## When to Use
+
+- Presenting forms, confirmations, or detailed content that requires user attention
+- Blocking interaction with the page behind until the user completes or dismisses an action
+- Building multi-step workflows in a focused overlay
+
+**Use instead:** `UIConfirmDialog` for simple yes/no confirmations, `UIFormDialog` for dialogs with integrated form handling, `UIPopover` for non-blocking floating content.
+
+## Import
+
+```ts
+import {
+  UIDialog,
+  UIDialogBody,
+  UIDialogContainer,
+  UIDialogFooter,
+  UIDialogFooterCancel,
+  UIDialogFooterPrimary,
+  UIDialogFooterSecondary,
+  UIDialogFooterSubmit,
+  UIDialogHeader,
+  useOverlay,
+  useDialogTriggerProps,
+} from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import {
+  UIDialog, UIDialogHeader, UIDialogBody, UIDialogFooter,
+  UIDialogFooterCancel, UIDialogFooterPrimary,
+} from '@wisemen/vue-core-design-system'
+
+const emit = defineEmits<{
+  close: []
+}>()
+</script>
+
+<template>
+  <UIDialog size="md" @close="emit('close')">
+    <UIDialogHeader title="Dialog Title" description="A brief description." />
+    <UIDialogBody>
+      <p class="text-sm text-secondary">Dialog content goes here.</p>
+    </UIDialogBody>
+    <UIDialogFooter>
+      <template #right>
+        <UIDialogFooterCancel label="Cancel" @click="emit('close')" />
+        <UIDialogFooterPrimary label="Confirm" @click="emit('close')" />
+      </template>
+    </UIDialogFooter>
+  </UIDialog>
+</template>
+```
+
+## API
+
+### Props (UIDialog)
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isOpen` | `boolean` | `false` | Controls the open state (v-model). |
+| `size` | `'xxs' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full-screen'` | `'md'` | The width of the dialog. |
+| `preventClickOutside` | `boolean` | `false` | Prevents closing the dialog by clicking the backdrop. |
+| `preventEsc` | `boolean` | `false` | Prevents closing the dialog by pressing Escape. |
+| `showCloseButton` | `boolean` | `true` | Whether to show the X close button in the top-right corner. |
+| `chin` | `ChinConfig \| null` | `null` | Configuration for the chin panel below the dialog (see Chin section). |
+
+### Slots (UIDialog)
+
+| Slot | Description |
+|------|-------------|
+| `default` | Dialog content. Compose with UIDialogHeader, UIDialogBody, and UIDialogFooter. |
+
+### Emits (UIDialog)
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `update:isOpen` | `boolean` | Fired when the open state changes. |
+| `close` | -- | Fired when the dialog is closed (backdrop click, Escape, or close button). |
+| `afterLeave` | -- | Fired after the close animation completes. |
+
+## Sub-Components
+
+### UIDialogContainer
+
+Renders all managed overlays created via `useOverlay`. **Must be placed once at the app root.**
+
+```vue
+<!-- App.vue -->
+<template>
+  <UIDialogContainer />
+  <RouterView />
+</template>
+```
+
+No props, no slots, no emits.
+
+---
+
+### UIDialogHeader
+
+Sticky header with title, optional description, optional icon, and a scroll-aware separator.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | -- (required) | The title text displayed in the header. |
+| `description` | `string \| null` | `null` | Optional description text below the title. |
+| `icon` | `Component \| null` | `null` | Optional icon component displayed in a colored circle. |
+| `iconVariant` | `'brand' \| 'error' \| 'success' \| 'warning'` | `'brand'` | Color variant for the icon container. |
+| `showSeparator` | `boolean` | `true` | Whether to show the bottom separator line. |
+
+The separator automatically fades out when the body is scrolled to the top, providing a clean visual when content is at rest.
+
+---
+
+### UIDialogBody
+
+Scrollable content area with `overflow-y-auto`. Provides scroll state to the header and footer separators.
+
+No props. Has a default slot for content.
+
+```vue
+<UIDialogBody>
+  <p>Scrollable content here</p>
+</UIDialogBody>
+```
+
+---
+
+### UIDialogFooter
+
+Sticky footer with left and right slot areas, separated by a scroll-aware divider.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `showSeparator` | `boolean` | `true` | Whether to show the top separator line. |
+
+#### Slots
+
+| Slot | Description |
+|------|-------------|
+| `left` | Content on the left side (e.g., a checkbox or secondary info). |
+| `right` | Content on the right side (e.g., cancel and confirm buttons). |
+
+The separator automatically fades out when the body is scrolled to the bottom.
+
+---
+
+### UIDialogFooterCancel
+
+A cancel button that **automatically closes the dialog** (wraps Reka UI `DialogClose`). Uses `variant="secondary"`.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | -- (required) | Button label text. |
+| `isDisabled` | `boolean` | `false` | Disables the button. |
+| `isLoading` | `boolean` | `false` | Shows loading state. |
+| `disabledReason` | `string \| null` | `null` | Tooltip text explaining why the button is disabled. |
+| `iconLeft` | `Component \| null` | `null` | Icon before the label. |
+| `iconRight` | `Component \| null` | `null` | Icon after the label. |
+| `form` | `string \| null` | `null` | Associates the button with a form by ID. |
+| `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | The button type attribute. |
+
+#### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `click` | -- | Fired when the button is clicked. The dialog closes automatically. |
+
+---
+
+### UIDialogFooterPrimary
+
+A primary action button (does **not** auto-close the dialog). Uses `variant="primary"`.
+
+#### Props
+
+Same as UIDialogFooterCancel (extends `DialogFooterButtonProps`).
+
+#### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `click` | -- | Fired when the button is clicked. |
+
+**Note:** This button does NOT auto-close the dialog. You must explicitly emit `close` or call `overlay.close()` in the click handler.
+
+---
+
+### UIDialogFooterSecondary
+
+A secondary action button (does **not** auto-close the dialog). Uses `variant="secondary"`.
+
+#### Props
+
+Same as UIDialogFooterCancel (extends `DialogFooterButtonProps`).
+
+#### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `click` | -- | Fired when the button is clicked. |
+
+---
+
+### UIDialogFooterSubmit
+
+A submit button for form dialogs. Uses `variant="primary"` and defaults to `type="submit"`.
+
+#### Props
+
+Same as UIDialogFooterCancel (extends `DialogFooterButtonProps`), except `type` defaults to `'submit'`.
+
+#### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `click` | -- | Fired when the button is clicked. |
+
+**Note:** This button does NOT auto-close the dialog. Typically used inside UIFormDialog where form submission handles the close logic.
+
+## useOverlay
+
+Imperative overlay management composable. See [overlay-system](../../foundations/overlay-system/SKILL.md) for full documentation.
+
+```ts
+const overlay = useOverlay()
+const dialog = overlay.create(MyDialogComponent)
+
+// Open and await result
+const result = await dialog.open({ title: 'Edit' })
+
+// Close programmatically
+dialog.close(result)
+
+// Update props without reopening
+dialog.patch({ title: 'Updated' })
+
+// Close all overlays
+overlay.closeAll()
+```
+
+## useDialogTriggerProps
+
+Helper that provides ARIA-compliant trigger props for a specific overlay instance.
+
+```ts
+import { useDialogTriggerProps } from '@wisemen/vue-core-design-system'
+
+const overlay = useOverlay()
+const dialog = overlay.create(MyDialog)
+const { triggerProps } = useDialogTriggerProps(dialog.id)
+```
+
+Returns a computed object with:
+- `aria-expanded`: `boolean` -- whether the dialog is open
+- `aria-haspopup`: `'dialog'`
+- `data-state`: `'open' | 'closed'`
+
+Bind these to your trigger element:
+
+```vue
+<UIButton v-bind="triggerProps" label="Open" @click="dialog.open()" />
+```
+
+## Variants
+
+### Size
+
+| Size | Max Width |
+|------|-----------|
+| `xxs` | `sm:max-w-90` (360px) |
+| `xs` | `sm:max-w-100` (400px) |
+| `sm` | `sm:max-w-120` (480px) |
+| `md` | `sm:max-w-140` (560px) |
+| `lg` | `sm:max-w-160` (640px) |
+| `xl` | `sm:max-w-180` (720px) |
+| `full-screen` | `sm:max-w-[90vw]` with `h-[90vh]` |
+
+On mobile (below `sm` breakpoint), the dialog renders as a bottom sheet with `rounded-t` corners.
+
+## Examples
+
+### Template-Driven
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  UIDialog, UIDialogHeader, UIDialogBody, UIDialogFooter,
+  UIDialogFooterCancel, UIDialogFooterPrimary, UIButton,
+} from '@wisemen/vue-core-design-system'
+
+const isOpen = ref(false)
+</script>
+
+<template>
+  <UIButton label="Open" @click="isOpen = true" />
+
+  <UIDialog v-model:is-open="isOpen" size="md">
+    <UIDialogHeader title="Template Dialog" description="Using v-model." />
+    <UIDialogBody>
+      <p class="text-sm text-secondary">Content here</p>
+    </UIDialogBody>
+    <UIDialogFooter>
+      <template #right>
+        <UIDialogFooterCancel label="Cancel" />
+        <UIDialogFooterPrimary label="Save" @click="isOpen = false" />
+      </template>
+    </UIDialogFooter>
+  </UIDialog>
+</template>
+```
+
+### Imperative (useOverlay)
+
+**Step 1: Create the dialog component**
+
+```vue
+<!-- EditUserDialog.vue -->
+<script setup lang="ts">
+import {
+  UIDialog, UIDialogHeader, UIDialogBody, UIDialogFooter,
+  UIDialogFooterCancel, UIDialogFooterPrimary,
+} from '@wisemen/vue-core-design-system'
+
+const props = defineProps<{
+  userId: string
+  userName: string
+}>()
+
+const emit = defineEmits<{
+  close: [saved: boolean]
+}>()
+</script>
+
+<template>
+  <UIDialog size="md" @close="emit('close', false)">
+    <UIDialogHeader :title="`Edit ${userName}`" />
+    <UIDialogBody>
+      <p class="text-sm text-secondary">Edit form for user {{ userId }}</p>
+    </UIDialogBody>
+    <UIDialogFooter>
+      <template #right>
+        <UIDialogFooterCancel label="Cancel" @click="emit('close', false)" />
+        <UIDialogFooterPrimary label="Save" @click="emit('close', true)" />
+      </template>
+    </UIDialogFooter>
+  </UIDialog>
+</template>
+```
+
+**Step 2: Open imperatively**
+
+```vue
+<script setup lang="ts">
+import { useOverlay, UIButton } from '@wisemen/vue-core-design-system'
+import EditUserDialog from './EditUserDialog.vue'
+
+const overlay = useOverlay()
+const editDialog = overlay.create(EditUserDialog)
+
+async function handleEdit(user: { id: string, name: string }) {
+  const saved = await editDialog.open({
+    userId: user.id,
+    userName: user.name,
+  })
+
+  if (saved) {
+    // Refresh data
+  }
+}
+</script>
+
+<template>
+  <UIButton label="Edit User" @click="handleEdit({ id: '1', name: 'John' })" />
+</template>
+```
+
+### With Header Icon
+
+```vue
+<UIDialogHeader
+  :icon="CheckCircleIcon"
+  icon-variant="success"
+  title="Success"
+  description="Your changes have been saved."
+/>
+```
+
+### With Footer Left Content
+
+```vue
+<UIDialogFooter>
+  <template #left>
+    <UICheckbox :model-value="false" label="Remember my choice" />
+  </template>
+  <template #right>
+    <UIDialogFooterCancel label="Cancel" />
+    <UIDialogFooterPrimary label="Confirm" />
+  </template>
+</UIDialogFooter>
+```
+
+### Scrollable Dialog with Separator Behavior
+
+```vue
+<UIDialog size="md">
+  <UIDialogHeader
+    title="Scrollable dialog"
+    description="Separators appear when content overflows."
+  />
+  <UIDialogBody>
+    <div class="flex flex-col gap-xl">
+      <p v-for="i in 20" :key="i" class="text-sm text-secondary">
+        Paragraph {{ i }}
+      </p>
+    </div>
+  </UIDialogBody>
+  <UIDialogFooter>
+    <template #right>
+      <UIDialogFooterCancel label="Cancel" />
+      <UIDialogFooterPrimary label="Confirm" />
+    </template>
+  </UIDialogFooter>
+</UIDialog>
+```
+
+The header separator fades in when the body is scrolled away from the top. The footer separator fades in when the body is scrolled away from the bottom.
+
+### With Chin
+
+The chin is a contextual action bar that slides out below the dialog (above on mobile). Use `useDialogChin()` to control it.
+
+```vue
+<script setup lang="ts">
+import { AlertSquareIcon } from '@wisemen/vue-core-icons'
+import { UIDialog, UIDialogHeader, UIDialogBody, UIDialogFooter,
+         UIDialogFooterCancel, UIDialogFooterPrimary } from '@wisemen/vue-core-design-system'
+import { useDialogChin } from '@wisemen/vue-core-design-system'
+
+const emit = defineEmits<{ close: [] }>()
+const dialogChin = useDialogChin()
+</script>
+
+<template>
+  <UIDialog :chin="dialogChin.chin.value" size="md" @close="emit('close')">
+    <UIDialogHeader title="With Chin" />
+    <UIDialogBody>
+      <p class="text-sm text-secondary">Content</p>
+    </UIDialogBody>
+    <UIDialogFooter>
+      <template #right>
+        <UIDialogFooterCancel label="Cancel" />
+        <UIDialogFooterPrimary
+          label="Show Chin"
+          @click="dialogChin.open({
+            icon: AlertSquareIcon,
+            text: 'You have unsaved changes',
+            variant: 'error',
+            primaryAction: {
+              type: 'button',
+              action: () => dialogChin.close(),
+              label: 'Save',
+              variant: 'default',
+            },
+            secondaryAction: {
+              type: 'button',
+              action: () => dialogChin.close(),
+              label: 'Discard',
+              variant: 'destructive',
+            },
+          })"
+        />
+      </template>
+    </UIDialogFooter>
+  </UIDialog>
+</template>
+```
+
+## Anatomy
+
+```
+UIDialog
+├── RekaDialogRoot (v-model:open, modal=true)
+���   ├── RekaDialogOverlay (animated backdrop)
+│   └── RekaDialogContent (positioned, animated)
+│       ├── <div> (content container with border, bg, clip)
+│       │   ├── <slot />
+│       │   │   ├── UIDialogHeader (sticky top)
+│       │   │   │   ├── RowLayout
+│       │   │   │   │   ├── Icon circle (if icon prop)
+│       │   │   │   │   └── ColumnLayout (title + description)
+│       │   │   │   └── UISeparator (scroll-aware opacity)
+│       │   │   ├── UIDialogBody (overflow-y-auto)
+│       │   │   │   └��─ <slot />
+│       │   │   └── UIDialogFooter (sticky bottom)
+│       │   │       ├── UISeparator (scroll-aware opacity)
+│       │   │       └── RowLayout
+│       │   ���           ├── <slot name="left" />
+│       │   │           └── RowLayout
+│       │   │               └─�� <slot name="right" />
+│       │   └── DialogCloseButton (if showCloseButton)
+│       └── DialogChin (if chin config provided)
+```
+
+## Styling
+
+**Style file:** `src/ui/dialog/dialog.style.ts`
+**tv() slots:**
+- `body` -- `flex-1 overflow-y-auto px-xl py-xs`
+- `chin` -- Absolutely positioned below the dialog with spring animation
+- `content` -- Rounded container with border and background
+- `contentWrapper` -- Fixed positioning, centered on desktop, bottom-sheet on mobile
+- `footer` -- Sticky bottom with background
+- `header` -- Sticky top with z-10
+- `overlay` -- Fixed inset backdrop with gradient
+
+**Animations:**
+- Overlay: 400ms fade-in, 120ms fade-out
+- Content: 400ms slide-up + fade-in, 120ms slide-down + fade-out
+- Respects `prefers-reduced-motion: reduce`
+
+## Common Mistakes
+
+### CRITICAL: Missing UIDialogContainer in app root
+
+```vue
+<!-- Wrong: Imperative overlays will not render -->
+<template>
+  <RouterView />
+</template>
+
+<!-- Correct -->
+<template>
+  <UIDialogContainer />
+  <RouterView />
+</template>
+```
+
+### HIGH: Creating overlay instances inside event handlers
+
+```ts
+// Wrong: Creates a new instance on every click
+function openDialog() {
+  const overlay = useOverlay()
+  const dialog = overlay.create(MyDialog) // Leaks!
+  dialog.open()
+}
+
+// Correct: Create once in setup
+const overlay = useOverlay()
+const dialog = overlay.create(MyDialog)
+
+function openDialog() {
+  dialog.open()
+}
+```
+
+### HIGH: Forgetting to emit 'close' from dialog component
+
+```vue
+<!-- Wrong: The overlay open() promise never resolves -->
+<UIDialogFooterPrimary label="Save" @click="save()" />
+
+<!-- Correct -->
+<UIDialogFooterPrimary label="Save" @click="save(); emit('close', result)" />
+```
+
+### MEDIUM: Confusing FooterCancel with FooterPrimary close behavior
+
+`UIDialogFooterCancel` auto-closes the dialog (wraps Reka UI `DialogClose`). `UIDialogFooterPrimary` does NOT auto-close -- you must handle closing explicitly. This is by design: primary actions often need to validate or save before closing.
+
+### MEDIUM: Using UIDialogFooterSubmit outside a form context
+
+`UIDialogFooterSubmit` defaults to `type="submit"`. It only works when inside a `<form>` element or when the `form` prop is set to a form ID. Outside of that context, the submit has no effect.
+
+## Accessibility
+
+- Built on Reka UI Dialog primitives with full ARIA compliance.
+- Focus is trapped within the dialog while open.
+- Escape key closes the dialog (unless `preventEsc` is true).
+- Clicking the backdrop closes the dialog (unless `preventClickOutside` is true).
+- `DialogTitle` uses `<h2>` semantics via `RekaDialogTitle`.
+- `DialogDescription` uses `<p>` via `RekaDialogDescription`.
+- The close button has an accessible label from i18n (`component.dialog.close`).
+- Focus returns to the trigger element when the dialog closes.
+- Animations respect `prefers-reduced-motion: reduce`.
+
+## See Also
+
+- [overlay-system](../../foundations/overlay-system/SKILL.md) -- useOverlay API, DialogContainer, promise-based results
+- [confirm-dialog](../confirm-dialog/SKILL.md) -- Pre-built confirmation dialog
+- [form-dialog](../form-dialog/SKILL.md) -- Dialog with form integration

--- a/packages/web/design-system/skills/components/dot/SKILL.md
+++ b/packages/web/design-system/skills/components/dot/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: dot
+description: >
+  Small colored circle used as a status indicator. Supports 8 color variants
+  and 3 sizes. Load this skill when you need a visual status dot, online/offline
+  indicator, or colored bullet point.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UIDot
+  - UIDotProps
+  - UIDotColor
+  - UIDotSize
+---
+
+# UIDot
+
+A small colored circle that visually communicates status or category.
+
+## When to Use
+
+- Indicating online/offline or active/inactive status next to a label
+- Color-coding items in a list (e.g., priority, category)
+- Showing a simple presence or availability indicator
+
+**Use instead:** `UIBadge` for labeled status tags, `UINumberBadge` for numeric counts.
+
+## Import
+
+```ts
+import { UIDot } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIDot } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIDot color="success" size="md" />
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `color` | `'blue' \| 'brand' \| 'error' \| 'gray' \| 'pink' \| 'purple' \| 'success' \| 'warning'` | `'gray'` | The color of the dot. |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | The size of the dot. |
+
+### Slots
+
+This component has no slots.
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+### Size
+
+| Size | CSS Class | Approximate Pixels |
+|------|-----------|-------------------|
+| `sm` | `size-1` | 4px |
+| `md` | `size-1.5` | 6px |
+| `lg` | `size-2` | 8px |
+
+### Color
+
+| Color | CSS Class |
+|-------|-----------|
+| `blue` | `bg-blue-500` |
+| `brand` | `bg-brand-500` |
+| `error` | `bg-error-500` |
+| `gray` | `bg-gray-400` |
+| `pink` | `bg-pink-500` |
+| `purple` | `bg-purple-500` |
+| `success` | `bg-success-500` |
+| `warning` | `bg-warning-500` |
+
+## Examples
+
+### Status Indicator Next to a Label
+
+```vue
+<script setup lang="ts">
+import { UIDot } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex items-center gap-xs">
+    <UIDot color="success" size="md" />
+    <span class="text-sm text-primary">Online</span>
+  </div>
+</template>
+```
+
+### Multiple Status Dots
+
+```vue
+<script setup lang="ts">
+import { UIDot } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex flex-col gap-sm">
+    <div class="flex items-center gap-xs">
+      <UIDot color="success" />
+      <span class="text-sm text-primary">Active</span>
+    </div>
+    <div class="flex items-center gap-xs">
+      <UIDot color="warning" />
+      <span class="text-sm text-primary">Pending</span>
+    </div>
+    <div class="flex items-center gap-xs">
+      <UIDot color="error" />
+      <span class="text-sm text-primary">Failed</span>
+    </div>
+  </div>
+</template>
+```
+
+## Anatomy
+
+```
+UIDot
+└── <div>  (rounded-full colored circle)
+```
+
+## Styling
+
+**Style file:** `src/ui/dot/dot.style.ts`
+**tv() slots:** None (single-element, uses `tv()` with `base` only)
+**Customization:** Pass a `class` attribute to override or extend the default styles. The dot uses `shrink-0 rounded-full` as its base classes, with color and size applied via variants.
+
+## Common Mistakes
+
+### LOW: Forgetting the dot is purely decorative
+
+Wrong:
+```vue
+<UIDot color="error" />
+<!-- Screen reader gets no context -->
+```
+
+Correct:
+```vue
+<div class="flex items-center gap-xs">
+  <UIDot color="error" />
+  <span class="text-sm text-primary">Error</span>
+</div>
+```
+
+The dot is a visual-only element with no semantic meaning. Always pair it with a text label so the status is communicated to screen readers.
+
+## Accessibility
+
+UIDot renders a plain `<div>` with no ARIA attributes. It is purely decorative and should always be accompanied by visible text or an `aria-label` on a parent element that conveys the status meaning. The dot itself has no keyboard interaction.
+
+## See Also
+
+- [UIBadge](../badge/SKILL.md) -- For labeled status tags with text
+- [UINumberBadge](../number-badge/SKILL.md) -- For numeric count indicators

--- a/packages/web/design-system/skills/components/dot/SKILL.md
+++ b/packages/web/design-system/skills/components/dot/SKILL.md
@@ -6,7 +6,6 @@ description: >
   indicator, or colored bullet point.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/dropdown-menu/SKILL.md
+++ b/packages/web/design-system/skills/components/dropdown-menu/SKILL.md
@@ -7,7 +7,6 @@ description: >
   options. Content is portalled to the body with configurable positioning.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: navigation
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/dropdown-menu/SKILL.md
+++ b/packages/web/design-system/skills/components/dropdown-menu/SKILL.md
@@ -1,0 +1,387 @@
+---
+name: dropdown-menu
+description: >
+  UIDropdownMenu is a popover-based menu triggered by a button or custom element.
+  Built on Reka UI's DropdownMenu primitives, it supports items with icons and
+  keyboard shortcuts, groups, headers, separators, and radio groups for single-select
+  options. Content is portalled to the body with configurable positioning.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: navigation
+requires: []
+exports:
+  - UIDropdownMenu
+  - UIDropdownMenuProps
+  - UIDropdownMenuItem
+  - UIDropdownMenuGroup
+  - UIDropdownMenuHeader
+  - UIDropdownMenuSeparator
+  - UIDropdownMenuRadioGroup
+  - UIDropdownMenuRadioItem
+  - DropdownMenuItem
+---
+
+# UIDropdownMenu
+
+A popover menu triggered by a button or custom element, with items, groups, radio selection, and keyboard navigation.
+
+## When to Use
+
+- Action menus triggered by a button (e.g. "More actions" dropdown).
+- Context menus with grouped actions, keyboard shortcuts, and separators.
+- Single-select radio groups inside a menu (e.g. sort order, view mode).
+
+**Use instead:** For form-level selection with search, use `UISelect` or `UIAutocomplete`. For simple tooltips, use `UIActionTooltip`.
+
+## Import
+
+```ts
+import {
+  UIDropdownMenu,
+  UIDropdownMenuItem,
+  UIDropdownMenuGroup,
+  UIDropdownMenuHeader,
+  UIDropdownMenuSeparator,
+  UIDropdownMenuRadioGroup,
+  UIDropdownMenuRadioItem,
+} from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import {
+  UIDropdownMenu,
+  UIDropdownMenuItem,
+  UIDropdownMenuGroup,
+} from '@wisemen/vue-core-design-system'
+import { UIIconButton } from '@wisemen/vue-core-design-system'
+import { DotsVerticalIcon, Edit02Icon, Trash01Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIDropdownMenu>
+    <template #trigger>
+      <UIIconButton :icon="DotsVerticalIcon" label="Actions" variant="tertiary" />
+    </template>
+    <template #content>
+      <UIDropdownMenuGroup>
+        <UIDropdownMenuItem :icon="Edit02Icon" label="Edit" @select="onEdit" />
+        <UIDropdownMenuItem :icon="Trash01Icon" label="Delete" @select="onDelete" />
+      </UIDropdownMenuGroup>
+    </template>
+  </UIDropdownMenu>
+</template>
+```
+
+## API
+
+### UIDropdownMenu Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `popoverSide` | `'top' \| 'right' \| 'bottom' \| 'left'` | `'top'` | Which side the dropdown opens on. |
+| `popoverSideOffset` | `number` | `4` | Distance in px between trigger and dropdown. |
+| `popoverAlign` | `'center' \| 'start' \| 'end'` | `'center'` | Alignment relative to the trigger. |
+| `popoverAlignOffset` | `number` | `0` | Offset in px from the alignment edge. |
+| `popoverWidth` | `'anchor-width' \| 'available-width' \| null` | `null` | Width strategy. `null` = natural content width. |
+| `popoverCollisionPadding` | `number` | `0` | Padding in px for collision detection with viewport edges. |
+| `popoverContainerElement` | `HTMLElement \| null` | `null` | Collision boundary element. |
+| `popoverAnimationName` | `string \| null` | `null` | Custom animation name. Defaults to `'dropdown-default'`. |
+| `isPopoverArrowVisible` | `boolean` | `false` | Whether to show an arrow pointing at the trigger. |
+| `popoverAnchorReferenceElement` | `ReferenceElement \| null` | `null` | Custom anchor element for positioning. |
+| `disableUpdateOnLayoutShift` | `boolean` | `false` | Disables repositioning on layout shifts. |
+| `prioritizePosition` | `boolean` | `false` | Constrain content to viewport even if it overlaps the trigger. |
+
+### UIDropdownMenu Slots
+
+| Slot | Description |
+|------|-------------|
+| `trigger` | The element that opens the menu. Rendered as child of Reka's DropdownMenuTrigger (`as-child`). |
+| `content` | Menu content: groups, items, headers, separators, radio groups. |
+
+### UIDropdownMenuItem Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | **(required)** | The item text. |
+| `icon` | `Component` | `undefined` | Optional leading icon. |
+| `keyboardShortcut` | `string \| null` | `null` | Visual keyboard shortcut badge (e.g. `'meta_k'`). |
+| `disabledReason` | `string \| null` | `null` | When set, disables the item and shows a tooltip with the reason. |
+
+### UIDropdownMenuItem Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `select` | (none) | Fired when the item is selected (click or keyboard). |
+
+### UIDropdownMenuHeader Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | **(required)** | Header text displayed above a group. |
+
+### UIDropdownMenuGroup
+
+No props. Wraps items in a Reka `DropdownMenuGroup` with `p-xs` padding.
+
+### UIDropdownMenuSeparator
+
+No props. Renders a horizontal separator line between groups.
+
+### UIDropdownMenuRadioGroup Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `modelValue` | `string` | **(required, v-model)** | The currently selected radio value. |
+
+### UIDropdownMenuRadioGroup Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | `UIDropdownMenuRadioItem` children. |
+
+### UIDropdownMenuRadioItem Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `string` | **(required)** | The value this item represents. |
+| `label` | `string` | **(required)** | Display text for the radio option. |
+| `hint` | `string \| null` | `null` | Secondary hint text shown after the label. |
+
+### UIDropdownMenuRadioItem Slots
+
+| Slot | Description |
+|------|-------------|
+| `left` | Content rendered before the label text. |
+
+### DropdownMenuItem Type (utility interface)
+
+```ts
+interface DropdownMenuItem {
+  icon: Component
+  label: string
+  keyboardShortcut?: string
+  onSelect: () => void
+}
+```
+
+A convenience type for building arrays of menu items programmatically.
+
+## Variants
+
+No visual variant props on UIDropdownMenu. The dropdown content always renders with:
+- `min-w-48` minimum width
+- `rounded-md border border-secondary bg-primary shadow-lg`
+- Animated entrance/exit per side (`dropdown-default` keyframes)
+
+### Items
+
+- Default: `rounded-sm px-md py-sm`, highlight on `data-highlighted` with `bg-secondary-hover`
+- Disabled: `cursor-not-allowed`, no highlight
+- Radio items: Show a `CheckIcon` indicator when selected, highlight with `bg-tertiary`
+
+## Examples
+
+### Grouped menu with header and separator
+
+```vue
+<script setup lang="ts">
+import {
+  UIDropdownMenu,
+  UIDropdownMenuItem,
+  UIDropdownMenuGroup,
+  UIDropdownMenuHeader,
+  UIDropdownMenuSeparator,
+} from '@wisemen/vue-core-design-system'
+import { UIIconButton } from '@wisemen/vue-core-design-system'
+import { DotsVerticalIcon, Edit02Icon, CopyIcon, Trash01Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIDropdownMenu popover-side="bottom" popover-align="end">
+    <template #trigger>
+      <UIIconButton :icon="DotsVerticalIcon" label="Actions" variant="tertiary" />
+    </template>
+    <template #content>
+      <UIDropdownMenuGroup>
+        <UIDropdownMenuHeader title="Actions" />
+        <UIDropdownMenuItem :icon="Edit02Icon" label="Edit" keyboard-shortcut="meta_e" @select="onEdit" />
+        <UIDropdownMenuItem :icon="CopyIcon" label="Duplicate" @select="onDuplicate" />
+      </UIDropdownMenuGroup>
+      <UIDropdownMenuSeparator />
+      <UIDropdownMenuGroup>
+        <UIDropdownMenuItem
+          :icon="Trash01Icon"
+          label="Delete"
+          keyboard-shortcut="meta_backspace"
+          @select="onDelete"
+        />
+      </UIDropdownMenuGroup>
+    </template>
+  </UIDropdownMenu>
+</template>
+```
+
+### Radio group for single-select
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  UIDropdownMenu,
+  UIDropdownMenuGroup,
+  UIDropdownMenuRadioGroup,
+  UIDropdownMenuRadioItem,
+} from '@wisemen/vue-core-design-system'
+import { UIButton } from '@wisemen/vue-core-design-system'
+
+const sortOrder = ref<string>('newest')
+</script>
+
+<template>
+  <UIDropdownMenu popover-side="bottom">
+    <template #trigger>
+      <UIButton label="Sort" variant="secondary" />
+    </template>
+    <template #content>
+      <UIDropdownMenuGroup>
+        <UIDropdownMenuRadioGroup v-model="sortOrder">
+          <UIDropdownMenuRadioItem value="newest" label="Newest first" />
+          <UIDropdownMenuRadioItem value="oldest" label="Oldest first" />
+          <UIDropdownMenuRadioItem value="name" label="Alphabetical" />
+        </UIDropdownMenuRadioGroup>
+      </UIDropdownMenuGroup>
+    </template>
+  </UIDropdownMenu>
+</template>
+```
+
+### Disabled item with reason
+
+```vue
+<template>
+  <UIDropdownMenuItem
+    :icon="Trash01Icon"
+    label="Delete"
+    disabled-reason="You do not have permission to delete this item."
+    @select="onDelete"
+  />
+</template>
+```
+
+The item is visually disabled and shows a tooltip on hover with the disabled reason.
+
+## Anatomy
+
+```
+UIDropdownMenu
+  RekaDropdownMenuRoot
+    RekaDropdownMenuTrigger (as-child)
+      slot[trigger]
+    RekaDropdownMenuPortal (to="body")
+      ThemeProvider (as-child)
+        RekaDropdownMenuContent (positioned, animated)
+          <div> (rounded, bordered, shadowed container)
+            slot[content]
+              UIDropdownMenuGroup (RekaDropdownMenuGroup, p-xs)
+                UIDropdownMenuHeader (<span> title)
+                UIDropdownMenuItem (RekaDropdownMenuItem)
+                  UIActionTooltip (for disabled reason)
+                    UIRowLayout
+                      Icon + UIText (label)
+                      KeyboardShortcut (optional)
+              UIDropdownMenuSeparator (Separator)
+              UIDropdownMenuRadioGroup (DropdownMenuRadioGroup, v-model)
+                UIDropdownMenuRadioItem (DropdownMenuRadioItem)
+                  RowLayout
+                    slot[left] + UIText (label) + UIText (hint)
+                    DropdownMenuItemIndicator (CheckIcon)
+          DropdownMenuArrow (optional, when isPopoverArrowVisible)
+```
+
+## Styling
+
+**Style file:** No dedicated `.style.ts`. Styles are inline Tailwind classes.
+
+**Content container:** `min-w-48 rounded-md border border-secondary bg-primary shadow-lg`
+
+**Item classes:** `rounded-sm px-md py-sm` with `data-highlighted:bg-secondary-hover`
+
+**Animation:** Built-in `dropdown-default` keyframes with side-aware slide + fade (100ms ease-in-out). Custom animations can be provided via `popoverAnimationName`.
+
+**Arrow:** Rotated square element with matching border/background.
+
+## Common Mistakes
+
+### ERROR: Missing trigger slot
+
+```vue
+<!-- WRONG: no trigger, menu cannot open -->
+<UIDropdownMenu>
+  <template #content>
+    <UIDropdownMenuItem label="Edit" />
+  </template>
+</UIDropdownMenu>
+
+<!-- CORRECT -->
+<UIDropdownMenu>
+  <template #trigger>
+    <UIIconButton :icon="DotsVerticalIcon" label="Menu" variant="tertiary" />
+  </template>
+  <template #content>
+    <UIDropdownMenuGroup>
+      <UIDropdownMenuItem label="Edit" @select="onEdit" />
+    </UIDropdownMenuGroup>
+  </template>
+</UIDropdownMenu>
+```
+
+### WARNING: Items without a group wrapper
+
+```vue
+<!-- WRONG: items directly in content slot without group -->
+<template #content>
+  <UIDropdownMenuItem label="Edit" />
+  <UIDropdownMenuItem label="Delete" />
+</template>
+
+<!-- CORRECT: wrap in a group for proper padding -->
+<template #content>
+  <UIDropdownMenuGroup>
+    <UIDropdownMenuItem label="Edit" @select="onEdit" />
+    <UIDropdownMenuItem label="Delete" @select="onDelete" />
+  </UIDropdownMenuGroup>
+</template>
+```
+
+`UIDropdownMenuGroup` provides the `p-xs` padding. Without it, items sit flush against the container edge.
+
+### WARNING: Using @click instead of @select
+
+```vue
+<!-- WRONG: @click does not close the menu properly -->
+<UIDropdownMenuItem label="Edit" @click="onEdit" />
+
+<!-- CORRECT: @select integrates with Reka's menu lifecycle -->
+<UIDropdownMenuItem label="Edit" @select="onEdit" />
+```
+
+Use the `@select` event which is emitted by the Reka DropdownMenuItem and properly handles menu closing.
+
+## Accessibility
+
+- Built on Reka UI's DropdownMenu primitives which implement the WAI-ARIA Menu pattern.
+- **Keyboard:** Arrow keys navigate items, Enter/Space selects, Escape closes.
+- **Focus management:** Focus is trapped within the open menu and returns to the trigger on close.
+- **Disabled items:** Set via `disabledReason` which adds `data-disabled` and shows a tooltip.
+- **Radio items:** Use `DropdownMenuRadioGroup` / `DropdownMenuRadioItem` for ARIA radio group semantics with `DropdownMenuItemIndicator` showing a check for the selected value.
+- Content is portalled to `<body>` to avoid z-index and overflow clipping issues.
+
+## See Also
+
+- [button](../button/SKILL.md) -- Common trigger elements for dropdown menus
+- [menu-item](../menu-item/SKILL.md) -- Rich content layout for menu items (used in select/autocomplete, not directly in dropdown-menu)
+- [tabs](../tabs/SKILL.md) -- Adaptive tabs use a dropdown for overflow items

--- a/packages/web/design-system/skills/components/form-dialog/SKILL.md
+++ b/packages/web/design-system/skills/components/form-dialog/SKILL.md
@@ -7,7 +7,6 @@ description: >
   that contain validated forms.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: overlay
 requires:
   - overlay-system

--- a/packages/web/design-system/skills/components/form-dialog/SKILL.md
+++ b/packages/web/design-system/skills/components/form-dialog/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: form-dialog
+description: >
+  A dialog with integrated formango form handling. Wraps UIDialog with form context,
+  automatic form ID generation, and optional unsaved-changes prompt. Uses FormDialogForm
+  internally to connect to formango's Form type. Load this skill when building dialogs
+  that contain validated forms.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: overlay
+requires:
+  - overlay-system
+exports: []
+# Note: UIFormDialog and FormDialogProps are internal components not exported from the dialog index.ts.
+# They must be imported directly from source paths (see Import section).
+---
+
+# UIFormDialog
+
+A dialog that integrates with formango for form state management, validation, and optional unsaved-changes prompting. It wraps UIDialog and provides a form context to all child components.
+
+## When to Use
+
+- Building a dialog that contains a validated form (create, edit, settings)
+- When you need automatic form ID association between the dialog and a submit button
+- When you want to prompt users about unsaved changes when they try to close the dialog
+
+**Use instead:** `UIDialog` when you do not need form integration, `UIConfirmDialog` for simple yes/no confirmations.
+
+## Import
+
+> **Note:** UIFormDialog and FormDialogForm are currently internal components not exported from the dialog index. They are used by importing directly from the source:
+
+```ts
+// Internal import (not yet in public API)
+import FormDialog from '@/ui/dialog/FormDialog.vue'
+import FormDialogForm from '@/ui/dialog/FormDialogForm.vue'
+```
+
+When using the design system externally, check if these have been added to the public exports.
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useForm } from 'formango'
+import { z } from 'zod'
+import FormDialog from '@/ui/dialog/FormDialog.vue'
+import FormDialogForm from '@/ui/dialog/FormDialogForm.vue'
+import {
+  UIDialogHeader, UIDialogBody, UIDialogFooter,
+  UIDialogFooterCancel, UIDialogFooterSubmit,
+} from '@wisemen/vue-core-design-system'
+
+const emit = defineEmits<{ close: [] }>()
+
+const { form } = useForm({
+  schema: z.object({
+    name: z.string().min(1),
+  }),
+  initialState: {
+    name: '',
+  },
+  onSubmit: async (values) => {
+    await saveItem(values)
+    emit('close')
+  },
+})
+</script>
+
+<template>
+  <FormDialog :form="form" size="md" @close="emit('close')">
+    <template #default="{ formId }">
+      <UIDialogHeader title="Create Item" />
+      <UIDialogBody>
+        <FormDialogForm>
+          <template #default="{ formId: innerFormId }">
+            <!-- Form fields here -->
+          </template>
+        </FormDialogForm>
+      </UIDialogBody>
+      <UIDialogFooter>
+        <template #right>
+          <UIDialogFooterCancel label="Cancel" />
+          <UIDialogFooterSubmit label="Save" :form="formId" />
+        </template>
+      </UIDialogFooter>
+    </template>
+  </FormDialog>
+</template>
+```
+
+## API
+
+### Props (FormDialog)
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `form` | `Form<any>` | -- (required) | The formango form instance. |
+| `size` | `'xxs' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full-screen'` | `'md'` | The width of the dialog. |
+| `preventClickOutside` | `boolean` | `false` | Prevents closing by clicking the backdrop. |
+| `preventEsc` | `boolean` | `false` | Prevents closing by pressing Escape. |
+| `showCloseButton` | `boolean` | `true` | Whether to show the X close button. |
+| `promptOnUnsavedChanges` | `boolean` | `false` | When true, shows a prompt if the user tries to close with unsaved changes. |
+| `renderOwnFormComponent` | `boolean` | `false` | When true, the dialog does not render a FormDialogForm internally; the consumer must render their own `<form>` element. |
+| `chin` | `ChinConfig \| null` | `null` | Chin configuration (inherited from DialogProps). |
+
+### Slots (FormDialog)
+
+| Slot | Slot Props | Description |
+|------|------------|-------------|
+| `default` | `{ formId: string }` | Dialog content. The `formId` can be passed to UIDialogFooterSubmit's `form` prop to associate the submit button with the form. |
+
+### Emits (FormDialog)
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `close` | -- | Fired when the dialog should close. |
+
+### FormDialogForm
+
+An internal form wrapper that connects to the FormDialog context. It renders a `UIForm` with the form instance and ID from the parent FormDialog.
+
+| Slot | Slot Props | Description |
+|------|------------|-------------|
+| `default` | `{ formId: string }` | Form content (fields, layouts). |
+
+FormDialogForm automatically:
+- Uses the form instance from the FormDialog context
+- Uses the auto-generated form ID
+- Applies `promptOnUnsavedChanges` from the FormDialog context
+
+## Variants
+
+Inherits all size variants from UIDialog. See [dialog](../dialog/SKILL.md) for the full size table.
+
+## Examples
+
+### Imperative Form Dialog
+
+**Step 1: Create the form dialog component**
+
+```vue
+<!-- CreateUserDialog.vue -->
+<script setup lang="ts">
+import { useForm } from 'formango'
+import { z } from 'zod'
+import FormDialog from '@/ui/dialog/FormDialog.vue'
+import FormDialogForm from '@/ui/dialog/FormDialogForm.vue'
+import {
+  UIDialogHeader, UIDialogBody, UIDialogFooter,
+  UIDialogFooterCancel, UIDialogFooterSubmit, UITextField,
+} from '@wisemen/vue-core-design-system'
+
+const emit = defineEmits<{ close: [] }>()
+
+const { form, register } = useForm({
+  schema: z.object({
+    firstName: z.string().min(1),
+    lastName: z.string().min(1),
+    email: z.string().email(),
+  }),
+  initialState: {
+    firstName: '',
+    lastName: '',
+    email: '',
+  },
+  onSubmit: async (values) => {
+    await createUser(values)
+    emit('close')
+  },
+})
+
+const firstName = register('firstName')
+const lastName = register('lastName')
+const email = register('email')
+</script>
+
+<template>
+  <FormDialog
+    :form="form"
+    :prompt-on-unsaved-changes="true"
+    size="md"
+    @close="emit('close')"
+  >
+    <template #default="{ formId }">
+      <UIDialogHeader title="Create User" />
+      <UIDialogBody>
+        <FormDialogForm>
+          <div class="grid grid-cols-2 gap-lg">
+            <UITextField v-bind="firstName" label="First name" />
+            <UITextField v-bind="lastName" label="Last name" />
+          </div>
+          <UITextField v-bind="email" label="Email" class="mt-lg" />
+        </FormDialogForm>
+      </UIDialogBody>
+      <UIDialogFooter>
+        <template #right>
+          <UIDialogFooterCancel label="Cancel" />
+          <UIDialogFooterSubmit label="Create" :form="formId" />
+        </template>
+      </UIDialogFooter>
+    </template>
+  </FormDialog>
+</template>
+```
+
+**Step 2: Open imperatively**
+
+```vue
+<script setup lang="ts">
+import { useOverlay, UIButton, UIDialogContainer } from '@wisemen/vue-core-design-system'
+import CreateUserDialog from './CreateUserDialog.vue'
+
+const overlay = useOverlay()
+const createDialog = overlay.create(CreateUserDialog)
+</script>
+
+<template>
+  <UIButton label="Create User" @click="createDialog.open()" />
+  <UIDialogContainer />
+</template>
+```
+
+### With Custom Form Component (renderOwnFormComponent)
+
+When `renderOwnFormComponent` is true, FormDialog does not render FormDialogForm. You manage the form element yourself:
+
+```vue
+<FormDialog
+  :form="form"
+  :render-own-form-component="true"
+  size="md"
+  @close="emit('close')"
+>
+  <template #default="{ formId }">
+    <UIDialogHeader title="Custom Form" />
+    <UIDialogBody>
+      <form :id="formId" @submit.prevent="form.submit()">
+        <!-- Your custom form fields -->
+      </form>
+    </UIDialogBody>
+    <UIDialogFooter>
+      <template #right>
+        <UIDialogFooterCancel label="Cancel" />
+        <UIDialogFooterSubmit label="Save" :form="formId" />
+      </template>
+    </UIDialogFooter>
+  </template>
+</FormDialog>
+```
+
+## Anatomy
+
+```
+UIFormDialog
+├── FormDialogContext (provides form, formId, promptOnUnsavedChanges)
+└── UIDialog (all dialog props forwarded)
+    └── <slot :form-id="id" />
+        ├── UIDialogHeader
+        ├── UIDialogBody
+        │   └── FormDialogForm (optional, unless renderOwnFormComponent)
+        │       └── UIForm (with form instance, id, promptOnUnsavedChanges)
+        │           └── <slot :form-id="formId" />
+        └── UIDialogFooter
+            └── UIDialogFooterSubmit (:form="formId")
+```
+
+## Styling
+
+**Style file:** No separate style file. Inherits all styling from UIDialog.
+
+## Common Mistakes
+
+### HIGH: Not passing formId to UIDialogFooterSubmit
+
+The submit button must be associated with the form via the `form` prop. Without it, clicking "Submit" does nothing because the button is outside the `<form>` element.
+
+```vue
+<!-- Wrong: Submit button is disconnected from the form -->
+<UIDialogFooterSubmit label="Save" />
+
+<!-- Correct: Pass formId from the slot props -->
+<FormDialog :form="form" @close="emit('close')">
+  <template #default="{ formId }">
+    ...
+    <UIDialogFooterSubmit label="Save" :form="formId" />
+  </template>
+</FormDialog>
+```
+
+### HIGH: Forgetting to emit 'close' in onSubmit
+
+The form dialog does not auto-close on successful submission. You must emit `close` in your `onSubmit` handler:
+
+```ts
+const { form } = useForm({
+  onSubmit: async (values) => {
+    await saveData(values)
+    emit('close')  // Must close explicitly
+  },
+})
+```
+
+### MEDIUM: Using UIDialogFooterPrimary instead of UIDialogFooterSubmit
+
+For form dialogs, use `UIDialogFooterSubmit` (which defaults to `type="submit"`) instead of `UIDialogFooterPrimary` (which defaults to `type="button"`). The submit type is required for the form association to work via the `form` attribute.
+
+### LOW: Not wrapping fields in FormDialogForm
+
+If `renderOwnFormComponent` is false (the default), your form fields must be inside `FormDialogForm` for validation to work:
+
+```vue
+<!-- Wrong: Fields outside FormDialogForm -->
+<UIDialogBody>
+  <UITextField v-bind="name" label="Name" />
+</UIDialogBody>
+
+<!-- Correct: Fields inside FormDialogForm -->
+<UIDialogBody>
+  <FormDialogForm>
+    <UITextField v-bind="name" label="Name" />
+  </FormDialogForm>
+</UIDialogBody>
+```
+
+## Accessibility
+
+- Inherits all accessibility features from UIDialog (focus trap, Escape, ARIA roles).
+- The form is associated with the submit button via the HTML `form` attribute, which is a standard accessibility pattern.
+- `promptOnUnsavedChanges` uses the browser's beforeunload mechanism and/or a custom prompt to warn users about losing form data.
+
+## See Also
+
+- [dialog](../dialog/SKILL.md) -- Base dialog component
+- [confirm-dialog](../confirm-dialog/SKILL.md) -- Simple confirmation dialog
+- [overlay-system](../../foundations/overlay-system/SKILL.md) -- useOverlay API
+- [form](../form/SKILL.md) -- UIForm component and formango integration

--- a/packages/web/design-system/skills/components/form/SKILL.md
+++ b/packages/web/design-system/skills/components/form/SKILL.md
@@ -6,7 +6,6 @@ description: >
   like FormSubmitButton. Always pair with a formango useForm() call.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: infrastructure
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/form/SKILL.md
+++ b/packages/web/design-system/skills/components/form/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: form
+description: >
+  Form wrapper that integrates with formango's Form object to provide submit handling,
+  unsaved changes detection with route-leave guards, and a context for child components
+  like FormSubmitButton. Always pair with a formango useForm() call.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: infrastructure
+requires: []
+exports:
+  - UIForm
+  - UIFormSubmitButton
+  - useInjectFormContext
+---
+
+# UIForm
+
+A form wrapper that integrates with formango's `Form` object, providing native form submission, unsaved changes detection with route-leave guards, and a shared context consumed by `UIFormSubmitButton`.
+
+## When to Use
+
+- Wrapping any form that uses formango's `useForm()` for validation and submission
+- When you need automatic unsaved changes detection that prompts before route navigation
+- When using `UIFormSubmitButton` for keyboard-shortcut-enabled submit buttons
+
+**Use instead:** A plain `<form>` element only when you are not using formango for form state management.
+
+## Import
+
+```ts
+import { UIForm, UIFormSubmitButton } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useForm } from 'formango'
+import { z } from 'zod'
+import { UIForm, UIFormSubmitButton } from '@wisemen/vue-core-design-system'
+
+const { form } = useForm({
+  schema: z.object({
+    name: z.string().min(1),
+  }),
+  onSubmit: async (values) => {
+    await saveUser(values)
+  },
+})
+</script>
+
+<template>
+  <UIForm :form="form" :prompt-on-unsaved-changes="true">
+    <!-- form fields here -->
+    <UIFormSubmitButton label="Save" />
+  </UIForm>
+</template>
+```
+
+## API
+
+### UIForm Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `form` | `Form<any>` | required | The formango `Form` object returned by `useForm()`. Provides submit handling, dirty tracking, and validation state. |
+| `promptOnUnsavedChanges` | `boolean` | required | When `true`, intercepts route navigation and browser tab close when the form is dirty, showing a confirmation dialog. |
+| `id` | `string \| null` | `null` | Custom form element ID. When `null`, an auto-generated ID is used. Useful when the submit button is outside the form element. |
+
+### UIForm Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Form content (fields, buttons, layout). All children can inject the form context. |
+
+### UIForm Emits
+
+This component has no custom events. Form submission is handled by formango's `form.submit()` which is called on the native `submit` event.
+
+### UIFormSubmitButton Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | required | The button label text. |
+| `variant` | `'primary' \| 'secondary'` | `'primary'` | The button variant. |
+| `disableKeyboardShortcut` | `boolean` | `false` | When `true`, disables the Cmd+Enter / Ctrl+Enter keyboard shortcut for submission. |
+
+### UIFormSubmitButton Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Override the default `UIButton` rendering entirely. The slot receives no props but the component still handles keyboard shortcuts and form binding. |
+
+### useInjectFormContext
+
+Inject the form context in any descendant component:
+
+```ts
+import { useInjectFormContext } from '@wisemen/vue-core-design-system'
+
+const { formId, form } = useInjectFormContext()
+// formId: string - the form element's ID
+// form: Form<any> - the formango Form object
+```
+
+## Variants
+
+This component has no visual variants.
+
+## Examples
+
+### Basic Form with Unsaved Changes
+
+```vue
+<script setup lang="ts">
+import { useForm, useFormField } from 'formango'
+import { z } from 'zod'
+import { UIForm, UIFormSubmitButton } from '@wisemen/vue-core-design-system'
+import { UITextField } from '@wisemen/vue-core-design-system'
+
+const { form } = useForm({
+  schema: z.object({
+    firstName: z.string().min(1, 'First name is required'),
+    lastName: z.string().min(1, 'Last name is required'),
+  }),
+  onSubmit: async (values) => {
+    await updateProfile(values)
+  },
+})
+
+const firstName = useFormField('firstName', form)
+const lastName = useFormField('lastName', form)
+</script>
+
+<template>
+  <UIForm :form="form" :prompt-on-unsaved-changes="true">
+    <UITextField
+      v-model="firstName.value.value"
+      :error-message="firstName.errors.value"
+      label="First name"
+    />
+    <UITextField
+      v-model="lastName.value.value"
+      :error-message="lastName.errors.value"
+      label="Last name"
+    />
+    <UIFormSubmitButton label="Save changes" />
+  </UIForm>
+</template>
+```
+
+### Submit Button Outside the Form
+
+```vue
+<script setup lang="ts">
+import { useForm } from 'formango'
+import { z } from 'zod'
+import { UIForm, UIFormSubmitButton } from '@wisemen/vue-core-design-system'
+
+const { form } = useForm({
+  schema: z.object({ name: z.string().min(1) }),
+  onSubmit: async (values) => { /* ... */ },
+})
+</script>
+
+<template>
+  <UIForm id="my-form" :form="form" :prompt-on-unsaved-changes="false">
+    <!-- fields -->
+  </UIForm>
+
+  <!-- Button outside the form, linked via form ID -->
+  <UIFormSubmitButton label="Save" />
+</template>
+```
+
+When `UIFormSubmitButton` is placed outside the `<UIForm>` element, it uses the `formId` from the injected context to link to the correct form via the HTML `form` attribute. Note: the button must still be a descendant of the `UIForm` in the Vue component tree (not the DOM tree) for context injection to work. If the button is truly outside the component tree, pass the `id` prop to `UIForm` and use a native button with `form="my-form"`.
+
+### Disabling Keyboard Shortcut
+
+```vue
+<UIFormSubmitButton
+  label="Save"
+  :disable-keyboard-shortcut="true"
+/>
+```
+
+By default, `UIFormSubmitButton` registers a Cmd+Enter (Mac) / Ctrl+Enter (Windows) keyboard shortcut that triggers form submission. Set `:disable-keyboard-shortcut="true"` to disable this.
+
+### Custom Submit Button
+
+```vue
+<UIFormSubmitButton label="Save">
+  <MyCustomButton type="submit" />
+</UIFormSubmitButton>
+```
+
+When using the default slot, the component still handles keyboard shortcuts and passes `is-loading` and `form` attributes via `Primitive`'s `as-child` to the slotted element.
+
+## Anatomy
+
+```
+UIForm
+  <form novalidate @submit.prevent="form.submit()">
+    <slot />
+
+UIFormSubmitButton
+  Primitive (as-child, passes form/isLoading/type=submit)
+    <slot>
+      UIButton (label, variant, keyboard-shortcut-keys, form, is-loading)
+    </slot>
+```
+
+## Styling
+
+This component has no visual styling. The `<form>` element renders with no classes. All visual styling comes from the child components (fields, buttons, layout).
+
+## Common Mistakes
+
+### HIGH: Forgetting to pass the form object
+
+Wrong:
+```vue
+<UIForm :prompt-on-unsaved-changes="true">
+  <!-- Missing :form prop -- will error -->
+</UIForm>
+```
+
+Correct:
+```vue
+<UIForm :form="form" :prompt-on-unsaved-changes="true">
+```
+
+The `form` prop is required. It must be the `Form` object returned by formango's `useForm()`.
+
+### HIGH: Using UIFormSubmitButton outside the form context
+
+Wrong:
+```vue
+<!-- UIFormSubmitButton is not a descendant of UIForm in the Vue tree -->
+<UIForm :form="form" :prompt-on-unsaved-changes="false">
+  <!-- fields -->
+</UIForm>
+<UIFormSubmitButton label="Save" />
+```
+
+`UIFormSubmitButton` calls `useInjectFormContext()` which requires it to be a descendant of `UIForm` in the Vue component tree. If you need the button in a different DOM location, keep it inside `UIForm` and use CSS positioning, or use a plain `UIButton` with `type="submit"` and the `form` attribute.
+
+### MEDIUM: Setting promptOnUnsavedChanges on a create form
+
+Consider whether `promptOnUnsavedChanges` is appropriate for your use case. On a "create" form, the user may have intentionally started filling in data and navigating away should warn them. On a "view" page with inline editing, it is essential. On a simple search/filter form, it is usually unnecessary.
+
+### LOW: Not handling submission errors
+
+The `UIFormSubmitButton` shows a loading state via `form.isSubmitting`. Make sure your `onSubmit` handler properly throws or handles errors so the loading state resolves:
+
+```ts
+const { form } = useForm({
+  schema,
+  onSubmit: async (values) => {
+    try {
+      await saveData(values)
+    } catch (error) {
+      // Handle error -- the form will stop showing the loading state
+      throw error
+    }
+  },
+})
+```
+
+## Accessibility
+
+- The `<form>` element uses `novalidate` to prevent native browser validation, relying on formango's schema-based validation instead.
+- `UIFormSubmitButton` renders a `<button type="submit">` linked to the form via the `form` attribute.
+- The Cmd+Enter / Ctrl+Enter keyboard shortcut provides a universal submit action. The shortcut keys are displayed on the button via `UIButton`'s `keyboard-shortcut-keys` prop.
+- The unsaved changes dialog is a `ConfirmDialog` with proper focus management and ARIA roles.
+- The `beforeunload` event handler prevents accidental tab/window close when the form is dirty.
+
+## See Also
+
+- [UIButton](../button/) -- The underlying button component used by UIFormSubmitButton
+- [input-system](../../foundations/input-system/) -- Shared input infrastructure used by form fields

--- a/packages/web/design-system/skills/components/interactable/SKILL.md
+++ b/packages/web/design-system/skills/components/interactable/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: interactable
+description: >
+  Low-level renderless wrapper that applies focus-visible outline and cursor styles to
+  interactive elements. Similar to UIClickableElement but with a different outline approach.
+  Load this skill when building custom interactive primitives.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: infrastructure
+requires: []
+exports:
+  - UIInteractable
+---
+
+# UIInteractable
+
+A renderless wrapper that applies interactive styles (focus ring, pointer cursor, disabled cursor) to its child element using Reka UI's `Primitive` with `as-child`. Differs from `UIClickableElement` in outline behavior: the outline color is always set to the brand color, and the `outline-2` width only appears on `focus-visible`.
+
+## When to Use
+
+- Building a custom interactive element that needs consistent focus and cursor behavior
+- Wrapping an element that should show a focus ring only on keyboard navigation
+- When creating compound interactive components that need a shared interaction base
+
+**Use instead:** `UIClickableElement` for similar behavior with an always-present (but transparent) 2px outline. `UIButton` or `UIIconButton` for complete button components.
+
+## Import
+
+```ts
+import { UIInteractable } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIInteractable } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIInteractable>
+    <button>Click me</button>
+  </UIInteractable>
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `class` | `string \| null` | `null` | Additional CSS classes merged onto the child element via `twMerge`. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | A single interactive child element (button, anchor, div, etc.) that receives the merged styles. |
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+This component has no size/variant/color options.
+
+## Examples
+
+### Interactive List Item
+
+```vue
+<script setup lang="ts">
+import { UIInteractable } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIInteractable>
+    <li
+      tabindex="0"
+      role="option"
+      class="rounded-md border p-3"
+    >
+      Focusable list item
+    </li>
+  </UIInteractable>
+</template>
+```
+
+### With Custom Classes
+
+```vue
+<script setup lang="ts">
+import { UIInteractable } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIInteractable class="ring-2 ring-offset-2">
+    <button class="rounded-md bg-primary p-2">
+      Custom styled button
+    </button>
+  </UIInteractable>
+</template>
+```
+
+## Anatomy
+
+```
+Primitive[as-child=true]   (no extra DOM node)
+  <slot />                 (child receives merged classes)
+```
+
+Because `as-child` is `true`, `UIInteractable` does not render its own DOM element. It merges styles directly onto the child.
+
+## Styling
+
+**Style file:** This component uses inline Tailwind classes (no separate style file).
+
+Applied classes:
+- `cursor-pointer` -- Pointer cursor for interactive indication
+- `rounded-sm` -- Border radius for focus ring shape
+- `outline-fg-brand-primary` -- Brand-colored outline (always set as the outline color)
+- `focus-visible:outline-2` -- 2px outline width only on keyboard focus
+- `disabled:cursor-not-allowed` -- Disabled state cursor
+
+### Difference from UIClickableElement
+
+| Aspect | UIClickableElement | UIInteractable |
+|--------|-------------------|----------------|
+| Outline width | Always `outline-2`, color is transparent until focus | No outline width until focus-visible |
+| Outline color | `transparent` by default, brand on focus | Brand color always, width 0 until focus |
+| Cursor override | `isDefaultCursor` prop available | Always `cursor-pointer` |
+
+## Common Mistakes
+
+### HIGH: Passing multiple children
+
+Wrong:
+```vue
+<UIInteractable>
+  <button>One</button>
+  <button>Two</button>
+</UIInteractable>
+```
+
+Correct:
+```vue
+<UIInteractable>
+  <button>One</button>
+</UIInteractable>
+```
+
+`as-child` mode requires exactly one child element. Multiple children cause unexpected behavior.
+
+## Accessibility
+
+- Applies `focus-visible:outline-2` with `outline-fg-brand-primary` for keyboard-only focus indication.
+- Sets `disabled:cursor-not-allowed` to visually indicate disabled state.
+- Does not add any ARIA attributes -- the child element must provide its own `role`, `aria-label`, etc.
+
+## See Also
+
+- [UIClickableElement](../clickable-element/) -- Similar wrapper with different outline strategy and cursor override option
+- [UIButton](../button/) -- Fully styled button for most action triggers

--- a/packages/web/design-system/skills/components/interactable/SKILL.md
+++ b/packages/web/design-system/skills/components/interactable/SKILL.md
@@ -6,7 +6,6 @@ description: >
   Load this skill when building custom interactive primitives.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: infrastructure
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/keyboard-shortcut/SKILL.md
+++ b/packages/web/design-system/skills/components/keyboard-shortcut/SKILL.md
@@ -7,7 +7,6 @@ description: >
   tooltips, menus, or help panels.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/keyboard-shortcut/SKILL.md
+++ b/packages/web/design-system/skills/components/keyboard-shortcut/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: keyboard-shortcut
+description: >
+  Renders a keyboard shortcut as styled key badges. Parses a shortcut string
+  (e.g., "meta_k", "g-d") into individual keys with platform-aware symbols
+  (macOS vs Windows). Load this skill when displaying keyboard shortcuts in
+  tooltips, menus, or help panels.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UIKeyboardShortcut
+---
+
+# UIKeyboardShortcut
+
+Displays a keyboard shortcut as a row of styled key badges, automatically converting modifier names to platform-specific symbols.
+
+## When to Use
+
+- Showing keyboard shortcuts in tooltips or action tooltips
+- Displaying shortcut hints in dropdown menu items
+- Building a keyboard shortcuts help panel or reference
+
+**Use instead:** A plain `<kbd>` element for simple one-key displays without platform awareness.
+
+## Import
+
+```ts
+import { UIKeyboardShortcut } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIKeyboardShortcut } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIKeyboardShortcut keyboard-shortcut="meta_k" />
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `keyboardShortcut` | `string` | **(required)** | The keyboard shortcut string. Use `_` to separate keys in a combination (e.g., `"meta_k"`) and `-` to separate keys in a sequence (e.g., `"g-d"`). |
+
+### Slots
+
+This component has no slots.
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+This component has no visual variants. Display adapts automatically based on platform.
+
+### Shortcut String Format
+
+| Separator | Meaning | Example | Renders As (macOS) |
+|-----------|---------|---------|-------------------|
+| `_` | Combination (pressed together) | `"meta_k"` | `[Cmd]` `[K]` |
+| `-` | Sequence (pressed one after another) | `"g-d"` | `[G]` then `[D]` |
+
+### Platform-Aware Key Mappings
+
+| Key Name | macOS | Windows/Linux |
+|----------|-------|---------------|
+| `meta` | `Cmd` | `Ctrl` |
+| `ctrl` | `Control` | `Ctrl` |
+| `alt` | `Option` | `Alt` |
+| `shift` | `Shift` | `Shift` |
+| `enter` | `Return` | `Return` |
+| `escape` | `Esc` | `Esc` |
+| `backspace` | `Delete` | `Delete` |
+| `arrowup` | `Up` | `Up` |
+| `arrowdown` | `Down` | `Down` |
+| `arrowleft` | `Left` | `Left` |
+| `arrowright` | `Right` | `Right` |
+| `tab` | `Tab` | `Tab` |
+
+Any unrecognized key name is rendered as-is (capitalized).
+
+## Examples
+
+### Single Combination Shortcut
+
+```vue
+<script setup lang="ts">
+import { UIKeyboardShortcut } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <!-- Renders: [Cmd] [K] on macOS, [Ctrl] [K] on Windows -->
+  <UIKeyboardShortcut keyboard-shortcut="meta_k" />
+</template>
+```
+
+### Sequence Shortcut
+
+```vue
+<script setup lang="ts">
+import { UIKeyboardShortcut } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <!-- Renders: [G] then [D] -->
+  <UIKeyboardShortcut keyboard-shortcut="g-d" />
+</template>
+```
+
+### Multi-Key Combination
+
+```vue
+<script setup lang="ts">
+import { UIKeyboardShortcut } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <!-- Renders: [Cmd] [Shift] [P] on macOS -->
+  <UIKeyboardShortcut keyboard-shortcut="meta_shift_p" />
+</template>
+```
+
+### Shortcut in a Menu Item Context
+
+```vue
+<script setup lang="ts">
+import { UIKeyboardShortcut } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex items-center justify-between gap-xl">
+    <span class="text-sm text-primary">Search</span>
+    <UIKeyboardShortcut keyboard-shortcut="meta_k" />
+  </div>
+</template>
+```
+
+## Anatomy
+
+```
+UIKeyboardShortcut
+└── UIRowLayout (gap="xs")
+    ├── <kbd>  (key badge for each key part)
+    └── <span>  (sequence separator label, "then", between sequences)
+```
+
+## Styling
+
+**Style file:** None (styles are inline Tailwind classes)
+**tv() slots:** None
+**Customization:** Each `<kbd>` element is styled with `h-4 min-w-4 rounded-xs border border-secondary px-xxs text-[0.6187rem] text-tertiary capitalize`. In dark mode, keys get `dark:bg-secondary`. The sequence separator text ("then") is styled as `text-xxs text-tertiary` and is localized via `vue-i18n` with the key `component.keyboard_shortcut.sequence_label`.
+
+## Common Mistakes
+
+### HIGH: Using wrong separator characters
+
+Wrong:
+```vue
+<!-- Using + or space instead of _ for combinations -->
+<UIKeyboardShortcut keyboard-shortcut="meta+k" />
+<UIKeyboardShortcut keyboard-shortcut="meta k" />
+```
+
+Correct:
+```vue
+<!-- Use _ for combinations, - for sequences -->
+<UIKeyboardShortcut keyboard-shortcut="meta_k" />
+```
+
+The component parses `_` as combination separator and `-` as sequence separator. Other separators will not be parsed correctly.
+
+### MEDIUM: Mixing up combination and sequence separators
+
+Wrong:
+```vue
+<!-- This means "meta then k" (sequence), not "meta + k" (combination) -->
+<UIKeyboardShortcut keyboard-shortcut="meta-k" />
+```
+
+Correct:
+```vue
+<!-- Combination: meta and k pressed together -->
+<UIKeyboardShortcut keyboard-shortcut="meta_k" />
+
+<!-- Sequence: g pressed, then d pressed -->
+<UIKeyboardShortcut keyboard-shortcut="g-d" />
+```
+
+`_` means keys pressed simultaneously (combination). `-` means keys pressed in order (sequence). Using the wrong separator changes the meaning entirely.
+
+## Accessibility
+
+The component renders each key as a `<kbd>` element, which is the semantic HTML element for keyboard input. The `<kbd>` elements are presented visually in a row. Sequence separators use a localized "then" label between key groups. The component relies on `vue-i18n` for the sequence label translation (`component.keyboard_shortcut.sequence_label`).
+
+## See Also
+
+- [UIActionTooltip](../action-tooltip/SKILL.md) -- Often wraps content with a tooltip that includes a keyboard shortcut
+- [UIDropdownMenu](../dropdown-menu/SKILL.md) -- Menu items commonly display keyboard shortcuts

--- a/packages/web/design-system/skills/components/layout/SKILL.md
+++ b/packages/web/design-system/skills/components/layout/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: layout
+description: >
+  Top-level application shell components that provide the outermost page structure.
+  UIMainLayoutContainer is the full-screen flex wrapper, and UIMainContent is the
+  sidebar-aware content area with animated padding. Use these as the root of every
+  page in a dashboard application.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: layout
+requires:
+  - layout-system
+exports:
+  - UIMainLayoutContainer
+  - UIMainContent
+---
+
+# UILayout (MainLayoutContainer + MainContent)
+
+Top-level application shell that wraps the sidebar and main content area into a full-viewport layout.
+
+## When to Use
+
+- As the outermost wrapper for every dashboard application page
+- When combining `UIMainSidebar` with page content that needs sidebar-aware padding
+- Building the root layout of an app that uses the design system navigation
+
+**Use instead:** A plain `div` only for pages that do not use the sidebar or dashboard page system (e.g., login, error pages).
+
+## Import
+
+```ts
+import { UIMainLayoutContainer, UIMainContent } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import {
+  UIMainLayoutContainer,
+  UIMainContent,
+  UIMainSidebar,
+} from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIMainLayoutContainer>
+    <UIMainSidebar>
+      <!-- sidebar slots -->
+    </UIMainSidebar>
+    <UIMainContent>
+      <!-- page content (router-view, DashboardPage, etc.) -->
+    </UIMainContent>
+  </UIMainLayoutContainer>
+</template>
+```
+
+## API
+
+### UIMainLayoutContainer
+
+The outermost shell. Renders a full-viewport `div` with `h-dvh` and `overflow-hidden`.
+
+#### Props
+
+No props.
+
+#### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Must contain `UIMainSidebar` and `UIMainContent` as direct children. |
+
+---
+
+### UIMainContent
+
+The main content area that sits beside the sidebar. Automatically applies animated left-padding that tracks the sidebar width, so content shifts smoothly when the sidebar opens, closes, or changes between collapsed variants.
+
+#### Props
+
+No props.
+
+#### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Page content (typically a `<router-view>` or `UIDashboardPage`). Rendered inside a bordered, rounded container. |
+
+### Emits
+
+No custom events on either component.
+
+## Variants
+
+These components have no visual variants. `UIMainContent` automatically adapts its padding based on sidebar state (open/closed, floating/minified) via the `useMainSidebar` composable.
+
+## Examples
+
+### Full Application Shell
+
+```vue
+<script setup lang="ts">
+import {
+  UIMainLayoutContainer,
+  UIMainContent,
+  UIMainSidebar,
+  UIMainSidebarHeaderLogoWithText,
+  UIMainSidebarNavigationGroup,
+  UIMainSidebarNavigationLink,
+  UIMainSidebarFooterAccountCard,
+} from '@wisemen/vue-core-design-system'
+import { DashboardIcon, UsersIcon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIMainLayoutContainer>
+    <UIMainSidebar collapsed-variant="minified">
+      <template #header>
+        <UIMainSidebarHeaderLogoWithText
+          url="/logo.png"
+          name="My App"
+        />
+      </template>
+      <template #navigation>
+        <UIMainSidebarNavigationGroup label="Main">
+          <UIMainSidebarNavigationLink
+            :to="{ name: 'dashboard' }"
+            :icon="DashboardIcon"
+            label="Dashboard"
+          />
+        </UIMainSidebarNavigationGroup>
+      </template>
+      <template #footer>
+        <UIMainSidebarFooterAccountCard
+          name="Jane Doe"
+          email="jane@example.com"
+          :menu-options="[]"
+          :on-sign-out="() => {}"
+        />
+      </template>
+    </UIMainSidebar>
+
+    <UIMainContent>
+      <router-view />
+    </UIMainContent>
+  </UIMainLayoutContainer>
+</template>
+```
+
+### Without Sidebar
+
+```vue
+<script setup lang="ts">
+import { UIMainLayoutContainer, UIMainContent } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIMainLayoutContainer>
+    <UIMainContent>
+      <div class="p-8">
+        <h1>Standalone page content</h1>
+      </div>
+    </UIMainContent>
+  </UIMainLayoutContainer>
+</template>
+```
+
+## Anatomy
+
+```
+UIMainLayoutContainer  div.flex.size-full.h-dvh.overflow-hidden
+  UIMainSidebar (absolute positioned)
+  UIMainContent  Motion[paddingLeft=sidebarWidth] .size-full.overflow-hidden.bg-primary.p-md
+    div .size-full.overflow-hidden.rounded-xl.border.border-secondary.shadow-sm/5
+      <slot />
+```
+
+## Styling
+
+**Style file:** No separate style file. Both components use inline Tailwind classes.
+
+**UIMainLayoutContainer:** `flex size-full h-dvh overflow-hidden` -- fills the viewport.
+
+**UIMainContent:** Uses `motion-v` `Motion` component for animated `paddingLeft` that tracks `sidebarWidth` from `useMainSidebar()`. The inner container has `rounded-xl border border-secondary shadow-sm/5` for the bordered content area. The spring animation has a duration of 0.3s with no bounce, respecting `prefers-reduced-motion`.
+
+## Common Mistakes
+
+### HIGH: Placing UIMainContent without UIMainLayoutContainer
+
+Wrong:
+```vue
+<UIMainContent>
+  <router-view />
+</UIMainContent>
+```
+
+Correct:
+```vue
+<UIMainLayoutContainer>
+  <UIMainSidebar>...</UIMainSidebar>
+  <UIMainContent>
+    <router-view />
+  </UIMainContent>
+</UIMainLayoutContainer>
+```
+
+`UIMainLayoutContainer` provides the full-viewport flex context. Without it, `UIMainContent` will not be sized correctly.
+
+### MEDIUM: Placing sidebar after content in DOM order
+
+Wrong:
+```vue
+<UIMainLayoutContainer>
+  <UIMainContent>...</UIMainContent>
+  <UIMainSidebar>...</UIMainSidebar>
+</UIMainLayoutContainer>
+```
+
+Correct:
+```vue
+<UIMainLayoutContainer>
+  <UIMainSidebar>...</UIMainSidebar>
+  <UIMainContent>...</UIMainContent>
+</UIMainLayoutContainer>
+```
+
+The sidebar is absolutely positioned and must come first. `UIMainContent` calculates its padding based on sidebar state.
+
+## Accessibility
+
+- `UIMainLayoutContainer` renders a plain `div`. It does not add landmark roles.
+- `UIMainContent` is purely presentational, handling layout animation.
+- Reduced motion is respected: animation duration is set to 0 when `prefers-reduced-motion` is enabled.
+- Focus management and landmarks are handled by child components (`UIMainSidebar` provides dialog semantics on mobile, `UIDashboardPage` renders a `<main>` landmark).
+
+## See Also
+
+- [UIMainSidebar](../sidebar/) -- The navigation sidebar that pairs with UIMainContent
+- [UIDashboardPage](../page/) -- The page component rendered inside UIMainContent
+- [Layout System](../../foundations/layout-system/) -- Foundation overview of the full layout architecture

--- a/packages/web/design-system/skills/components/layout/SKILL.md
+++ b/packages/web/design-system/skills/components/layout/SKILL.md
@@ -7,7 +7,6 @@ description: >
   page in a dashboard application.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: layout
 requires:
   - layout-system

--- a/packages/web/design-system/skills/components/loader/SKILL.md
+++ b/packages/web/design-system/skills/components/loader/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: loader
+description: >
+  Animated SVG loading spinner that inherits size and color from its parent. Has no
+  props -- sized via CSS classes and colored via currentColor. Load this skill when
+  you need a spinning loading indicator.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UILoader
+---
+
+# UILoader
+
+An animated circular SVG spinner that inherits its size and color from the parent element.
+
+## When to Use
+
+- Showing a loading state while data is being fetched
+- Indicating processing inside a button or container
+- Displaying a full-page or inline loading indicator
+
+**Use instead:** `UISkeletonItem` for placeholder loading states that mimic content layout.
+
+## Import
+
+```ts
+import { UILoader } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UILoader } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UILoader class="size-6 text-primary" />
+</template>
+```
+
+## API
+
+### Props
+
+This component has no props. Size and color are controlled via CSS classes.
+
+### Slots
+
+This component has no slots.
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+This component has no built-in variants. Control appearance through CSS classes:
+
+| Need | Class Example |
+|------|---------------|
+| Small spinner | `class="size-4"` |
+| Medium spinner | `class="size-6"` |
+| Large spinner | `class="size-8"` |
+| Brand color | `class="text-brand-500"` |
+| Primary color | `class="text-primary"` |
+| White (on dark bg) | `class="text-white"` |
+
+## Examples
+
+### Different Sizes
+
+```vue
+<script setup lang="ts">
+import { UILoader } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex items-center gap-8">
+    <UILoader class="size-4 text-primary" />
+    <UILoader class="size-6 text-primary" />
+    <UILoader class="size-8 text-primary" />
+  </div>
+</template>
+```
+
+### Centered Full-Page Loader
+
+```vue
+<script setup lang="ts">
+import { UILoader } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex h-full items-center justify-center">
+    <UILoader class="size-8 text-brand-500" />
+  </div>
+</template>
+```
+
+### Inline Loading State
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UILoader } from '@wisemen/vue-core-design-system'
+
+const isLoading = ref(true)
+</script>
+
+<template>
+  <div class="flex items-center gap-sm">
+    <UILoader v-if="isLoading" class="size-4 text-secondary" />
+    <span class="text-sm text-secondary">Loading results...</span>
+  </div>
+</template>
+```
+
+## Anatomy
+
+```
+UILoader
+└── <svg viewBox="25 25 50 50" aria-hidden="true">
+    └── <circle>  (animated stroke-dasharray spinner)
+```
+
+## Styling
+
+**Style file:** None (styles are scoped CSS in the component)
+**tv() slots:** None
+**Customization:** Size is controlled via Tailwind `size-*` classes on the component root. Color is controlled via `text-*` classes, since the SVG stroke uses `currentColor`. The animation is defined in scoped `<style>` with two keyframes: a 2s rotation and a 1.5s dash animation.
+
+## Common Mistakes
+
+### HIGH: Not setting a size class
+
+Wrong:
+```vue
+<!-- SVG will be unsized and may not display correctly -->
+<UILoader />
+```
+
+Correct:
+```vue
+<UILoader class="size-6 text-primary" />
+```
+
+UILoader is a raw SVG with no default dimensions. You must provide a size class (e.g., `size-4`, `size-6`, `size-8`) for it to render at the intended size.
+
+### MEDIUM: Using fill-based color classes
+
+Wrong:
+```vue
+<!-- fill classes won't work; the spinner uses stroke -->
+<UILoader class="size-6 fill-brand-500" />
+```
+
+Correct:
+```vue
+<UILoader class="size-6 text-brand-500" />
+```
+
+The spinner SVG uses `stroke="currentColor"`, so it inherits color from the CSS `color` property. Use `text-*` utility classes to set the color.
+
+## Accessibility
+
+The SVG element has `aria-hidden="true"` since it is a decorative loading indicator. When using UILoader, pair it with visible text (e.g., "Loading...") or use `aria-live="polite"` on a parent container along with a screen-reader-only message to announce the loading state.
+
+## See Also
+
+- [UISkeletonItem](../skeleton-item/SKILL.md) -- For content-shaped placeholder loading states
+- [UIButton](../button/SKILL.md) -- Has built-in loading state with an integrated loader

--- a/packages/web/design-system/skills/components/loader/SKILL.md
+++ b/packages/web/design-system/skills/components/loader/SKILL.md
@@ -6,7 +6,6 @@ description: >
   you need a spinning loading indicator.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/logo/SKILL.md
+++ b/packages/web/design-system/skills/components/logo/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: logo
+description: >
+  Displays a brand or app logo image with optional text label. UILogo renders a
+  sized image with fallback placeholder on error. UILogoWithText combines the logo
+  with a name label. Load this skill for brand identity elements in headers or
+  sidebars.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UILogo
+  - UILogoWithText
+---
+
+# UILogo
+
+Renders a logo image at a fixed size with rounded corners and a fallback placeholder when the image fails to load.
+
+## When to Use
+
+- Displaying a brand or company logo in a sidebar, header, or navigation
+- Showing a tenant or workspace logo
+- Anywhere a small logo image is needed with graceful error handling
+
+**Use instead:** `UIAvatar` for user profile images with initials fallback.
+
+## Import
+
+```ts
+import { UILogo, UILogoWithText } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UILogo } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UILogo src="/logo.png" alt="Company Logo" size="sm" />
+</template>
+```
+
+## API
+
+### UILogo Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `src` | `string` | **(required)** | The image source URL for the logo. |
+| `alt` | `string` | **(required)** | Accessible alt text for the logo image. |
+| `size` | `'3xs' \| 'xxs' \| 'xs' \| 'sm'` | **(required)** | The size of the logo. |
+
+### UILogoWithText Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `src` | `string \| null` | **(required)** | The image source URL for the logo. When `null`, only the text is displayed. |
+| `name` | `string` | **(required)** | The name displayed next to the logo. |
+| `size` | `'xxs' \| 'xs' \| 'sm'` | **(required)** | The size of the logo and text. |
+
+### Slots
+
+These components have no slots.
+
+### Emits
+
+These components have no custom events.
+
+## Variants
+
+### UILogo Sizes
+
+| Size | Dimensions | Border Radius |
+|------|-----------|---------------|
+| `3xs` | `size-3.5` (14px) | `rounded-xs` |
+| `xxs` | `size-5` (20px) | `rounded-sm` |
+| `xs` | `size-6` (24px) | `rounded-md` |
+| `sm` | `size-8` (32px) | `rounded-lg` |
+
+### UILogoWithText Sizes
+
+| Size | Logo Size | Text Size |
+|------|-----------|-----------|
+| `xxs` | `size-5` | `text-xs` |
+| `xs` | `size-6` | `text-sm` |
+| `sm` | `size-8` | `text-xl` |
+
+Note: UILogoWithText does not support the `3xs` size.
+
+## Examples
+
+### Basic Logo
+
+```vue
+<script setup lang="ts">
+import { UILogo } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UILogo src="/logo.png" alt="Acme Corp" size="sm" />
+</template>
+```
+
+### Logo with Text
+
+```vue
+<script setup lang="ts">
+import { UILogoWithText } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UILogoWithText src="/logo.png" name="Acme Corp" size="sm" />
+</template>
+```
+
+### Logo with Text, No Image
+
+```vue
+<script setup lang="ts">
+import { UILogoWithText } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UILogoWithText :src="null" name="Acme Corp" size="xs" />
+</template>
+```
+
+### All Logo Sizes
+
+```vue
+<script setup lang="ts">
+import { UILogo } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex items-center gap-md">
+    <UILogo src="/logo.png" alt="Logo 3xs" size="3xs" />
+    <UILogo src="/logo.png" alt="Logo xxs" size="xxs" />
+    <UILogo src="/logo.png" alt="Logo xs" size="xs" />
+    <UILogo src="/logo.png" alt="Logo sm" size="sm" />
+  </div>
+</template>
+```
+
+## Anatomy
+
+```
+UILogo
+├── <div>  (fallback placeholder, shown on image error)
+└── <img>  (logo image with object-contain)
+
+UILogoWithText
+└── UIRowLayout (gap="md")
+    ├── Logo  (conditionally rendered if src !== null)
+    └── <span>  (name text, font-semibold text-secondary)
+```
+
+## Styling
+
+**Style file:** None (styles are inline Tailwind classes)
+**tv() slots:** None
+**Customization:** UILogo uses `shrink-0` and `object-contain` with size-specific classes. The image has a subtle gradient background in dark mode (`dark:bg-primary-solid dark:bg-linear-to-b`). The error fallback renders a `bg-quaternary` placeholder div with the same size and border radius. UILogoWithText uses `UIRowLayout` with `gap="md"` and renders the name in `font-semibold text-secondary`.
+
+## Common Mistakes
+
+### HIGH: Using UILogoWithText size "3xs"
+
+Wrong:
+```vue
+<!-- 3xs is only available on UILogo, not UILogoWithText -->
+<UILogoWithText src="/logo.png" name="Brand" size="3xs" />
+```
+
+Correct:
+```vue
+<UILogoWithText src="/logo.png" name="Brand" size="xxs" />
+```
+
+UILogoWithText only supports `'xxs' | 'xs' | 'sm'`. The `3xs` size is only available on UILogo.
+
+### MEDIUM: Missing alt text on UILogo
+
+Wrong:
+```vue
+<UILogo src="/logo.png" alt="" size="sm" />
+```
+
+Correct:
+```vue
+<UILogo src="/logo.png" alt="Company Name Logo" size="sm" />
+```
+
+The `alt` prop is required and should describe the logo for screen readers.
+
+## Accessibility
+
+UILogo renders an `<img>` element with the `alt` prop mapped directly to the HTML `alt` attribute. When the image fails to load, a plain `<div>` placeholder is shown. There is no keyboard interaction. UILogoWithText displays the name as visible text, providing an additional text alternative alongside the image.
+
+## See Also
+
+- [UIAvatar](../avatar/SKILL.md) -- For user profile images with initials fallback
+- [UISidebar](../sidebar/SKILL.md) -- Common placement for logos in app navigation

--- a/packages/web/design-system/skills/components/logo/SKILL.md
+++ b/packages/web/design-system/skills/components/logo/SKILL.md
@@ -7,7 +7,6 @@ description: >
   sidebars.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/menu-item/SKILL.md
+++ b/packages/web/design-system/skills/components/menu-item/SKILL.md
@@ -7,7 +7,6 @@ description: >
   the content layer inside UIDropdownMenuItem and select/autocomplete items.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/menu-item/SKILL.md
+++ b/packages/web/design-system/skills/components/menu-item/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: menu-item
+description: >
+  UIMenuItem is a flexible content layout component for items in dropdown menus,
+  lists, and selectable options. It supports icons, avatars, dots, descriptions,
+  right-side content (text, icons, keyboard shortcuts), and a right slot. Used as
+  the content layer inside UIDropdownMenuItem and select/autocomplete items.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UIMenuItem
+  - UIMenuItemProps
+  - UIMenuItemConfig
+  - UIMenuItemAvatarConfig
+  - UIMenuItemDotConfig
+  - UIMenuItemRightConfig
+---
+
+# UIMenuItem
+
+A flexible content layout component for rendering items in menus, dropdowns, and lists.
+
+## When to Use
+
+- Inside `UIDropdownMenuItem` or select/autocomplete item slots for rich content layout.
+- Any list where items need icon/avatar + label + description + right-side content.
+- When you need a consistent item layout with configurable left and right content.
+
+**Use instead:** For the interactive dropdown menu item wrapper itself, use `UIDropdownMenuItem`. UIMenuItem is the content layout, not the interactive container.
+
+## Import
+
+```ts
+import { UIMenuItem } from '@wisemen/vue-core-design-system'
+import type { UIMenuItemConfig } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIMenuItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIMenuItem label="Apple" />
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string \| null` | `null` | The label text. Falls back to `config.label` when not provided. |
+| `config` | `MenuItemConfig \| null` | `null` | Configuration object for advanced content layout. |
+| `size` | `'md' \| 'sm'` | `'md'` | The size of the menu item. |
+
+### MenuItemConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `label` | `string \| null` | `null` | Override label shown in the item. |
+| `icon` | `Component \| null` | `null` | Icon displayed to the left. Cannot combine with `avatar` or `dot`. |
+| `avatar` | `MenuItemAvatarConfig \| null` | `null` | Avatar to the left. Cannot combine with `icon` or `dot`. |
+| `dot` | `MenuItemDotConfig \| null` | `null` | Colored dot to the left. Cannot combine with `icon` or `avatar`. |
+| `description` | `string \| null` | `null` | Secondary text below (or inline with) the label. |
+| `descriptionLayout` | `'block' \| 'inline'` | `'block'` | `'block'`: description on its own line. `'inline'`: same line, truncates. |
+| `right` | `MenuItemRightConfig \| null` | `null` | Trailing content to the right of the label. |
+
+### MenuItemAvatarConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `string` | **(required)** | Name used for fallback initials. |
+| `src` | `string \| null` | `null` | Image source URL. |
+| `imageAlt` | `string \| null` | `null` | Alt text for the avatar image. |
+
+### MenuItemDotConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `color` | `DotColor` | `'gray'` | The color of the dot (e.g. `'success'`, `'error'`, `'gray'`). |
+
+### MenuItemRightConfig (discriminated union on `type`)
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `'text'` | `text: string` | Plain text on the right. |
+| `'icon'` | `icon: Component` | Single icon on the right. |
+| `'icon-text'` | `icon: Component, text: string` | Icon followed by text. |
+| `'shortcut'` | `keys: string` | Keyboard shortcut badge (e.g. `'meta_k'`). |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `right` | Custom content rendered after the right config content. |
+
+### Emits
+
+No custom events.
+
+## Variants
+
+### Sizes
+
+| Size | Min height | Padding |
+|------|------------|---------|
+| `md` | `min-h-8` | Vertical `py-sm`, horizontal depends on left/right content (`pl-md`/`pl-lg`, `pr-md`/`pr-lg`) |
+| `sm` | `min-h-7` | `px-sm py-xs` |
+
+### Left content (mutually exclusive)
+
+Only one of `icon`, `avatar`, or `dot` can be used at a time:
+- **icon**: Renders at `size-3.5 text-tertiary`
+- **avatar**: Renders `UIAvatar` at size `'xs'` (or `'sm'` when a description is present)
+- **dot**: Renders `UIDot` with the specified color
+
+## Examples
+
+### With icon and description
+
+```vue
+<script setup lang="ts">
+import { UIMenuItem } from '@wisemen/vue-core-design-system'
+import { User02Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIMenuItem
+    :config="{
+      icon: User02Icon,
+      label: 'Alice Johnson',
+      description: 'alice@example.com',
+    }"
+  />
+</template>
+```
+
+### With avatar and right text
+
+```vue
+<script setup lang="ts">
+import { UIMenuItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIMenuItem
+    :config="{
+      avatar: { name: 'Alice Johnson', src: 'https://i.pravatar.cc/150?u=alice' },
+      label: 'Alice Johnson',
+      right: { type: 'text', text: 'Admin' },
+    }"
+  />
+</template>
+```
+
+### With keyboard shortcut
+
+```vue
+<script setup lang="ts">
+import { UIMenuItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIMenuItem
+    :config="{
+      right: { type: 'shortcut', keys: 'meta_k' },
+    }"
+    label="Search"
+  />
+</template>
+```
+
+### With right slot (custom check icon)
+
+```vue
+<script setup lang="ts">
+import { UIMenuItem } from '@wisemen/vue-core-design-system'
+import { CheckIcon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIMenuItem label="Selected item">
+    <template #right>
+      <CheckIcon class="size-3.5 text-tertiary" />
+    </template>
+  </UIMenuItem>
+</template>
+```
+
+### Inline description with truncation
+
+```vue
+<script setup lang="ts">
+import { UIMenuItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIMenuItem
+    :config="{
+      label: 'Alice Johnson',
+      description: 'this-is-a-very-long-email@example.com',
+      descriptionLayout: 'inline',
+    }"
+  />
+</template>
+```
+
+### Dot indicator
+
+```vue
+<script setup lang="ts">
+import { UIMenuItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIMenuItem
+    :config="{ dot: { color: 'success' } }"
+    label="Active"
+  />
+</template>
+```
+
+## Anatomy
+
+```
+UIMenuItem (UIRowLayout justify="between")
+  Left section (UIRowLayout align="center" gap="lg")
+    UIAvatar | Icon | UIDot (mutually exclusive, optional)
+    Inline layout (UIRowLayout) -- when descriptionLayout='inline'
+      UIText (label)
+      UIText (description, truncated)
+    Block layout (UIColumnLayout) -- when descriptionLayout='block' or no description
+      UIText (label)
+      UIText (description, optional)
+  Right section (UIRowLayout align="center" gap="sm")
+    Right config content (text | icon | icon-text | shortcut)
+    slot[right]
+```
+
+## Styling
+
+**Style file:** `src/ui/menu-item/menuItem.style.ts`
+
+**tv() slots:** `base`, `iconWrapper`, `dotWrapper`
+
+**Variant axes:** `size` (`md` | `sm`), `hasLeftContent` (boolean), `hasRightContent` (boolean)
+
+Compound variants adjust horizontal padding: items with left/right content get extra padding (`pl-lg`/`pr-lg` at `md` size).
+
+## Common Mistakes
+
+### ERROR: Combining icon, avatar, and dot
+
+```vue
+<!-- WRONG: only one left-content type is rendered -->
+<UIMenuItem
+  :config="{
+    icon: User02Icon,
+    avatar: { name: 'Alice' },
+    dot: { color: 'success' },
+  }"
+  label="Item"
+/>
+
+<!-- CORRECT: pick one -->
+<UIMenuItem
+  :config="{ icon: User02Icon }"
+  label="Item"
+/>
+```
+
+The template renders `avatar`, `icon`, and `dot` with `v-if` / `v-else-if` priority: avatar > icon > dot. Only the first match renders.
+
+### WARNING: Using config.label and prop label together
+
+```vue
+<!-- Both are set; config.label is never shown because prop label takes precedence via ?? -->
+<UIMenuItem
+  :config="{ label: 'Config label' }"
+  label="Prop label"
+/>
+```
+
+The resolved label uses `config.label ?? props.label`. If both are non-null, `config.label` wins. Set only one to avoid confusion.
+
+## Accessibility
+
+- UIMenuItem is a layout component, not an interactive element. Accessibility roles come from the parent (e.g. `UIDropdownMenuItem` adds `role="menuitem"`).
+- Text uses `select-none` to prevent accidental text selection during interaction.
+
+## See Also
+
+- [dropdown-menu](../dropdown-menu/SKILL.md) -- Uses UIMenuItem as content inside dropdown items
+- [button](../button/SKILL.md) -- For action triggers instead of list items

--- a/packages/web/design-system/skills/components/number-badge/SKILL.md
+++ b/packages/web/design-system/skills/components/number-badge/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: number-badge
+description: >
+  Small pill-shaped badge that displays a numeric value with color and variant options.
+  Useful for counts, notification indicators, and numeric status labels. Load this skill
+  when you need to show a number inside a colored badge.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UINumberBadge
+  - UINumberBadgeProps
+---
+
+# UINumberBadge
+
+A compact, pill-shaped badge that displays a formatted numeric value. Supports multiple colors, sizes, and visual variants (translucent, outline, solid).
+
+## When to Use
+
+- Displaying notification counts (e.g., unread messages)
+- Showing numeric status indicators (e.g., item counts, scores)
+- Labeling quantities in tables, lists, or navigation items
+
+**Use instead:** `UIBadge` when you need text labels, icons, dots, or avatars inside the badge. Use plain text for inline numbers that do not need visual emphasis.
+
+## Import
+
+```ts
+import { UINumberBadge } from '@wisemen/vue-core-design-system'
+import type { UINumberBadgeProps } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UINumberBadge } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UINumberBadge value="5" />
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `string` | **(required)** | The number to display. Always pass a pre-formatted string (e.g., `"1.400"`, `"4,5"`). |
+| `ariaLabel` | `string \| null` | `null` | Accessible label for screen readers. When `null`, the badge value is used. |
+| `color` | `UtilityColor` | `'gray'` | The color theme. One of: `'blue'`, `'brand'`, `'error'`, `'gray'`, `'pink'`, `'purple'`, `'success'`, `'warning'`. |
+| `size` | `'lg' \| 'md'` | `'md'` | The size of the badge. `'md'` = 16px height, `'lg'` = 20px height. |
+| `variant` | `'outline' \| 'solid' \| 'translucent'` | `'translucent'` | The visual style. `translucent` = tinted background, `outline` = border only, `solid` = filled background. |
+
+### Slots
+
+This component has no slots.
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+### Sizes
+
+| Size | Height | Font size |
+|------|--------|-----------|
+| `md` | `h-4` (16px) | `text-[0.625rem]` (10px) |
+| `lg` | `h-5` (20px) | `text-xs` (12px) |
+
+### Visual Variants
+
+| Variant | Description |
+|---------|-------------|
+| `translucent` | Tinted background with colored text and subtle border |
+| `outline` | Transparent background with colored border and text |
+| `solid` | Filled background with white (or on-brand) text |
+
+### Colors
+
+All `UtilityColor` values: `gray`, `brand`, `blue`, `pink`, `error`, `success`, `warning`, `purple`.
+
+## Examples
+
+### Notification Count
+
+```vue
+<script setup lang="ts">
+import { UINumberBadge } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex items-center gap-2">
+    <span>Messages</span>
+    <UINumberBadge value="12" color="error" variant="solid" />
+  </div>
+</template>
+```
+
+### All Variants
+
+```vue
+<script setup lang="ts">
+import { UINumberBadge } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex items-center gap-3">
+    <UINumberBadge value="5" color="brand" variant="translucent" />
+    <UINumberBadge value="5" color="brand" variant="outline" />
+    <UINumberBadge value="5" color="brand" variant="solid" />
+  </div>
+</template>
+```
+
+### Multi-digit Values
+
+```vue
+<script setup lang="ts">
+import { UINumberBadge } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex items-center gap-3">
+    <UINumberBadge value="3" />
+    <UINumberBadge value="42" />
+    <UINumberBadge value="128" />
+  </div>
+</template>
+```
+
+## Anatomy
+
+```
+span.inline-flex.rounded-full.border  (base)
+  UIText                               (label)
+```
+
+## Styling
+
+**Style file:** `src/ui/number-badge/numberBadge.style.ts`
+**tv() slots:** `base`, `label`
+
+The `base` slot controls the pill container (height, padding, border, background). The `label` slot controls the text (font weight, color). Color-variant combinations are defined as `compoundVariants`.
+
+## Common Mistakes
+
+### HIGH: Passing a number instead of a string
+
+Wrong:
+```vue
+<UINumberBadge :value="42" />
+```
+
+Correct:
+```vue
+<UINumberBadge value="42" />
+```
+
+The `value` prop is typed as `string`. Always pass a pre-formatted string. This ensures locale-specific formatting (e.g., `"1.400"` or `"4,5"`) is controlled by the consumer.
+
+### LOW: Using UINumberBadge for text labels
+
+Wrong:
+```vue
+<UINumberBadge value="New" />
+```
+
+Correct:
+```vue
+<UIBadge label="New" />
+```
+
+UINumberBadge is designed for numeric values. For text labels, use `UIBadge` instead.
+
+## Accessibility
+
+- Renders with `role="status"` so screen readers announce content changes.
+- Accepts an `ariaLabel` prop for custom screen reader text. When omitted, the displayed `value` is read.
+
+## See Also
+
+- [UIBadge](../badge/) -- Full-featured badge with text labels, icons, dots, and avatars

--- a/packages/web/design-system/skills/components/number-badge/SKILL.md
+++ b/packages/web/design-system/skills/components/number-badge/SKILL.md
@@ -6,7 +6,6 @@ description: >
   when you need to show a number inside a colored badge.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/number-field/SKILL.md
+++ b/packages/web/design-system/skills/components/number-field/SKILL.md
@@ -7,7 +7,6 @@ description: >
   form validation.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: input
 requires:
   - input-system

--- a/packages/web/design-system/skills/components/number-field/SKILL.md
+++ b/packages/web/design-system/skills/components/number-field/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: number-field
+description: >
+  Numeric input with locale-aware formatting, optional increment/decrement
+  controls, min/max bounds, and step snapping. Built on Reka UI NumberField
+  with InputWrapper > FieldWrapper composition. Integrates with formango for
+  form validation.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: input
+requires:
+  - input-system
+exports:
+  - UINumberField
+  - UINumberFieldProps
+---
+
+# UINumberField
+
+A numeric input field with locale-aware number formatting, optional increment/decrement controls, min/max bounds, and configurable step values.
+
+## When to Use
+
+- Capturing numeric values: quantities, ages, prices, measurements
+- When you need locale-aware number formatting (decimal/thousands separators)
+- When you need increment/decrement buttons for stepping values
+- When you need min/max constraints with step snapping
+
+**Use instead:** [UITextField](../text-field/SKILL.md) for free-text input, [UITextField type="tel"](../text-field/SKILL.md) for phone numbers (formatted strings, not numbers).
+
+## Import
+
+```ts
+import { UINumberField } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UINumberField } from '@wisemen/vue-core-design-system'
+
+const quantity = ref<number | null>(null)
+</script>
+
+<template>
+  <UINumberField
+    v-model="quantity"
+    label="Quantity"
+    placeholder="0"
+  />
+</template>
+```
+
+## API
+
+### Props
+
+> Inherits from: `Input`, `AutocompleteInput`, `InputWrapper`, `FieldWrapper` (see [input-system](../../foundations/input-system/SKILL.md))
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `formatOptions` | `Intl.NumberFormatOptions \| null` | `null` | Number formatting options using `Intl.NumberFormatOptions`. Controls display of decimals, currency, percentage, etc. |
+| `max` | `number \| null` | `null` | Maximum allowed value. The increment button is disabled when the value reaches this limit. |
+| `min` | `number \| null` | `null` | Minimum allowed value. The decrement button is disabled when the value reaches this limit. |
+| `showControls` | `boolean` | `false` | When `true`, shows increment (+) and decrement (-) buttons on the left and right of the input. Also centers the input text. |
+| `step` | `number` | `1` | The increment/decrement step value. Determines how much the value changes when using controls or arrow keys. |
+
+### v-model
+
+| Model | Type | Required | Description |
+|-------|------|----------|-------------|
+| `modelValue` | `number \| null` | Yes | The current numeric value. `null` means empty. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `label-left` | Content rendered to the left of the label text. |
+| `label-right` | Content rendered to the right of the label text. |
+| `left` | Content rendered inside the FieldWrapper, to the left of the input. Overrides the decrement button when `showControls` is true. |
+| `right` | Content rendered inside the FieldWrapper, to the right of the input. Overrides the increment button when `showControls` is true. |
+
+### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `blur` | `FocusEvent` | Emitted when the input loses focus. |
+
+## Variants
+
+The number field does not have size variants. When `showControls` is `true`, the input text is centered.
+
+## Examples
+
+### Basic Usage
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UINumberField } from '@wisemen/vue-core-design-system'
+
+const age = ref<number | null>(null)
+</script>
+
+<template>
+  <UINumberField
+    v-model="age"
+    :min="0"
+    :max="150"
+    label="Age"
+    placeholder="Years"
+    :is-required="true"
+  />
+</template>
+```
+
+### With Formango
+
+```vue
+<script setup lang="ts">
+import { useForm } from '@wisemen/formango'
+import { UINumberField } from '@wisemen/vue-core-design-system'
+import { z } from 'zod'
+
+const { form } = useForm({
+  schema: z.object({
+    quantity: z.number().min(1, 'Must be at least 1').max(99, 'Cannot exceed 99'),
+  }),
+  onSubmit(values) {
+    console.log(values)
+  },
+})
+
+const quantity = form.register('quantity')
+</script>
+
+<template>
+  <UINumberField
+    v-model="quantity.modelValue.value"
+    :error-message="quantity.isTouched.value ? quantity.errors.value?._errors?.[0] ?? null : null"
+    :is-required="true"
+    :min="1"
+    :max="99"
+    label="Quantity"
+    placeholder="0"
+    @blur="quantity.setTouched()"
+  />
+</template>
+```
+
+### With Increment/Decrement Controls
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UINumberField } from '@wisemen/vue-core-design-system'
+
+const quantity = ref<number | null>(1)
+</script>
+
+<template>
+  <UINumberField
+    v-model="quantity"
+    :show-controls="true"
+    :min="1"
+    :max="99"
+    :step="1"
+    label="Quantity"
+    hint="How many items?"
+  />
+</template>
+```
+
+### Currency Formatting
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UINumberField } from '@wisemen/vue-core-design-system'
+
+const price = ref<number | null>(null)
+</script>
+
+<template>
+  <UINumberField
+    v-model="price"
+    :format-options="{ style: 'currency', currency: 'EUR' }"
+    :step="0.01"
+    label="Price"
+    placeholder="0.00"
+  />
+</template>
+```
+
+## Anatomy
+
+```
+InputWrapper
+├── InputWrapperLabel          (label text + asterisk + help icon)
+├── RekaNumberFieldRoot        (Reka UI number field root, handles formatting/locale)
+│   └── FieldWrapper
+│       ├── slot#left / RekaNumberFieldDecrement  (decrement button when showControls)
+│       ├── RekaNumberFieldInput                  (formatted number input)
+│       ├── slot#right / RekaNumberFieldIncrement (increment button when showControls)
+│       ├── FieldWrapperIcon                      (iconRight) OR FieldWrapperLoader
+│       └──
+├── InputWrapperHint           (hint text)
+└── InputWrapperErrorMessage   (error text)
+```
+
+## Styling
+
+**Style file:** `src/ui/number-field/numberField.style.ts`
+**tv() slots:**
+- `input` -- The number input element. Truncated, transparent background, themed text. Includes placeholder, read-only, and disabled states.
+- `leftControl` -- Padding for the decrement button area (`pl-xs`).
+- `rightControl` -- Padding for the increment button area (`pr-xs`).
+
+When `showControls` is `true`, the `input` slot adds `text-center` to center the value between the buttons.
+
+## Common Mistakes
+
+### CRITICAL: Passing errorMessage without checking touched state
+
+Wrong:
+```vue
+<UINumberField
+  v-model="field.modelValue.value"
+  :error-message="field.errors.value?._errors?.[0]"
+/>
+```
+
+Correct:
+```vue
+<UINumberField
+  v-model="field.modelValue.value"
+  :error-message="field.isTouched.value ? field.errors.value?._errors?.[0] ?? null : null"
+  @blur="field.setTouched()"
+/>
+```
+
+### HIGH: Using v-model with string type instead of number
+
+Wrong:
+```vue
+<script setup lang="ts">
+const value = ref<string>('')  // Wrong type!
+</script>
+<UINumberField v-model="value" />
+```
+
+Correct:
+```vue
+<script setup lang="ts">
+const value = ref<number | null>(null)
+</script>
+<UINumberField v-model="value" />
+```
+
+The v-model type is `number | null`, not `string`. The component handles locale-aware parsing internally.
+
+### MEDIUM: Expecting real-time v-model updates during typing
+
+The underlying Reka UI NumberField only commits the formatted value on blur or Enter key press. During typing, the raw input is parsed and the numeric `modelValue` is updated via a custom `onInput` handler, but the displayed formatted text only syncs on blur. This is by design for locale-aware formatting.
+
+## Accessibility
+
+- `useInput` composable auto-generates: `aria-invalid`, `aria-describedby`, `aria-required`, `aria-busy`
+- Reka UI NumberField handles: arrow key increment/decrement, Home/End for min/max
+- Increment/decrement buttons have accessible labels via `i18n.t('component.number_field.increment')` and `i18n.t('component.number_field.decrement')`
+- `disable-wheel-change` is set to `true` to prevent accidental value changes when scrolling
+- Keyboard: Arrow Up/Down to increment/decrement, Enter to commit value
+
+## See Also
+
+- [input-system](../../foundations/input-system/SKILL.md) -- Inherited props and architecture
+- [text-field](../text-field/SKILL.md) -- Single-line text input for non-numeric values

--- a/packages/web/design-system/skills/components/page/SKILL.md
+++ b/packages/web/design-system/skills/components/page/SKILL.md
@@ -6,7 +6,6 @@ description: >
   8+ sub-components. Use for any page inside the dashboard layout shell.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: layout
 requires:
   - layout-system

--- a/packages/web/design-system/skills/components/page/SKILL.md
+++ b/packages/web/design-system/skills/components/page/SKILL.md
@@ -1,0 +1,592 @@
+---
+name: page
+description: >
+  Full dashboard page system with header, breadcrumbs, action bars, content area, loading
+  state, and a resizable detail pane. UIDashboardPage is the root orchestrator that composes
+  8+ sub-components. Use for any page inside the dashboard layout shell.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: layout
+requires:
+  - layout-system
+exports:
+  - UIDashboardPage
+  - UIDashboardPageContainer
+  - UIDashboardPageContent
+  - UIDashboardPageHeader
+  - UIDashboardPageActions
+  - UIDashboardPageHeaderMasterActionButton
+  - UIDashboardPageLoadingState
+  - UIDashboardPageDetailPaneToggle
+  - DashboardPageProps
+  - PageTab
+  - PageBreadcrumb
+  - DetailPaneConfig
+  - DetailPaneVariant
+  - DetailPaneStorage
+  - DetailPaneStorageStrategy
+  - useProvideDetailPaneContext
+  - useInjectDetailPaneContext
+---
+
+# UIDashboardPage
+
+Full dashboard page layout with a header (title, breadcrumbs, tabs, actions), optional action bar, scrollable content area, loading skeleton, and a resizable detail pane that slides in from the right.
+
+## When to Use
+
+- Building any page inside the dashboard application shell
+- Pages that need a header with breadcrumbs, tabs, or action buttons
+- Master-detail layouts with a togglable side panel
+- Pages that need a consistent loading skeleton
+
+**Use instead:** A plain `<div>` for non-dashboard pages (login, error, onboarding). `UIMainContent` alone for pages that do not need header/actions/detail-pane structure.
+
+## Import
+
+```ts
+import {
+  UIDashboardPage,
+  UIDashboardPageContainer,
+  UIDashboardPageContent,
+  UIDashboardPageActions,
+  UIDashboardPageHeaderMasterActionButton,
+  UIDashboardPageLoadingState,
+  UIDashboardPageDetailPaneToggle,
+} from '@wisemen/vue-core-design-system'
+```
+
+Types:
+
+```ts
+import type {
+  DashboardPageProps,
+  PageTab,
+  PageBreadcrumb,
+  DetailPaneConfig,
+  DetailPaneVariant,
+  DetailPaneStorage,
+  DetailPaneStorageStrategy,
+} from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import {
+  UIDashboardPage,
+  UIDashboardPageContent,
+} from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIDashboardPage title="Users">
+    <UIDashboardPageContent>
+      <p>Your page content here.</p>
+    </UIDashboardPageContent>
+  </UIDashboardPage>
+</template>
+```
+
+## API
+
+### UIDashboardPage (root)
+
+The main orchestrator component. Renders the header, wires up the detail pane context, and composes all sub-components.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string \| null` | (required) | Page title shown in the header. Pass `null` to hide. |
+| `breadcrumbs` | `PageBreadcrumb[]` | `[]` | Breadcrumb trail displayed in the header. |
+| `tabs` | `PageTab[]` | `[]` | Tab items displayed below the header (currently passed through). |
+| `actions` | `any[]` | `[]` | Action items (reserved for future use). |
+| `detailPane` | `DetailPaneConfig \| null` | `null` | Configuration for the detail pane. Pass `null` to disable. |
+
+#### v-model
+
+| Model | Type | Default | Description |
+|-------|------|---------|-------------|
+| `isDetailPaneOpen` | `boolean` | `true` | Controls whether the detail pane is open. |
+
+#### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Main page content (typically `UIDashboardPageActions` + `UIDashboardPageContent`). |
+| `title` | Override the default title rendering. |
+| `title-left` | Content placed to the left of the title. |
+| `header-action-left` | Actions in the left area of the header action row. |
+| `header-action-center` | Actions in the center area of the header action row. |
+| `header-action-right` | Actions in the right area of the header action row. |
+| `header-master-actions` | Persistent actions to the right of the header (before the detail pane toggle). |
+| `detail-pane` | Content rendered inside the detail pane. The pane only appears if both `detailPane` prop is set and this slot is provided. |
+
+---
+
+### UIDashboardPageContainer
+
+A centered container with horizontal padding. Used internally by the header, actions, and content, but can also be used standalone.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `class` | `string \| null` | `null` | Additional CSS classes merged with `mx-auto flex w-full flex-col px-2xl`. |
+
+#### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Container content. |
+
+---
+
+### UIDashboardPageContent
+
+The main scrollable content area. Automatically adjusts its right margin when the detail pane is open (inline variants) using animated spring transitions.
+
+#### Props
+
+No props.
+
+#### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Page content rendered inside a `UIDashboardPageContainer` with `py-4xl` padding. |
+
+---
+
+### UIDashboardPageActions
+
+An action bar rendered between the header and content. Adjusts its right padding to account for the detail pane.
+
+#### Props
+
+No props.
+
+#### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Full-width custom content for the action bar. |
+| `left` | Left-aligned content in the default two-column layout. |
+| `right` | Right-aligned content in the default two-column layout. |
+
+---
+
+### UIDashboardPageHeaderMasterActionButton
+
+An icon button displayed in the master actions area of the header. Renders as a tertiary-variant `UIIconButton`.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `icon` | `Component` | (required) | The icon component to display. |
+| `label` | `string` | (required) | Accessible label for the button. |
+
+#### Slots
+
+No slots.
+
+---
+
+### UIDashboardPageLoadingState
+
+A full-page loading skeleton that renders a `UIDashboardPage` with a `SkeletonItem` placeholder in the title area and a screen-reader-only loading heading.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `breadcrumbs` | `PageBreadcrumb[]` | (required) | Breadcrumbs to display while loading (preserves navigation context). |
+
+#### Slots
+
+No slots.
+
+---
+
+### UIDashboardPageDetailPaneToggle
+
+A toggle button that opens/closes the detail pane. Displays a panel icon that visually indicates the current state. Includes a tooltip with a `Meta+I` keyboard shortcut hint.
+
+#### Props
+
+No props. Reads state from `DetailPaneContext` via `useInjectDetailPaneContext()`.
+
+#### Slots
+
+No slots.
+
+### Emits
+
+No custom events on any sub-component. State is managed through `v-model:isDetailPaneOpen` on the root `UIDashboardPage` and the `DetailPaneContext`.
+
+## Types
+
+### PageBreadcrumb
+
+```ts
+interface PageBreadcrumb {
+  label: string
+  to?: RouteLocationRaw   // optional navigation target
+  icon?: Component         // optional leading icon
+  imageSrc?: string        // optional image instead of icon
+  isLoading?: boolean      // show skeleton placeholder
+}
+```
+
+### PageTab
+
+```ts
+interface PageTab {
+  label: string
+  icon?: Component
+  to: RouteLocationRaw
+  keyboardShortcutKeys?: KeyboardKey[] | null
+}
+```
+
+### DetailPaneConfig
+
+```ts
+interface DetailPaneConfig {
+  variant?: DetailPaneVariant    // default: 'full-height-inline'
+  isResizable?: boolean          // default: true
+  storage?: DetailPaneStorage | null  // persistence configuration
+}
+```
+
+### DetailPaneVariant
+
+```ts
+type DetailPaneVariant =
+  | 'bordered-inline'       // Rounded bordered pane, pushes content left
+  | 'bordered-overlay'      // Rounded bordered pane, overlays content
+  | 'full-height-inline'    // Full-height pane with left border, pushes content
+  | 'full-height-overlay'   // Full-height pane with left border, overlays content
+```
+
+**Inline** variants push the main content to the left when open. **Overlay** variants float on top of the content. On small screens (< 960px), all variants become overlay.
+
+### DetailPaneStorage
+
+```ts
+interface DetailPaneStorage {
+  key: string                          // storage key
+  strategy: DetailPaneStorageStrategy  // 'localStorage' | 'routeQuery'
+}
+
+type DetailPaneStorageStrategy = 'localStorage' | 'routeQuery'
+```
+
+### DetailPaneContext
+
+Provided via `useProvideDetailPaneContext` / `useInjectDetailPaneContext`:
+
+```ts
+interface DetailPaneContext {
+  isOpen: Ref<boolean>
+  isFloatingDetailPane: ComputedRef<boolean>
+  isResizable: boolean
+  isResizing: Ref<boolean>
+  sidebarWidth: Ref<string>
+  variant: DetailPaneVariant
+  toggleIsOpen: () => void
+  onResizeStart: (event: PointerEvent) => void
+  onResizeKeyDown: (event: KeyboardEvent) => void
+}
+```
+
+## Variants
+
+### Detail Pane Variants
+
+| Variant | Behavior | Pane Appearance |
+|---------|----------|-----------------|
+| `bordered-inline` | Pushes content left | Rounded corners, border, floating shadow, 2px inset |
+| `bordered-overlay` | Overlays content | Rounded corners, border, floating shadow, 2px inset |
+| `full-height-inline` | Pushes content left | Full height, left border only |
+| `full-height-overlay` | Overlays content | Full height, left border only |
+
+## Examples
+
+### Page with Breadcrumbs and Actions
+
+```vue
+<script setup lang="ts">
+import {
+  UIDashboardPage,
+  UIDashboardPageActions,
+  UIDashboardPageContent,
+  UIDashboardPageHeaderMasterActionButton,
+} from '@wisemen/vue-core-design-system'
+import { PlusIcon, SearchMdIcon } from '@wisemen/vue-core-icons'
+import type { PageBreadcrumb } from '@wisemen/vue-core-design-system'
+
+const breadcrumbs: PageBreadcrumb[] = [
+  { label: 'Projects', to: { path: '/projects' } },
+  { label: 'Project Alpha', to: { path: '/projects/alpha' } },
+]
+</script>
+
+<template>
+  <UIDashboardPage
+    :breadcrumbs="breadcrumbs"
+    title="Project Alpha"
+  >
+    <template #header-master-actions>
+      <UIDashboardPageHeaderMasterActionButton
+        :icon="SearchMdIcon"
+        label="Search"
+      />
+    </template>
+
+    <template #header-action-right>
+      <UIButton :icon-left="PlusIcon" label="New Item" />
+    </template>
+
+    <UIDashboardPageActions>
+      <template #left>
+        <UIButton label="Filter" variant="secondary" />
+      </template>
+      <template #right>
+        <UIButton label="Export" variant="secondary" />
+      </template>
+    </UIDashboardPageActions>
+
+    <UIDashboardPageContent>
+      <p>Main content here.</p>
+    </UIDashboardPageContent>
+  </UIDashboardPage>
+</template>
+```
+
+### Page with Detail Pane
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  UIDashboardPage,
+  UIDashboardPageContent,
+} from '@wisemen/vue-core-design-system'
+import type { DetailPaneConfig } from '@wisemen/vue-core-design-system'
+
+const isDetailOpen = ref<boolean>(true)
+
+const detailPaneConfig: DetailPaneConfig = {
+  variant: 'bordered-overlay',
+  isResizable: true,
+  storage: {
+    key: 'users-detail-pane',
+    strategy: 'localStorage',
+  },
+}
+</script>
+
+<template>
+  <UIDashboardPage
+    v-model:is-detail-pane-open="isDetailOpen"
+    :detail-pane="detailPaneConfig"
+    title="Users"
+  >
+    <UIDashboardPageContent>
+      <p>Select a user to see details.</p>
+    </UIDashboardPageContent>
+
+    <template #detail-pane>
+      <div class="flex h-full flex-col gap-lg p-lg">
+        <h2 class="text-sm font-medium">User Details</h2>
+        <p class="text-sm text-secondary">Detail content here.</p>
+      </div>
+    </template>
+  </UIDashboardPage>
+</template>
+```
+
+### Loading State
+
+```vue
+<script setup lang="ts">
+import {
+  UIDashboardPageLoadingState,
+  UIDashboardPageContent,
+  UIDashboardPage,
+} from '@wisemen/vue-core-design-system'
+import type { PageBreadcrumb } from '@wisemen/vue-core-design-system'
+
+const isLoading = ref<boolean>(true)
+
+const breadcrumbs: PageBreadcrumb[] = [
+  { label: 'Projects', to: { path: '/projects' } },
+]
+</script>
+
+<template>
+  <UIDashboardPageLoadingState
+    v-if="isLoading"
+    :breadcrumbs="breadcrumbs"
+  />
+  <UIDashboardPage
+    v-else
+    :breadcrumbs="breadcrumbs"
+    title="Projects"
+  >
+    <UIDashboardPageContent>
+      <p>Loaded content.</p>
+    </UIDashboardPageContent>
+  </UIDashboardPage>
+</template>
+```
+
+## Anatomy
+
+```
+UIDashboardPage  .relative.flex.size-full.h-full.flex-col.overflow-hidden.bg-secondary
+  Page  <main id="main-content">
+    DashboardPageHeader  <header .border-b.border-secondary>
+      div .flex.h-11.items-center
+        DashboardPageContainer
+          RowLayout[justify=between]
+            RowLayout[gap=none]
+              DashboardPageHeaderSidebarToggle (toggle sidebar)
+              Separator (if breadcrumbs/title)
+              RowLayout[gap=xl]
+                title / breadcrumbs / action-left slot
+            action-center slot
+            RowLayout[gap=xs]
+              action-right slot
+              DashboardPageHeaderActions
+                Separator (if master-actions present)
+                master-actions slot
+                DashboardPageDetailPaneToggle (if detail pane)
+      div (small-screen action row, shown < 1024px)
+    div .relative.flex.size-full.overflow-hidden
+      div .flex.size-full.flex-col.overflow-hidden
+        <slot /> (DashboardPageActions + DashboardPageContent)
+      DashboardPageDetailPane (if detail pane configured)
+        AnimatePresence
+          DashboardPageDetailPaneTransition
+            Motion[translateX] (slide in/out)
+              resize handle (if resizable)
+              detail-pane slot content
+```
+
+## Styling
+
+**Style file:** `detailPane.style.ts` -- uses `tv()` (Tailwind Variants) for detail pane styling.
+
+**tv() slots:**
+
+| Slot | Description |
+|------|-------------|
+| `pane` | The detail pane container. Positioning, border, shadow. |
+| `resizeHandle` | The draggable resize handle on the left edge. |
+| `resizeHandleBar` | The visual bar inside the resize handle. |
+
+**Variants (in tv):**
+
+| Variant | `pane` classes | `resizeHandle` classes |
+|---------|----------------|------------------------|
+| `bordered-inline` | `inset-y-2 right-2 rounded-lg border shadow-floating` | `-inset-y-2` |
+| `bordered-overlay` | `inset-y-2 right-2 rounded-lg border shadow-floating` | `-inset-y-2` |
+| `full-height-inline` | `inset-y-0 right-0 h-full border-l` | `inset-y-0` |
+| `full-height-overlay` | `inset-y-0 right-0 h-full border-l` | `inset-y-0` |
+
+**Detail pane dimensions:** Default width `20rem`, min `16rem`, max `25rem`. Resizable via pointer drag or Arrow Left/Right keyboard.
+
+## Common Mistakes
+
+### HIGH: Missing title causes accessibility warning
+
+Wrong:
+```vue
+<UIDashboardPage :title="null">
+  <!-- No h1 anywhere in the page -->
+</UIDashboardPage>
+```
+
+Correct:
+```vue
+<UIDashboardPage :title="null">
+  <template #title>
+    <h1 class="text-sm font-medium">Custom Title</h1>
+  </template>
+  <UIDashboardPageContent>...</UIDashboardPageContent>
+</UIDashboardPage>
+```
+
+The component warns in `onMounted` if no `<h1>` element is found on the page. When passing `title: null`, provide a custom title via the `#title` slot.
+
+### HIGH: Providing detail-pane prop without the slot
+
+Wrong:
+```vue
+<UIDashboardPage
+  :detail-pane="{ variant: 'bordered-overlay' }"
+  title="Users"
+>
+  <!-- no #detail-pane slot -->
+</UIDashboardPage>
+```
+
+Correct:
+```vue
+<UIDashboardPage
+  :detail-pane="{ variant: 'bordered-overlay' }"
+  title="Users"
+>
+  <UIDashboardPageContent>...</UIDashboardPageContent>
+  <template #detail-pane>
+    <div>Detail content</div>
+  </template>
+</UIDashboardPage>
+```
+
+The detail pane only renders when both the `detailPane` prop is non-null AND the `#detail-pane` slot is provided.
+
+### MEDIUM: Using DashboardPageContent without DashboardPage
+
+Wrong:
+```vue
+<UIDashboardPageContent>
+  <p>Content</p>
+</UIDashboardPageContent>
+```
+
+Correct:
+```vue
+<UIDashboardPage title="Page">
+  <UIDashboardPageContent>
+    <p>Content</p>
+  </UIDashboardPageContent>
+</UIDashboardPage>
+```
+
+`UIDashboardPageContent` relies on `DetailPaneContext` for right-margin animation. Without `UIDashboardPage`, the context is missing (though it handles the null case gracefully with 0px padding).
+
+## Accessibility
+
+- Renders a `<main id="main-content">` landmark via the internal `Page` component.
+- The header renders as a `<header>` element with proper `<h1>` for the page title.
+- When breadcrumbs are present AND a title is set, a screen-reader-only `<h1>` is rendered to maintain heading hierarchy.
+- The detail pane toggle uses `reka-ui Toggle` with `aria-label` that changes between "expand" and "collapse".
+- The detail pane toggle tooltip shows the `Meta+I` keyboard shortcut.
+- The sidebar toggle in the header uses `reka-ui Toggle` with an `aria-label` and a `Meta+B` keyboard shortcut.
+- The detail pane resize handle has `role="separator"`, `aria-orientation="vertical"`, and `tabindex="0"` for keyboard accessibility. Arrow Left/Right keys resize the pane.
+- On small screens (< 1024px), header actions wrap to a second row for better mobile UX.
+- Reduced motion is respected throughout: all spring animations use duration 0 when `prefers-reduced-motion` is enabled.
+
+## See Also
+
+- [UIMainSidebar](../sidebar/) -- Navigation sidebar that pairs with the dashboard page
+- [UILayout](../layout/) -- The outer shell (MainLayoutContainer + MainContent) that wraps the page
+- [UIRowLayout](../row-layout/) -- Used extensively inside the page header
+- [Layout System](../../foundations/layout-system/) -- Foundation overview of the full layout architecture

--- a/packages/web/design-system/skills/components/popover/SKILL.md
+++ b/packages/web/design-system/skills/components/popover/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: popover
+description: >
+  A floating content panel anchored to a trigger element. Built on Reka UI PopoverRoot
+  with configurable alignment, side, collision handling, and animated open/close transitions.
+  Load this skill when you need interactive floating panels that appear on click.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: overlay
+requires:
+  - overlay-system
+exports:
+  - UIPopover
+  - UIPopoverProps
+---
+
+# UIPopover
+
+A floating content panel that appears anchored to a trigger element when clicked.
+
+## When to Use
+
+- Displaying interactive content (forms, actions, filters) attached to a trigger button
+- Building custom dropdown-like panels with arbitrary content
+- Showing contextual information that requires user interaction (not just hover)
+
+**Use instead:** `UITooltip` for hover-only informational text, `UIDropdownMenu` for menu item lists, `UIDialog` for large or blocking content.
+
+## Import
+
+```ts
+import { UIPopover } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIPopover, UIButton } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIPopover>
+    <template #trigger>
+      <UIButton label="Open popover" />
+    </template>
+    <template #content>
+      <div class="p-md">
+        <p class="text-sm text-secondary">Popover content here</p>
+      </div>
+    </template>
+  </UIPopover>
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isOpen` | `boolean` | `false` | Controls the open state (v-model). |
+| `isPopoverArrowVisible` | `boolean` | `false` | Shows an arrow pointing to the trigger. |
+| `popoverAlign` | `'center' \| 'start' \| 'end'` | `'center'` | Alignment of the popover relative to the trigger. |
+| `popoverAlignOffset` | `number` | `0` | Offset in pixels from the alignment edge. |
+| `popoverAnchorReferenceElement` | `ReferenceElement \| null` | `null` | Custom anchor element. If null, uses the trigger. |
+| `popoverAnimationName` | `string \| null` | `null` | Custom animation name. Falls back to `'popover-default'`. |
+| `popoverCollisionPadding` | `number` | `0` | Padding in pixels for collision detection. |
+| `popoverContainerElement` | `HTMLElement \| null` | `null` | Boundary element for collision detection. |
+| `popoverSide` | `'top' \| 'right' \| 'bottom' \| 'left'` | `'top'` | Which side of the trigger the popover appears on. |
+| `popoverSideOffset` | `number` | `0` | Distance in pixels between the popover and the trigger. |
+| `popoverWidth` | `'anchor-width' \| 'available-width' \| null` | `null` | Width behavior: match trigger width, fill available space, or use natural width. |
+| `disableSideFlip` | `boolean` | `false` | Disables flipping to the opposite side when insufficient space. |
+| `disableUpdateOnLayoutShift` | `boolean` | `false` | Disables repositioning on layout shifts. |
+| `prioritizePosition` | `boolean` | `false` | Constrains the content to remain within the viewport, even if it overlaps the trigger. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `trigger` | The element that toggles the popover. Must be a single root element. |
+| `content` | The content rendered inside the popover panel. |
+
+### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `update:isOpen` | `boolean` | Fired when the open state changes. |
+| `escapeKeyDown` | `KeyboardEvent` | Fired when Escape is pressed while open. |
+| `focusOutside` | `CustomEvent` | Fired when focus moves outside the popover. |
+| `interactOutside` | `CustomEvent` | Fired when an interaction occurs outside the popover. |
+| `autoFocusOnClose` | `Event` | Fired when auto-focus triggers on close. Call `event.preventDefault()` to prevent. |
+
+## Variants
+
+This component has no size/variant options. Appearance is controlled through content styling and positioning props.
+
+## Examples
+
+### Controlled Open State
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIPopover, UIButton } from '@wisemen/vue-core-design-system'
+
+const isOpen = ref(false)
+</script>
+
+<template>
+  <UIPopover v-model:is-open="isOpen" popover-side="bottom" :popover-side-offset="4">
+    <template #trigger>
+      <UIButton label="Toggle" />
+    </template>
+    <template #content>
+      <div class="p-md">
+        <p class="text-sm text-secondary">Controlled popover</p>
+      </div>
+    </template>
+  </UIPopover>
+</template>
+```
+
+### With Arrow and Custom Alignment
+
+```vue
+<script setup lang="ts">
+import { UIPopover, UIButton } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIPopover
+    :is-popover-arrow-visible="true"
+    popover-side="bottom"
+    popover-align="start"
+    :popover-side-offset="4"
+  >
+    <template #trigger>
+      <UIButton label="With arrow" />
+    </template>
+    <template #content>
+      <div class="p-md">
+        <p class="text-sm text-secondary">Arrow points to the trigger</p>
+      </div>
+    </template>
+  </UIPopover>
+</template>
+```
+
+### Matching Trigger Width
+
+```vue
+<UIPopover popover-width="anchor-width" popover-side="bottom">
+  <template #trigger>
+    <UIButton label="Full width popover" />
+  </template>
+  <template #content>
+    <div class="p-md">
+      <p class="text-sm text-secondary">This popover matches the trigger width</p>
+    </div>
+  </template>
+</UIPopover>
+```
+
+## Anatomy
+
+```
+UIPopover
+├── RekaPopoverRoot (v-model:open)
+│   ├── RekaPopoverAnchor
+│   │   └── RekaPopoverTrigger (as-child)
+│   │       └── <slot name="trigger" />
+│   └── RekaPopoverPortal (to="body")
+│       └── ThemeProvider
+│           └── RekaPopoverContent (positioned, animated)
+│               ├── <div> (border, bg, shadow container)
+│               │   └── <slot name="content" />
+│               └── PopoverArrow (if isPopoverArrowVisible)
+```
+
+## Styling
+
+**Style file:** No separate style file. Styles are inline Tailwind classes in `Popover.vue`.
+**Content container:** `rounded-md border border-secondary bg-primary shadow-lg`
+**Animations:** CSS keyframes `popoverFadeIn*` / `popoverFadeOut*` with direction-aware transitions (top/right/bottom/left). Duration: 100ms ease-in-out.
+**Z-index:** `z-40` on the content wrapper.
+
+## Common Mistakes
+
+### MEDIUM: Forgetting as-child behavior on the trigger
+
+Wrong:
+```vue
+<template #trigger>
+  <div>
+    <UIButton label="Open" />
+  </div>
+</template>
+```
+
+The trigger slot uses `as-child`, so it expects a single root element that receives the click handler. Wrapping in a div breaks the trigger behavior.
+
+Correct:
+```vue
+<template #trigger>
+  <UIButton label="Open" />
+</template>
+```
+
+### LOW: Not setting popoverSideOffset
+
+Without an offset, the popover sits flush against the trigger. Add a small offset for visual breathing room:
+
+```vue
+<UIPopover :popover-side-offset="4" popover-side="bottom">
+```
+
+## Accessibility
+
+- Built on Reka UI Popover primitives which handle ARIA attributes automatically.
+- Escape key closes the popover.
+- Focus is trapped within the popover content while open.
+- Focus returns to the trigger on close (controllable via `autoFocusOnClose` event).
+- The trigger receives appropriate `aria-expanded` and `aria-haspopup` attributes.
+
+## See Also
+
+- [tooltip](../tooltip/SKILL.md) -- For hover-only informational content
+- [dropdown-menu](../dropdown-menu/SKILL.md) -- For menu item lists
+- [overlay-system](../../foundations/overlay-system/SKILL.md) -- useOverlay API for imperative overlays

--- a/packages/web/design-system/skills/components/popover/SKILL.md
+++ b/packages/web/design-system/skills/components/popover/SKILL.md
@@ -6,7 +6,6 @@ description: >
   Load this skill when you need interactive floating panels that appear on click.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: overlay
 requires:
   - overlay-system

--- a/packages/web/design-system/skills/components/radio-group/SKILL.md
+++ b/packages/web/design-system/skills/components/radio-group/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: radio-group
+description: >
+  A radio group for single-value selection from multiple options. Built on
+  Reka UI RadioGroupRoot with context-based item registration. Supports
+  standard radio items and card-style items with descriptions. Includes
+  vertical/horizontal orientation and disabled state with reason tooltip.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: form-control
+requires:
+  - input-system
+exports:
+  - UIRadioGroup
+  - UIRadioGroupItem
+  - UIRadioGroupItemProps
+---
+
+# UIRadioGroup
+
+A radio group for selecting a single value from multiple options, with support for standard and card-style items.
+
+## When to Use
+
+- Selecting exactly one option from a small set (2-7 options)
+- When all options should be visible at once (not hidden in a dropdown)
+- When options benefit from descriptions (card variant)
+
+**Use instead:** [UISelect](../select/SKILL.md) for larger option sets or when space is constrained (dropdown), [UICheckboxGroup](../checkbox-group/SKILL.md) for multi-select, [UISwitch](../switch/SKILL.md) for binary on/off toggles.
+
+## Import
+
+```ts
+import { UIRadioGroup, UIRadioGroupItem } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIRadioGroup, UIRadioGroupItem } from '@wisemen/vue-core-design-system'
+
+const plan = ref<string | null>(null)
+</script>
+
+<template>
+  <UIRadioGroup v-model="plan">
+    <div class="flex flex-col gap-sm">
+      <UIRadioGroupItem value="basic" label="Basic" />
+      <UIRadioGroupItem value="pro" label="Pro" />
+      <UIRadioGroupItem value="enterprise" label="Enterprise" />
+    </div>
+  </UIRadioGroup>
+</template>
+```
+
+## API
+
+### UIRadioGroup (Root) Props
+
+> Inherits from: `Input`, `InputWrapper` (see [input-system](../../foundations/input-system/SKILL.md))
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `orientation` | `'horizontal' \| 'vertical'` | `'vertical'` | Controls the keyboard navigation direction of the radio group. |
+
+### UIRadioGroup v-model
+
+| Model | Type | Required | Description |
+|-------|------|----------|-------------|
+| `modelValue` | `TValue` | Yes | The currently selected value. Generic type `TValue` extends `AcceptableValue`. |
+
+### UIRadioGroupItem Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `id` | `string \| null` | `null` | The id of the radio item element. |
+| `isDisabled` | `boolean` | `false` | Disables this individual radio item. |
+| `disabledReason` | `string \| null` | `null` | Tooltip shown on hover when this item is disabled. |
+| `isLabelHidden` | `boolean` | `false` | Visually hides the label (sr-only). Useful for custom card layouts. |
+| `description` | `string \| null` | `null` | Description text displayed below the label. |
+| `label` | `string` | **required** | Label text displayed next to the radio indicator. |
+| `value` | `AcceptableInputValue` | **required** | The value this radio item represents. |
+
+### Slots
+
+| Component | Slot | Description |
+|-----------|------|-------------|
+| UIRadioGroup | `default` | Place UIRadioGroupItem components here. |
+
+### Emits
+
+| Component | Event | Payload | Description |
+|-----------|-------|---------|-------------|
+| UIRadioGroupItem | `blur` | none | Emitted when the radio item loses focus. |
+| UIRadioGroupItem | `focus` | none | Emitted when the radio item gains focus. |
+
+## Variants
+
+### Orientation
+
+| Value | Behavior |
+|-------|----------|
+| `vertical` | Keyboard navigation uses Up/Down arrow keys. Default. |
+| `horizontal` | Keyboard navigation uses Left/Right arrow keys. |
+
+Note: Like UICheckboxGroup, the `orientation` prop controls keyboard navigation only. Visual layout must be handled with CSS.
+
+## Examples
+
+### Basic Usage
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIRadioGroup, UIRadioGroupItem } from '@wisemen/vue-core-design-system'
+
+const color = ref<string | null>(null)
+</script>
+
+<template>
+  <UIRadioGroup v-model="color">
+    <div class="flex flex-col gap-sm">
+      <UIRadioGroupItem value="red" label="Red" />
+      <UIRadioGroupItem value="green" label="Green" />
+      <UIRadioGroupItem value="blue" label="Blue" />
+    </div>
+  </UIRadioGroup>
+</template>
+```
+
+### With Formango
+
+```vue
+<script setup lang="ts">
+import { useForm } from '@wisemen/formango'
+import { UIRadioGroup, UIRadioGroupItem } from '@wisemen/vue-core-design-system'
+import { z } from 'zod'
+
+const { form } = useForm({
+  schema: z.object({
+    plan: z.enum(['basic', 'pro', 'enterprise'], {
+      errorMap: () => ({ message: 'Please select a plan' }),
+    }),
+  }),
+  onSubmit(values) {
+    console.log(values)
+  },
+})
+
+const plan = form.register('plan')
+</script>
+
+<template>
+  <UIRadioGroup v-model="plan.modelValue.value">
+    <div class="flex flex-col gap-sm">
+      <UIRadioGroupItem value="basic" label="Basic" />
+      <UIRadioGroupItem value="pro" label="Pro" />
+      <UIRadioGroupItem value="enterprise" label="Enterprise" />
+    </div>
+  </UIRadioGroup>
+</template>
+```
+
+### With Descriptions
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIRadioGroup, UIRadioGroupItem } from '@wisemen/vue-core-design-system'
+
+const plan = ref<string | null>(null)
+</script>
+
+<template>
+  <UIRadioGroup v-model="plan">
+    <div class="flex flex-col gap-sm">
+      <UIRadioGroupItem
+        value="basic"
+        label="Basic plan"
+        description="Includes up to 10 users"
+      />
+      <UIRadioGroupItem
+        value="pro"
+        label="Pro plan"
+        description="Includes up to 50 users"
+      />
+      <UIRadioGroupItem
+        value="enterprise"
+        label="Enterprise plan"
+        description="Unlimited users"
+      />
+    </div>
+  </UIRadioGroup>
+</template>
+```
+
+### Horizontal Layout
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIRadioGroup, UIRadioGroupItem } from '@wisemen/vue-core-design-system'
+
+const size = ref<string | null>(null)
+</script>
+
+<template>
+  <UIRadioGroup v-model="size" orientation="horizontal">
+    <div class="flex items-center gap-lg">
+      <UIRadioGroupItem value="sm" label="Small" />
+      <UIRadioGroupItem value="md" label="Medium" />
+      <UIRadioGroupItem value="lg" label="Large" />
+    </div>
+  </UIRadioGroup>
+</template>
+```
+
+### Disabled with Reason
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIRadioGroup, UIRadioGroupItem } from '@wisemen/vue-core-design-system'
+
+const plan = ref<string | null>(null)
+</script>
+
+<template>
+  <UIRadioGroup
+    v-model="plan"
+    :is-disabled="true"
+    disabled-reason="You don't have permission to change this setting"
+  >
+    <div class="flex flex-col gap-sm">
+      <UIRadioGroupItem value="basic" label="Basic" />
+      <UIRadioGroupItem value="pro" label="Pro" />
+    </div>
+  </UIRadioGroup>
+</template>
+```
+
+## Anatomy
+
+```
+ActionTooltip                    (shows disabledReason when group is disabled)
+└── RekaRadioGroupRoot           (Reka UI, manages single-value selection)
+    └── slot#default
+        └── UIRadioGroupItem (one per option)
+            └── BaseRadioGroup
+                └── ActionTooltip  (per-item disabledReason)
+                    └── RekaRadioGroupItem
+                        └── RowLayout
+                            ├── div.control          (circular radio indicator)
+                            │   └── RadioGroupIndicator  (animated dot)
+                            └── ColumnLayout
+                                ├── UIText (label)
+                                └── UIText (description, optional)
+```
+
+## Styling
+
+**Style file:** `src/ui/radio-group/base/baseRadioGroup.style.ts`
+**tv() slots:**
+- `root` -- The clickable radio item wrapper. Flex layout with cursor and disabled styles.
+- `cardRoot` -- Alternative card-style wrapper with border, padding, and active state highlight.
+- `control` -- The 16x16 circular radio indicator. Includes checked (brand color fill), disabled, error, and focus-visible states.
+- `indicator` -- The inner dot (6x6 white circle) with spring animation on selection.
+- `label` -- The label text. Medium weight, primary color.
+- `description` -- The description text. Tertiary color, smaller size.
+
+The radio indicator uses Motion (motion-v) with spring animation for the dot appearance.
+
+## Common Mistakes
+
+### CRITICAL: Not wrapping items in a layout container
+
+The UIRadioGroup renders a bare `<slot />` with no layout. You must provide your own flex/grid wrapper:
+
+Wrong:
+```vue
+<UIRadioGroup v-model="val">
+  <UIRadioGroupItem value="a" label="A" />
+  <UIRadioGroupItem value="b" label="B" />
+  <!-- Items stack with no gap -->
+</UIRadioGroup>
+```
+
+Correct:
+```vue
+<UIRadioGroup v-model="val">
+  <div class="flex flex-col gap-sm">
+    <UIRadioGroupItem value="a" label="A" />
+    <UIRadioGroupItem value="b" label="B" />
+  </div>
+</UIRadioGroup>
+```
+
+### HIGH: Confusing orientation with visual layout
+
+The `orientation` prop only affects keyboard navigation (arrow key direction), NOT visual layout. Setting `orientation="horizontal"` does NOT arrange items in a row -- you must add `flex-row` yourself.
+
+### MEDIUM: Using UIRadioGroup for multi-select
+
+UIRadioGroup is for single selection only. If you need multi-select, use [UICheckboxGroup](../checkbox-group/SKILL.md).
+
+## Accessibility
+
+- Reka UI RadioGroupRoot handles `role="radiogroup"`, `aria-orientation`
+- Each RadioGroupItem gets `role="radio"`, `aria-checked`
+- Keyboard: Arrow keys navigate between items, Space/Enter selects the focused item
+- `orientation` prop maps to `aria-orientation` and determines which arrow keys navigate
+- Disabled state propagates from the group to all items
+- Per-item `disabledReason` shows tooltip on hover via ActionTooltip
+- `data-invalid` attribute on items when parent has error, driving error border styles
+- The `isLabelHidden` prop renders the label with `sr-only` for screen reader accessibility in custom layouts
+
+## See Also
+
+- [input-system](../../foundations/input-system/SKILL.md) -- Inherited props and architecture
+- [checkbox-group](../checkbox-group/SKILL.md) -- Multi-value selection
+- [select](../select/SKILL.md) -- Single selection in a dropdown

--- a/packages/web/design-system/skills/components/radio-group/SKILL.md
+++ b/packages/web/design-system/skills/components/radio-group/SKILL.md
@@ -7,7 +7,6 @@ description: >
   vertical/horizontal orientation and disabled state with reason tooltip.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: form-control
 requires:
   - input-system

--- a/packages/web/design-system/skills/components/row-layout/SKILL.md
+++ b/packages/web/design-system/skills/components/row-layout/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: row-layout
+description: >
+  Horizontal flex container with configurable gap, alignment, and justification using
+  design-token spacing. Renders as a customizable HTML element and provides a default
+  slot for child content. Use for any horizontal arrangement of elements.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: layout
+requires:
+  - layout-system
+exports:
+  - UIRowLayout
+---
+
+# UIRowLayout
+
+Horizontal flex container with token-based gap, cross-axis alignment, and main-axis justification.
+
+## When to Use
+
+- Placing buttons, badges, or controls side by side with consistent spacing
+- Building action bars, toolbars, or inline form layouts
+- Any horizontal arrangement where you need design-token spacing rather than raw Tailwind
+
+**Use instead:** `UIColumnLayout` for vertical stacking. A plain `div` with `flex` when you need wrapping or non-standard flex behavior.
+
+## Import
+
+```ts
+import { UIRowLayout } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIRowLayout, UIButton } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIRowLayout gap="lg" align="center" justify="between">
+    <UIButton label="Cancel" variant="secondary" />
+    <UIButton label="Save" />
+  </UIRowLayout>
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `align` | `'baseline' \| 'center' \| 'end' \| 'start'` | `'center'` | Cross-axis (vertical) alignment of items. |
+| `as` | `string` | `'div'` | The HTML element to render as the container. |
+| `gap` | `LayoutGap` | `'md'` | Spacing between items. See gap scale below. |
+| `justify` | `'between' \| 'center' \| 'end' \| 'start'` | `'start'` | Main-axis (horizontal) distribution of items. |
+
+**`LayoutGap` values:** `'none'` | `'xxs'` | `'xs'` | `'sm'` | `'md'` | `'lg'` | `'xl'` | `'2xl'` | `'3xl'` | `'4xl'` | `'5xl'` | `'6xl'` | `'7xl'` | `'8xl'` | `'9xl'` | `'10xl'` | `'11xl'`
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Child elements arranged horizontally. |
+
+### Emits
+
+No custom events.
+
+## Variants
+
+This component has no visual variants. All appearance is controlled via props (`gap`, `align`, `justify`).
+
+## Examples
+
+### Space Between with Large Gap
+
+```vue
+<script setup lang="ts">
+import { UIRowLayout, UIButton } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIRowLayout gap="lg" justify="between" class="w-full">
+    <UIButton label="Hello" />
+    <UIButton label="Hi there" variant="secondary" />
+    <UIButton label="Morning" variant="tertiary" />
+  </UIRowLayout>
+</template>
+```
+
+### Center Justified
+
+```vue
+<script setup lang="ts">
+import { UIRowLayout, UIButton } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIRowLayout gap="md" justify="center" class="w-full">
+    <UIButton label="Ping" />
+    <UIButton label="Pong" variant="secondary" />
+  </UIRowLayout>
+</template>
+```
+
+### Rendered as a Section Element
+
+```vue
+<script setup lang="ts">
+import { UIRowLayout } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIRowLayout as="section" gap="xl" align="start">
+    <div>Block A</div>
+    <div>Block B</div>
+  </UIRowLayout>
+</template>
+```
+
+## Anatomy
+
+```
+Component[as] .flex.flex-row .[alignClass] .[justifyClass] .[gapClass]
+  <slot />
+```
+
+## Styling
+
+**Style file:** No separate style file. Uses inline Tailwind classes mapped from props.
+**CSS classes:** `flex flex-row` is always applied. Alignment, justification, and gap classes are computed from props (e.g., `items-center`, `justify-between`, `gap-lg`).
+
+## Common Mistakes
+
+### MEDIUM: Using raw Tailwind flex instead of UIRowLayout
+
+Wrong:
+```html
+<div class="flex flex-row items-center gap-4">
+  <button>A</button>
+  <button>B</button>
+</div>
+```
+
+Correct:
+```vue
+<UIRowLayout gap="xl" align="center">
+  <UIButton label="A" />
+  <UIButton label="B" />
+</UIRowLayout>
+```
+
+UIRowLayout uses design-token spacing (`gap-md`, `gap-lg`, etc.) to ensure consistency across the application.
+
+### LOW: Expecting wrap behavior
+
+UIRowLayout does not wrap by default and has no `wrap` prop. If you need flex-wrap, use a raw `div` with Tailwind classes or extend the component.
+
+## Accessibility
+
+- Renders a semantic HTML element (default `div`, customizable via `as`).
+- No ARIA attributes are added; rely on the semantic meaning of `as` (e.g., `nav`, `section`) when appropriate.
+- Keyboard navigation depends on the child elements, not the layout container.
+
+## See Also
+
+- [UIColumnLayout](../column-layout/) -- Vertical flex container with the same gap/align/justify API
+- [Layout System](../../foundations/layout-system/) -- Foundation overview of all layout primitives

--- a/packages/web/design-system/skills/components/row-layout/SKILL.md
+++ b/packages/web/design-system/skills/components/row-layout/SKILL.md
@@ -6,7 +6,6 @@ description: >
   slot for child content. Use for any horizontal arrangement of elements.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: layout
 requires:
   - layout-system

--- a/packages/web/design-system/skills/components/scrollable/SKILL.md
+++ b/packages/web/design-system/skills/components/scrollable/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: scrollable
+description: >
+  Scrollable container that shows gradient fade indicators at the top/bottom when content
+  overflows. Supports infinite scroll via an onNext callback. Load this skill when building
+  scrollable lists, panels, or any container that needs visual scroll cues.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: layout
+requires: []
+exports:
+  - UIScrollable
+---
+
+# UIScrollable
+
+A scrollable container that renders gradient overlays at the top and bottom edges when the user scrolls, providing visual cues that more content exists. Optionally triggers infinite-scroll loading via `onNext`.
+
+## When to Use
+
+- Wrapping a list or panel that may overflow its container and needs scroll-fade indicators
+- Building an infinite-scroll list that fetches the next page when the user nears the bottom
+- Any container where you want subtle visual cues that content extends beyond the visible area
+
+**Use instead:** A plain `overflow-auto` div when you do not need gradient indicators or infinite scroll.
+
+## Import
+
+```ts
+import { UIScrollable } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIScrollable } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIScrollable>
+    <div v-for="i in 100" :key="i">
+      Item {{ i }}
+    </div>
+  </UIScrollable>
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `as` | `string \| Component` | `'div'` | The HTML element or Vue component used for the scrollable inner container. |
+| `distance` | `number` | `250` | Pixel distance from the bottom at which `onNext` is triggered (infinite scroll threshold). |
+| `onNext` | `() => Promise<void> \| void` | `undefined` | Callback invoked when the user scrolls within `distance` pixels of the bottom. Use for pagination / infinite scroll. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Content rendered inside the scrollable area. |
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+This component has no size/variant/color options.
+
+## Examples
+
+### Infinite Scroll
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIScrollable } from '@wisemen/vue-core-design-system'
+
+const items = ref<string[]>(Array.from({ length: 20 }, (_, i) => `Item ${i + 1}`))
+
+async function loadMore(): Promise<void> {
+  const start = items.value.length
+  const next = Array.from({ length: 20 }, (_, i) => `Item ${start + i + 1}`)
+  items.value.push(...next)
+}
+</script>
+
+<template>
+  <div class="h-64">
+    <UIScrollable :on-next="loadMore" :distance="200">
+      <div v-for="item in items" :key="item" class="p-2">
+        {{ item }}
+      </div>
+    </UIScrollable>
+  </div>
+</template>
+```
+
+### Custom Element Type
+
+```vue
+<script setup lang="ts">
+import { UIScrollable } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIScrollable as="ul">
+    <li v-for="i in 50" :key="i">
+      List item {{ i }}
+    </li>
+  </UIScrollable>
+</template>
+```
+
+## Anatomy
+
+```
+div.relative.flex.size-full.flex-col.overflow-hidden
+  div (top gradient, shown when scrolled from top)
+  div (bottom gradient, shown when scrolled from bottom)
+  Primitive[as] .overflow-auto  (scrollable content)
+    <slot />
+```
+
+## Styling
+
+**Style file:** This component uses inline Tailwind classes (no separate style file).
+**Gradient overlays:** `from-primary to-transparent`, height `h-8`, positioned absolute at top/bottom with `z-1`.
+
+The gradients use `bg-linear-to-b` (top) and `bg-linear-to-t` (bottom) with the `from-primary` color token, so they blend with the page background.
+
+## Common Mistakes
+
+### MEDIUM: Forgetting to set a fixed height on the parent
+
+Wrong:
+```vue
+<UIScrollable>
+  <!-- Content will never overflow because the container grows unbounded -->
+  <div v-for="i in 100" :key="i">{{ i }}</div>
+</UIScrollable>
+```
+
+Correct:
+```vue
+<div class="h-64">
+  <UIScrollable>
+    <div v-for="i in 100" :key="i">{{ i }}</div>
+  </UIScrollable>
+</div>
+```
+
+UIScrollable uses `size-full` on its root, so it fills its parent. The parent must have a constrained height for overflow to occur and gradients to appear.
+
+### LOW: Passing an async onNext without handling errors
+
+Wrong:
+```vue
+<UIScrollable :on-next="fetchNextPage" />
+```
+
+Correct:
+```vue
+<UIScrollable :on-next="handleLoadMore" />
+```
+
+```ts
+async function handleLoadMore(): Promise<void> {
+  try {
+    await fetchNextPage()
+  } catch (error) {
+    // handle error gracefully
+  }
+}
+```
+
+Unhandled promise rejections in `onNext` can silently break infinite scroll. Wrap async logic in try/catch.
+
+## Accessibility
+
+- The scrollable area is a plain `div` (or custom `as` element) with native browser scrolling.
+- Gradient overlays are `pointer-events-none`, so they do not block interaction with content beneath them.
+- The component relies on native scroll behavior, which is keyboard-accessible by default (arrow keys, Page Up/Down, Home/End).
+
+## See Also
+
+- [UIColumnLayout](../column-layout/) -- For stacking content vertically with consistent gap spacing

--- a/packages/web/design-system/skills/components/scrollable/SKILL.md
+++ b/packages/web/design-system/skills/components/scrollable/SKILL.md
@@ -6,7 +6,6 @@ description: >
   scrollable lists, panels, or any container that needs visual scroll cues.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: layout
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/select/SKILL.md
+++ b/packages/web/design-system/skills/components/select/SKILL.md
@@ -6,7 +6,6 @@ description: >
   Determines single vs multi mode from the v-model type (value vs array).
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: input
 requires:
   - input-system

--- a/packages/web/design-system/skills/components/select/SKILL.md
+++ b/packages/web/design-system/skills/components/select/SKILL.md
@@ -1,0 +1,567 @@
+---
+name: select
+description: >
+  Dropdown select component supporting single and multi-select modes with optional
+  search (local or remote), pagination, and rich option rendering via getItemConfig.
+  Determines single vs multi mode from the v-model type (value vs array).
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: input
+requires:
+  - input-system
+exports:
+  - UISelect
+  - UISelectContent
+  - UISelectDropdown
+  - UISelectOption
+  - UISelectProps
+  - SelectValue
+  - SelectItem
+  - SelectOptionItem
+  - SelectSeparatorItem
+  - SelectOptionConfig
+  - SelectOptionAvatarConfig
+  - SelectOptionRightConfig
+  - createSelectOptions
+---
+
+# UISelect
+
+A dropdown select that supports single-select, multi-select, optional search filtering, pagination, and rich option rendering. Single vs multi mode is determined by the v-model type: pass a single value for single-select, pass an array for multi-select.
+
+## When to Use
+
+- When the user must pick one or more values from a predefined list without typing free text
+- When options need rich decoration (avatars, icons, dots, descriptions, shortcuts)
+- When the list is paginated and requires infinite scroll
+
+**Use instead:** `UIAutocomplete` when the user should type to search (combobox pattern); a `UIRadioGroup` or `UICheckboxGroup` when all options should be visible at once.
+
+## Import
+
+```ts
+import { UISelect, createSelectOptions } from '@wisemen/vue-core-design-system'
+import type { SelectValue, SelectItem } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UISelect, createSelectOptions } from '@wisemen/vue-core-design-system'
+
+const items = createSelectOptions(['Apple', 'Banana', 'Cherry', 'Mango'])
+const selected = ref<string | null>(null)
+
+function displayFn(value: string): string {
+  return value
+}
+</script>
+
+<template>
+  <UISelect
+    v-model="selected"
+    :display-fn="displayFn"
+    :items="items"
+    label="Fruit"
+    placeholder="Select a fruit..."
+    class="w-72"
+  />
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `modelValue` | `TValue` | required | The selected value (v-model). Pass a single `SelectValue` for single-select, or `SelectValue[]` for multi-select. |
+| `displayFn` | `(item: NonNullable<GetValue<TValue>>) => string` | required | Returns the display label for a value. Used in the trigger and in each dropdown option. |
+| `items` | `SelectItem<GetValue<TValue>>[]` | required | The items shown in the dropdown. Use `createSelectOptions()` to build this array. |
+| `search` | `'local' \| 'remote' \| null` | `null` | `null` disables search; `local` adds a filter input that filters client-side; `remote` adds a filter input that emits `update:search` for server-side filtering. |
+| `size` | `'sm' \| 'md'` | `'md'` | Controls trigger height and padding. |
+| `getItemConfig` | `((value: NonNullable<GetValue<TValue>>) => MenuItemConfig \| null) \| null` | `null` | Maps a value to visual config (avatar, icon, dot, description, right content). Used both in the trigger display and in each dropdown option. Required for paginated selects where the selected item may not be in the loaded page. |
+| `keepDropdownOpenOnSelect` | `boolean \| null` | `null` | `null` auto-closes for single-select and stays open for multi-select. `true` always keeps open; `false` always closes. |
+| `limit` | `number \| null` | `null` | When set, and the number of items equals this limit, a "more results available" hint is shown at the bottom of the dropdown. Use for non-paginated but backend-limited lists. |
+| `isDisabled` | `boolean` | `false` | Disables the select trigger. |
+| `isReadonly` | `boolean` | `false` | Makes the select read-only. |
+| `isRequired` | `boolean` | `false` | Marks the field as required (shows asterisk). |
+| `isLoading` | `boolean` | `false` | Shows a loading spinner in the trigger and skeleton items in the dropdown when empty. |
+| `label` | `string \| null` | `null` | Label displayed above the trigger. |
+| `placeholder` | `string \| null` | `null` | Placeholder text shown when no value is selected. |
+| `errorMessage` | `string \| null` | `null` | Error message below the trigger. |
+| `hideErrorMessage` | `boolean` | `false` | Hides the error message visually while keeping error styling. |
+| `hint` | `string \| null` | `null` | Hint text next to the label. |
+| `helpText` | `string \| null` | `null` | Help text in a tooltip next to the label. |
+| `iconLeft` | `Component \| null` | `null` | Icon on the left side of the trigger. |
+| `disabledReason` | `string \| null` | `null` | Tooltip explaining why the field is disabled. |
+| `popoverSide` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'bottom'` | Side where the dropdown appears. |
+| `popoverAlign` | `'start' \| 'center' \| 'end'` | `'center'` | Alignment of the dropdown. |
+| `popoverSideOffset` | `number` | `4` | Pixel offset between trigger and dropdown. |
+| `popoverCollisionPadding` | `number` | `8` | Padding from viewport edges. |
+| `popoverWidth` | `string` | `'anchor-width'` | Width strategy for the dropdown popover. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `label-left` | Content to the left of the label text. |
+| `label-right` | Content to the right of the label text. |
+| `left` | Content inside the field wrapper, to the left of the value display. |
+| `right` | Content inside the field wrapper, to the right of the value display. |
+| `value` | Override the selected value display in the trigger. Receives no props. Shown only when a value is selected. |
+
+### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `update:modelValue` | `TValue` | Fired when the selected value changes. |
+| `update:search` | `string` | Fired when the debounced search term changes (remote mode only). Emits `''` on dropdown close. |
+| `blur` | none | Fired when the dropdown closes. |
+| `nextPage` | none | Fired when the user scrolls near the bottom of the dropdown (for pagination / infinite scroll). |
+
+## Variants
+
+### Size
+
+- `md` (default) -- Standard trigger height with `px-md` padding.
+- `sm` -- Compact trigger height with `px-sm` padding.
+
+## Key Concepts
+
+### SelectValue Type
+
+```ts
+type SelectValue = number | string | Record<string, any> | null
+```
+
+Values can be primitives (string, number) or complex objects. The generic `TValue` is inferred from `v-model`: pass `string | null` for single-select with strings, pass `User | null` for single-select with objects, pass `string[]` for multi-select with strings.
+
+### createSelectOptions Utility
+
+Wraps a plain array of values into the required `SelectItem` format:
+
+```ts
+function createSelectOptions<TValue extends NonNullable<SelectValue>>(
+  options: TValue[],
+): SelectItem<TValue>[]
+
+// Usage:
+const items = createSelectOptions(['Apple', 'Banana', 'Cherry'])
+// Result: [{ type: 'option', value: 'Apple' }, { type: 'option', value: 'Banana' }, ...]
+```
+
+You can also build items manually to include separators:
+
+```ts
+const items: SelectItem<string>[] = [
+  { type: 'option', value: 'Apple' },
+  { type: 'option', value: 'Banana' },
+  { type: 'separator' },
+  { type: 'option', value: 'Cherry' },
+]
+```
+
+### Single vs Multi-Select
+
+The mode is determined entirely by the `v-model` type:
+
+```ts
+// Single-select: pass a single value or null
+const selected = ref<string | null>(null)
+
+// Multi-select: pass an array
+const selected = ref<string[]>([])
+```
+
+In multi-select mode:
+- Selected items are shown as truncatable badges in the trigger
+- Selected items are grouped at the top of the dropdown, separated from unselected items
+- The dropdown stays open after each selection (toggle behavior)
+
+### getItemConfig for Rich Options
+
+The `getItemConfig` function maps each value to a `MenuItemConfig`:
+
+```ts
+interface MenuItemConfig {
+  avatar?: { name: string; src?: string | null; imageAlt?: string | null } | null
+  description?: string | null
+  descriptionLayout?: 'block' | 'inline'
+  dot?: { color?: DotColor } | null
+  icon?: Component | null
+  label?: string | null
+  right?: MenuItemRightConfig | null
+}
+```
+
+This config is used both in the trigger (to display the selected value with its avatar/icon/dot) and in each dropdown option.
+
+## Examples
+
+### Single Select with Strings
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UISelect, createSelectOptions } from '@wisemen/vue-core-design-system'
+
+const items = createSelectOptions([
+  'Apple', 'Banana', 'Cherry', 'Mango', 'Orange', 'Strawberry',
+])
+const selected = ref<string | null>(null)
+
+function displayFn(value: string): string {
+  return value
+}
+</script>
+
+<template>
+  <UISelect
+    v-model="selected"
+    :display-fn="displayFn"
+    :items="items"
+    label="Fruit"
+    placeholder="Select a fruit..."
+    class="w-72"
+  />
+</template>
+```
+
+### Multi-Select with Strings
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UISelect, createSelectOptions } from '@wisemen/vue-core-design-system'
+
+const items = createSelectOptions([
+  'Apple', 'Banana', 'Cherry', 'Mango', 'Orange', 'Strawberry',
+])
+const selected = ref<string[]>([])
+
+function displayFn(value: string): string {
+  return value
+}
+</script>
+
+<template>
+  <UISelect
+    v-model="selected"
+    :display-fn="displayFn"
+    :items="items"
+    label="Fruits"
+    placeholder="Select fruits..."
+    class="w-72"
+  />
+</template>
+```
+
+### Single Select with Complex Objects and Item Config
+
+```vue
+<script setup lang="ts">
+import { Building01Icon } from '@wisemen/vue-core-icons'
+import { ref } from 'vue'
+import { UISelect, createSelectOptions } from '@wisemen/vue-core-design-system'
+import type { MenuItemConfig } from '@wisemen/vue-core-design-system'
+
+interface User {
+  id: number
+  name: string
+  email: string
+  avatarSrc?: string
+}
+
+const users: User[] = [
+  { id: 1, name: 'Alice Johnson', avatarSrc: 'https://i.pravatar.cc/150?u=alice', email: 'alice@example.com' },
+  { id: 2, name: 'Bob Smith', avatarSrc: 'https://i.pravatar.cc/150?u=bob', email: 'bob@example.com' },
+  { id: 3, name: 'Carol White', email: 'carol@example.com' },
+]
+
+const items = createSelectOptions(users)
+const selected = ref<User | null>(null)
+
+function displayFn(user: User): string {
+  return user.name
+}
+
+function getItemConfig(user: User): MenuItemConfig {
+  return {
+    description: user.email,
+    descriptionLayout: 'block',
+    dot: { color: 'pink' },
+    label: user.name,
+    right: { icon: Building01Icon, text: 'Wisemen', type: 'icon-text' },
+  }
+}
+</script>
+
+<template>
+  <UISelect
+    v-model="selected"
+    :display-fn="displayFn"
+    :items="items"
+    :get-item-config="getItemConfig"
+    label="User"
+    placeholder="Select a user..."
+    class="w-150"
+  />
+</template>
+```
+
+### With Local Search
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UISelect, createSelectOptions } from '@wisemen/vue-core-design-system'
+
+const items = createSelectOptions([
+  'Apple', 'Banana', 'Cherry', 'Mango', 'Orange', 'Strawberry',
+])
+const selected = ref<string | null>(null)
+
+function displayFn(value: string): string {
+  return value
+}
+</script>
+
+<template>
+  <UISelect
+    v-model="selected"
+    :display-fn="displayFn"
+    :items="items"
+    search="local"
+    label="Fruit"
+    placeholder="Select a fruit..."
+    class="w-72"
+  />
+</template>
+```
+
+### With Remote Search and Pagination
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UISelect, createSelectOptions } from '@wisemen/vue-core-design-system'
+import type { SelectItem } from '@wisemen/vue-core-design-system'
+
+interface Product {
+  id: string
+  name: string
+}
+
+const items = ref<SelectItem<Product>[]>([])
+const selected = ref<Product | null>(null)
+const isLoading = ref(false)
+let currentPage = 1
+
+function displayFn(product: Product): string {
+  return product.name
+}
+
+async function onSearch(search: string): Promise<void> {
+  isLoading.value = true
+  currentPage = 1
+  try {
+    const response = await fetchProducts({ search, page: 1 })
+    items.value = createSelectOptions(response.data)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function onNextPage(): Promise<void> {
+  currentPage++
+  const response = await fetchProducts({ page: currentPage })
+  items.value = [...items.value, ...createSelectOptions(response.data)]
+}
+</script>
+
+<template>
+  <UISelect
+    v-model="selected"
+    :display-fn="displayFn"
+    :items="items"
+    :is-loading="isLoading"
+    search="remote"
+    label="Product"
+    placeholder="Search products..."
+    class="w-72"
+    @update:search="onSearch"
+    @next-page="onNextPage"
+  />
+</template>
+```
+
+### Multi-Select with Item Config (Avatars)
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UISelect, createSelectOptions } from '@wisemen/vue-core-design-system'
+import type { MenuItemConfig } from '@wisemen/vue-core-design-system'
+
+interface User {
+  id: number
+  name: string
+  email: string
+  avatarSrc?: string
+}
+
+const users: User[] = [
+  { id: 1, name: 'Alice Johnson', avatarSrc: 'https://i.pravatar.cc/150?u=alice', email: 'alice@example.com' },
+  { id: 2, name: 'Bob Smith', avatarSrc: 'https://i.pravatar.cc/150?u=bob', email: 'bob@example.com' },
+  { id: 3, name: 'Carol White', email: 'carol@example.com' },
+]
+
+const items = createSelectOptions(users)
+const selected = ref<User[]>([])
+
+function displayFn(user: User): string {
+  return user.name
+}
+
+function getItemConfig(user: User): MenuItemConfig {
+  return {
+    avatar: { name: user.name, src: user.avatarSrc ?? null },
+    description: user.email,
+    descriptionLayout: 'block',
+  }
+}
+</script>
+
+<template>
+  <UISelect
+    v-model="selected"
+    :display-fn="displayFn"
+    :items="items"
+    :get-item-config="getItemConfig"
+    label="Users"
+    placeholder="Select users..."
+    class="w-150"
+  />
+</template>
+```
+
+## Anatomy
+
+```
+UISelect
+  InputWrapper (label, hint, error)
+    FieldWrapper (iconLeft, ChevronDownIcon, loading)
+      RowLayout (value display area)
+        BadgeGroupTruncate (multi-select: badges for each selected value)
+        RowLayout (single-select: avatar/icon/dot + label text)
+        UIText (placeholder, when nothing selected)
+      SelectDropdown
+        Popover
+          slot#trigger (invisible combobox button)
+          slot#content
+            SelectContent
+              RekaListboxRoot
+                RekaListboxFilter (search input, when search != null)
+                Scrollable (scroll + infinite-scroll)
+                  SelectOption (per item)
+                    RekaListboxItem
+                      UIMenuItem (avatar/icon/dot + label + check indicator)
+                  UISeparator (for separator items / selected-group divider)
+                  SelectLoading (skeleton, shown when loading + empty)
+                  "No results found" text
+                  "More results available" text (when items.length === limit)
+```
+
+## Styling
+
+This component uses inline Tailwind classes (no separate style file).
+
+**Trigger:** Inherits `FieldWrapper` styling. The chevron-down icon is always shown on the right. Multi-select badges use `BadgeGroupTruncate` with `size="sm"`, `color="gray"`, `variant="translucent"`.
+
+**Dropdown:** `rounded-md border border-secondary bg-primary shadow-lg`. The search input has `h-7 rounded-sm bg-secondary px-md text-xs`. Max height clamped to `min(--reka-popover-content-available-height, 32rem)`.
+
+**Options:** Keyboard-highlighted items get `bg-secondary-hover`. Selected items show a `CheckIcon` indicator.
+
+## Common Mistakes
+
+### HIGH: Passing a single value for multi-select or vice versa
+
+Wrong:
+```vue
+<!-- This creates a multi-select but you probably wanted single -->
+<script setup>
+const selected = ref<string[]>([])
+</script>
+<UISelect v-model="selected" ... />
+<!-- The dropdown stays open, badges appear, etc. -->
+```
+
+The select mode is inferred from the v-model type. Use `ref<string | null>(null)` for single-select and `ref<string[]>([])` for multi-select.
+
+### HIGH: Not providing getItemConfig for paginated selects
+
+Wrong:
+```vue
+<UISelect
+  v-model="selected"
+  :items="pagedItems"
+  :display-fn="displayFn"
+  search="remote"
+  @update:search="fetchPage"
+/>
+```
+
+Correct:
+```vue
+<UISelect
+  v-model="selected"
+  :items="pagedItems"
+  :display-fn="displayFn"
+  :get-item-config="getItemConfig"
+  search="remote"
+  @update:search="fetchPage"
+/>
+```
+
+When using pagination, the selected item may not be in the currently loaded page. Without `getItemConfig`, the trigger cannot display the avatar/icon/dot for the selected value because it only has `displayFn`. Always provide `getItemConfig` for paginated selects.
+
+### MEDIUM: Not wrapping items with createSelectOptions
+
+Wrong:
+```vue
+<UISelect :items="['Apple', 'Banana']" />
+```
+
+Correct:
+```vue
+<UISelect :items="createSelectOptions(['Apple', 'Banana'])" />
+```
+
+Items must be `SelectItem<TValue>[]` with a `type: 'option'` discriminator. Use `createSelectOptions()` to wrap plain values.
+
+### MEDIUM: Using search="local" with remote data
+
+When items come from an API, use `search="remote"` so the search term is emitted for server-side filtering. With `search="local"`, filtering happens client-side on the currently loaded items only.
+
+### LOW: Forgetting update:search emits empty string on close
+
+When `search="remote"`, the component emits `update:search` with `''` when the dropdown unmounts. Your search handler should handle this gracefully (e.g., reset to the initial page of results or no-op).
+
+## Accessibility
+
+- The trigger is a `<button>` with `role="combobox"`, `aria-expanded`, `aria-controls`, `aria-required`, `aria-invalid`, and `aria-busy` attributes.
+- The dropdown uses Reka UI's `ListboxRoot` with proper `role="listbox"` semantics.
+- Keyboard: Arrow Up/Down opens the dropdown and navigates options. Enter selects. Escape closes. Typing characters opens the dropdown.
+- Selected options show a check icon indicator via `RekaListboxItemIndicator`.
+- In multi-select, `selection-behavior="toggle"` allows toggling items on/off.
+- Error and hint messages are linked via `aria-describedby`.
+- A screen-reader-only `<span>` in the trigger announces the current value label.
+
+## See Also
+
+- [UIAutocomplete](../autocomplete/) -- For typeahead search where the user types to filter
+- [input-system](../../foundations/input-system/) -- Shared input infrastructure (InputWrapper, FieldWrapper, error/label/hint)

--- a/packages/web/design-system/skills/components/separator/SKILL.md
+++ b/packages/web/design-system/skills/components/separator/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: separator
+description: >
+  A horizontal or vertical divider line built on Reka UI's Separator primitive.
+  Supports horizontal and vertical orientations. Load this skill when you need
+  a visual divider between sections or inline elements.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UISeparator
+---
+
+# UISeparator
+
+A thin line that visually separates content sections, available in horizontal or vertical orientation.
+
+## When to Use
+
+- Dividing sections within a card or panel
+- Separating items in a horizontal toolbar or row
+- Creating a visual break between content blocks
+
+**Use instead:** A border class (e.g., `border-b border-secondary`) when you need a separator that is part of an element's styling rather than a standalone element.
+
+## Import
+
+```ts
+import { UISeparator } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UISeparator } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UISeparator />
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | The orientation of the separator. |
+| `class` | `string` | `undefined` | Additional CSS classes to apply to the separator. |
+
+### Slots
+
+This component has no slots.
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+### Orientation
+
+| Orientation | CSS Classes | Description |
+|-------------|-------------|-------------|
+| `horizontal` | `h-px w-full` | Full-width horizontal line (default) |
+| `vertical` | `h-full w-px` | Full-height vertical line |
+
+## Examples
+
+### Horizontal Separator
+
+```vue
+<script setup lang="ts">
+import { UISeparator } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex w-64 flex-col gap-sm">
+    <span class="text-sm text-primary">Section above</span>
+    <UISeparator />
+    <span class="text-sm text-primary">Section below</span>
+  </div>
+</template>
+```
+
+### Vertical Separator
+
+```vue
+<script setup lang="ts">
+import { UISeparator } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex h-6 items-center gap-sm">
+    <span class="text-sm text-primary">Left</span>
+    <UISeparator orientation="vertical" />
+    <span class="text-sm text-primary">Right</span>
+  </div>
+</template>
+```
+
+### Inside a Card
+
+```vue
+<script setup lang="ts">
+import { UICard } from '@wisemen/vue-core-design-system'
+import { UISeparator } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UICard>
+    <div class="p-xl">
+      <h3 class="text-lg font-semibold text-primary">Title</h3>
+    </div>
+    <UISeparator />
+    <div class="p-xl">
+      <p class="text-sm text-secondary">Content below the separator</p>
+    </div>
+  </UICard>
+</template>
+```
+
+## Anatomy
+
+```
+UISeparator
+└── <Separator>  (Reka UI primitive, role="presentation")
+```
+
+## Styling
+
+**Style file:** `src/ui/separator/separator.style.ts`
+**tv() slots:** `separator`
+**Customization:** The base style is `bg-tertiary`. Orientation variants control dimensions: `h-px w-full` for horizontal, `h-full w-px` for vertical. Pass additional classes via the `class` prop to customize color or spacing (e.g., `class="my-lg"` for vertical margin).
+
+## Common Mistakes
+
+### MEDIUM: Vertical separator not visible without parent height
+
+Wrong:
+```vue
+<!-- Vertical separator has h-full but parent has no height -->
+<div class="flex items-center gap-sm">
+  <span>Left</span>
+  <UISeparator orientation="vertical" />
+  <span>Right</span>
+</div>
+```
+
+Correct:
+```vue
+<!-- Parent has a fixed height so the vertical separator is visible -->
+<div class="flex h-6 items-center gap-sm">
+  <span>Left</span>
+  <UISeparator orientation="vertical" />
+  <span>Right</span>
+</div>
+```
+
+The vertical separator uses `h-full`, so it requires a parent with a defined height. Without it, the separator collapses to zero height and becomes invisible.
+
+## Accessibility
+
+UISeparator renders the Reka UI `<Separator>` primitive with `role="presentation"`, indicating it is purely decorative. It has no keyboard interaction and is ignored by screen readers. Use it only for visual separation; do not rely on it to convey structural meaning.
+
+## See Also
+
+- [UICard](../card/SKILL.md) -- Common container where separators divide sections
+- [UIRowLayout](../row-layout/SKILL.md) -- Horizontal layout where vertical separators are used

--- a/packages/web/design-system/skills/components/separator/SKILL.md
+++ b/packages/web/design-system/skills/components/separator/SKILL.md
@@ -6,7 +6,6 @@ description: >
   a visual divider between sections or inline elements.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/sidebar/SKILL.md
+++ b/packages/web/design-system/skills/components/sidebar/SKILL.md
@@ -1,0 +1,696 @@
+---
+name: sidebar
+description: >
+  Main navigation sidebar with collapsible behavior, navigation groups, links with badges
+  and status dots, global search trigger, header logo, footer account card, and featured card.
+  Includes the useMainSidebar composable for programmatic control. On small screens, the
+  sidebar becomes a dialog overlay. Use for primary app navigation in dashboard layouts.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: layout
+requires:
+  - layout-system
+exports:
+  - UIMainSidebar
+  - UIMainSidebarProps
+  - UIMainSidebarHeaderLogoWithText
+  - UIMainSidebarGlobalSearch
+  - UIMainSidebarNavigationGroup
+  - UIMainSidebarNavigationLink
+  - UIMainSidebarNavigationLinkBadge
+  - UIMainSidebarNavigationLinkStatusDot
+  - UIMainSidebarFooterAccountCard
+  - UIMainSidebarFooterFeaturedCard
+  - useMainSidebar
+  - UIMainSidebarCollapsedVariant
+  - UIMainSidebarGroup
+  - UIMainSidebarNavLink
+---
+
+# UIMainSidebar
+
+Primary navigation sidebar with three zones (header, navigation, footer), collapsible behavior (hidden or minified), and responsive dialog mode on small screens. Includes sub-components for logo, search, navigation groups/links, badges, status dots, and user account cards.
+
+## When to Use
+
+- As the primary navigation for any dashboard application
+- When you need collapsible sidebar navigation with grouped links
+- Building an app shell with logo, search, nav links, and user account
+
+**Use instead:** A custom sidebar only if you need fundamentally different layout (e.g., horizontal nav). For secondary/contextual navigation, use tabs or dropdown menus.
+
+## Import
+
+```ts
+import {
+  UIMainSidebar,
+  UIMainSidebarHeaderLogoWithText,
+  UIMainSidebarGlobalSearch,
+  UIMainSidebarNavigationGroup,
+  UIMainSidebarNavigationLink,
+  UIMainSidebarNavigationLinkBadge,
+  UIMainSidebarNavigationLinkStatusDot,
+  UIMainSidebarFooterAccountCard,
+  UIMainSidebarFooterFeaturedCard,
+  useMainSidebar,
+} from '@wisemen/vue-core-design-system'
+```
+
+Types:
+
+```ts
+import type {
+  UIMainSidebarProps,
+  UIMainSidebarCollapsedVariant,
+  UIMainSidebarGroup,
+  UIMainSidebarNavLink,
+} from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import {
+  UIMainSidebar,
+  UIMainSidebarHeaderLogoWithText,
+  UIMainSidebarNavigationGroup,
+  UIMainSidebarNavigationLink,
+  UIMainSidebarFooterAccountCard,
+} from '@wisemen/vue-core-design-system'
+import { BarChartSquare02Icon, Settings01Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIMainSidebar collapsed-variant="minified">
+    <template #header>
+      <UIMainSidebarHeaderLogoWithText url="/logo.png" name="My App" />
+    </template>
+    <template #navigation>
+      <UIMainSidebarNavigationGroup label="Main">
+        <UIMainSidebarNavigationLink
+          :to="{ name: 'dashboard' }"
+          :icon="BarChartSquare02Icon"
+          label="Dashboard"
+        />
+      </UIMainSidebarNavigationGroup>
+    </template>
+    <template #footer>
+      <UIMainSidebarFooterAccountCard
+        name="Jane Doe"
+        email="jane@example.com"
+        :menu-options="[]"
+        :on-sign-out="() => {}"
+      />
+    </template>
+  </UIMainSidebar>
+</template>
+```
+
+## API
+
+### UIMainSidebar (root)
+
+The root sidebar container. On large screens (>= 960px), renders as a static panel with open/close animation. On small screens (< 960px), renders as a `DialogRoot` overlay with a backdrop.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `collapsedVariant` | `'hidden' \| 'minified'` | `'hidden'` | Behavior when collapsed. `'hidden'` slides out entirely. `'minified'` collapses to a 48px icon-only strip. |
+
+#### Slots
+
+| Slot | Description |
+|------|-------------|
+| `header` | Top section of the sidebar (logo, search). |
+| `navigation` | Middle scrollable section (navigation groups and links). |
+| `footer` | Bottom section (featured card, footer nav, account card). |
+
+---
+
+### UIMainSidebarHeaderLogoWithText
+
+Displays a logo image with an app name and an optional right slot (typically a search button). The name and right slot fade out when the sidebar is minified and closed.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `name` | `string` | (required) | Application name displayed next to the logo. |
+| `url` | `string` | (required) | URL of the logo image. |
+
+#### Slots
+
+| Slot | Description |
+|------|-------------|
+| `right` | Content placed to the right of the logo and name (e.g., global search button). |
+
+---
+
+### UIMainSidebarGlobalSearch
+
+An icon button that emits a `click` event to trigger global search. Displays a search icon with an accessible label.
+
+#### Props
+
+No props.
+
+#### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `click` | none | Emitted when the search button is clicked. Wire this to open your search dialog/palette. |
+
+---
+
+### UIMainSidebarNavigationGroup
+
+A labeled group of navigation links. The label fades out when the sidebar is minified and closed.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string \| null` | `null` | Optional group label displayed above the links. Pass `null` or omit for an unlabeled group. |
+
+#### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | `UIMainSidebarNavigationLink` components. |
+
+---
+
+### UIMainSidebarNavigationLink
+
+A single navigation link with an icon, label, optional keyboard shortcut tooltip, and an optional right slot for badges/dots. Uses `vue-router` `RouterLink` for navigation. Automatically highlights when the current route matches.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `icon` | `Component` | (required) | Icon component displayed on the left side. |
+| `label` | `string` | (required) | Text label for the link. |
+| `to` | `RouteLocationRaw` | (required) | Vue Router destination. |
+| `isActive` | `(route: RouteLocationNormalized) => boolean` | `() => false` | Custom function to determine active state beyond the default route matching. |
+| `keyboardShortcut` | `string \| null` | `null` | Keyboard shortcut string displayed in the tooltip (e.g., `'meta_d'`). |
+
+#### Slots
+
+| Slot | Description |
+|------|-------------|
+| `right` | Content placed to the right of the label (badges, status dots, icons). Only visible when the sidebar is expanded. |
+
+#### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `click` | none | Emitted when the link is clicked (in addition to navigation). |
+
+---
+
+### UIMainSidebarNavigationLinkBadge
+
+A small badge rendered inside a navigation link's `right` slot. Automatically changes color based on the link's active state (`brand` when active, `gray` when inactive).
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | (required) | Badge text (typically a count like `"10"`). |
+
+#### Slots
+
+No slots.
+
+---
+
+### UIMainSidebarNavigationLinkStatusDot
+
+A small green status dot rendered inside a navigation link's `right` slot. Has no props or configuration -- always renders as a 2px green circle.
+
+#### Props
+
+No props.
+
+#### Slots
+
+No slots.
+
+---
+
+### UIMainSidebarFooterAccountCard
+
+A user account card with avatar, name, email, and a dropdown menu for account actions and sign-out. The card collapses to an avatar-only view when minified.
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `name` | `string` | (required) | User's display name. |
+| `email` | `string` | (required) | User's email address. |
+| `avatarUrl` | `string` | `undefined` | URL for the user's avatar image. Falls back to initials if omitted. |
+| `menuOptions` | `MenuOption[]` | (required) | Array of dropdown menu items. |
+| `onSignOut` | `() => void` | (required) | Callback invoked when the "Sign out" menu item is selected. |
+
+**MenuOption type:**
+
+```ts
+interface MenuOption {
+  icon: Component        // Icon component for the menu item
+  label: string          // Menu item text
+  onSelect: () => void   // Callback when selected
+  keyboardShortcut?: string  // Optional keyboard shortcut hint
+}
+```
+
+#### Slots
+
+No slots.
+
+#### Emits
+
+No custom events. Uses `onSignOut` prop callback.
+
+---
+
+### UIMainSidebarFooterFeaturedCard
+
+A placeholder component for promotional or featured content in the sidebar footer. Currently renders an empty `<div>`. Override with custom content as needed.
+
+#### Props
+
+No props.
+
+#### Slots
+
+No slots.
+
+---
+
+### useMainSidebar Composable
+
+A shared composable that manages sidebar state globally. Uses `@vueuse/core` for breakpoints and localStorage persistence.
+
+```ts
+import { useMainSidebar } from '@wisemen/vue-core-design-system'
+
+const {
+  isSidebarOpen,         // Ref<boolean> - get/set sidebar open state
+  isFloatingSidebar,     // ComputedRef<boolean> - true when screen < 960px
+  collapsedVariant,      // Ref<MainSidebarCollapsedVariant>
+  sidebarWidth,          // Ref<string> - current width (e.g., '14rem', '3rem')
+  closeIfFloatingSidebar, // () => void - close only if in floating mode
+  setCollapsedVariant,   // (variant) => void - change collapsed behavior
+  minifiedSidebarWidth,  // string - '3rem' (48px)
+  sidebarContainerPadding, // string - '0.5625rem' (9px)
+  sidebarIconSize,       // string - '1rem' (16px)
+  sidebarIconCellSize,   // string - '1.875rem' (30px)
+  sidebarLinkHeight,     // string - '1.875rem' (30px)
+  sidebarLogoPadding,    // string - '0.1875rem' (3px)
+  sidebarAvatarPadding,  // string - '0.1875rem' (3px)
+  sidebarLogoHeight,     // string - '2.6rem' (41.6px)
+} = useMainSidebar()
+```
+
+**Key behaviors:**
+- Open/close state is persisted to `localStorage` under key `dashboard-sidebar-is-open`.
+- On screens < 960px, the sidebar becomes floating (dialog overlay). The floating open state is separate from the persisted setting.
+- When `collapsedVariant` is `'minified'`, closing the sidebar shrinks it to `3rem` (48px) instead of hiding it completely.
+- Default sidebar width is `14rem` (224px).
+
+## Types
+
+### DashboardSidebarNavLink
+
+```ts
+interface DashboardSidebarNavLink {
+  icon: Component
+  label: string
+  to: RouteLocationRaw
+  isActive?: (route: RouteLocationNormalized) => boolean
+  keyboardShortcut?: string | null
+  onClick?: () => void
+}
+```
+
+### DashboardSidebarGroup
+
+```ts
+interface DashboardSidebarGroup {
+  label?: string
+  links: DashboardSidebarNavLink[]
+}
+```
+
+### MainSidebarCollapsedVariant
+
+```ts
+type MainSidebarCollapsedVariant = 'hidden' | 'minified'
+```
+
+## Variants
+
+### Collapsed Variants
+
+| Variant | Collapsed State | Open State |
+|---------|-----------------|------------|
+| `hidden` | Sidebar slides completely out of view (width 0) | Full sidebar at 14rem |
+| `minified` | Collapses to 3rem icon-only strip | Full sidebar at 14rem |
+
+### Responsive Behavior
+
+| Screen Size | Behavior |
+|-------------|----------|
+| >= 960px | Static panel, controlled by `collapsedVariant` |
+| < 960px | Dialog overlay with backdrop, slides in from left |
+
+## Examples
+
+### Full Sidebar with All Features
+
+```vue
+<script setup lang="ts">
+import {
+  UIMainSidebar,
+  UIMainSidebarHeaderLogoWithText,
+  UIMainSidebarGlobalSearch,
+  UIMainSidebarNavigationGroup,
+  UIMainSidebarNavigationLink,
+  UIMainSidebarNavigationLinkBadge,
+  UIMainSidebarNavigationLinkStatusDot,
+  UIMainSidebarFooterAccountCard,
+  UIMainSidebarFooterFeaturedCard,
+} from '@wisemen/vue-core-design-system'
+import {
+  BarChartSquare02Icon,
+  Rows01Icon,
+  File05Icon,
+  Settings01Icon,
+  LifeBuoy01Icon,
+} from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UIMainSidebar collapsed-variant="minified">
+    <template #header>
+      <UIMainSidebarHeaderLogoWithText url="/logo.png" name="Wisemen">
+        <template #right>
+          <UIMainSidebarGlobalSearch @click="openCommandPalette" />
+        </template>
+      </UIMainSidebarHeaderLogoWithText>
+    </template>
+
+    <template #navigation>
+      <UIMainSidebarNavigationGroup label="Main">
+        <UIMainSidebarNavigationLink
+          :to="{ name: 'dashboard' }"
+          :icon="BarChartSquare02Icon"
+          label="Dashboard"
+        />
+        <UIMainSidebarNavigationLink
+          :to="{ name: 'projects' }"
+          :icon="Rows01Icon"
+          label="Projects"
+        >
+          <template #right>
+            <UIMainSidebarNavigationLinkBadge label="12" />
+            <UIMainSidebarNavigationLinkStatusDot />
+          </template>
+        </UIMainSidebarNavigationLink>
+      </UIMainSidebarNavigationGroup>
+
+      <UIMainSidebarNavigationGroup label="Resources">
+        <UIMainSidebarNavigationLink
+          :to="{ name: 'documents' }"
+          :icon="File05Icon"
+          label="Documents"
+          keyboard-shortcut="meta_d"
+        />
+      </UIMainSidebarNavigationGroup>
+    </template>
+
+    <template #footer>
+      <UIMainSidebarFooterFeaturedCard />
+      <UIMainSidebarNavigationGroup>
+        <UIMainSidebarNavigationLink
+          :to="{ name: 'support' }"
+          :icon="LifeBuoy01Icon"
+          label="Support"
+        />
+        <UIMainSidebarNavigationLink
+          :to="{ name: 'settings' }"
+          :icon="Settings01Icon"
+          label="Settings"
+        />
+      </UIMainSidebarNavigationGroup>
+      <UIMainSidebarFooterAccountCard
+        name="Jane Doe"
+        email="jane.doe@example.com"
+        avatar-url="/avatars/jane.jpg"
+        :menu-options="[
+          {
+            icon: Settings01Icon,
+            label: 'Account settings',
+            onSelect: () => router.push({ name: 'account' }),
+          },
+          {
+            icon: LifeBuoy01Icon,
+            label: 'Support',
+            onSelect: () => router.push({ name: 'support' }),
+          },
+        ]"
+        :on-sign-out="handleSignOut"
+      />
+    </template>
+  </UIMainSidebar>
+</template>
+```
+
+### Programmatic Sidebar Control
+
+```vue
+<script setup lang="ts">
+import { useMainSidebar } from '@wisemen/vue-core-design-system'
+
+const { isSidebarOpen, isFloatingSidebar } = useMainSidebar()
+
+function toggleSidebar(): void {
+  isSidebarOpen.value = !isSidebarOpen.value
+}
+</script>
+
+<template>
+  <button @click="toggleSidebar">
+    {{ isSidebarOpen ? 'Close' : 'Open' }} Sidebar
+  </button>
+  <p v-if="isFloatingSidebar">Sidebar is in floating (mobile) mode</p>
+</template>
+```
+
+### Data-Driven Navigation
+
+```vue
+<script setup lang="ts">
+import {
+  UIMainSidebar,
+  UIMainSidebarNavigationGroup,
+  UIMainSidebarNavigationLink,
+} from '@wisemen/vue-core-design-system'
+import type {
+  UIMainSidebarGroup,
+} from '@wisemen/vue-core-design-system'
+import { computed } from 'vue'
+
+const groups = computed<UIMainSidebarGroup[]>(() => [
+  {
+    label: 'Main',
+    links: [
+      { icon: DashboardIcon, label: 'Dashboard', to: { name: 'dashboard' } },
+      { icon: UsersIcon, label: 'Users', to: { name: 'users' } },
+    ],
+  },
+])
+</script>
+
+<template>
+  <UIMainSidebar>
+    <template #navigation>
+      <UIMainSidebarNavigationGroup
+        v-for="group in groups"
+        :key="group.label"
+        :label="group.label"
+      >
+        <UIMainSidebarNavigationLink
+          v-for="link in group.links"
+          :key="link.label"
+          :to="link.to"
+          :icon="link.icon"
+          :label="link.label"
+        />
+      </UIMainSidebarNavigationGroup>
+    </template>
+  </UIMainSidebar>
+</template>
+```
+
+## Anatomy
+
+```
+UIMainSidebar
+  (screen >= 960px, collapsedVariant='hidden')
+    AnimatePresence
+      MainSidebarTransition  Motion[translateX]
+        MainSidebarContent
+          div[padding=containerPadding]  #header slot
+          nav[padding=containerPadding]  #navigation slot
+          div[padding=containerPadding]  #footer slot
+
+  (screen >= 960px, collapsedVariant='minified')
+    Motion[width=sidebarWidth]  .absolute.h-full.overflow-hidden
+      MainSidebarContent
+        (same structure as above)
+
+  (screen < 960px)
+    DialogRoot
+      AnimatePresence
+        DialogContent[asChild]
+          MainSidebarTransition  Motion[translateX]
+            div .rounded-xl.border.bg-secondary.shadow-lg
+              DialogTitle (sr-only)
+              DialogDescription (sr-only)
+              MainSidebarContent
+                (same structure as above)
+        DialogOverlay  Motion[opacity]  .bg-black/10
+
+MainSidebarNavigationLink
+  ActionTooltip[label, keyboardShortcut, side=right]
+    ClickableElement
+      RouterLink
+        MainSidebarNavigationLinkProvider (context: isActive)
+          div[data-active] .grid
+            RowLayout (icon cell)
+              Component[is=icon]
+            MainSidebarFadeTransition
+              RowLayout[justify=between]
+                span (label)
+                RowLayout (#right slot - badges, dots)
+
+MainSidebarFooterAccountCard
+  DropdownMenu[side=right, align=end]
+    #trigger
+      UICard .grid
+        Avatar
+        MainSidebarFadeTransition
+          name + email + chevron
+    #content
+      DropdownMenuGroup (custom menu options)
+      DropdownMenuGroup (sign out)
+```
+
+## Styling
+
+**Style file:** No separate style file. Uses inline Tailwind classes throughout.
+
+**Sidebar dimensions (from composable):**
+
+| Token | Value | Description |
+|-------|-------|-------------|
+| Default width | `14rem` (224px) | Full sidebar width |
+| Minified width | `3rem` (48px) | Icon-only collapsed width |
+| Container padding | `0.5625rem` (9px) | Inner padding for header/nav/footer |
+| Icon size | `1rem` (16px) | Navigation link icon size |
+| Icon cell size | `1.875rem` (30px) | Grid cell containing the icon |
+| Link height | `1.875rem` (30px) | Height of each navigation link |
+| Logo height | `2.6rem` (41.6px) | Height of the logo row |
+
+**Active link styling:** `bg-brand-primary` (light) / `bg-tertiary` (dark), with `text-fg-brand-primary` (light) / `text-fg-primary` (dark) for the icon and label.
+
+**Transitions:** All open/close and fade transitions use `motion-v` spring animations (duration 0.3s, no bounce) with reduced-motion support. The `MainSidebarFadeTransition` uses CSS opacity transitions (150ms in, 100ms out) for label text fade.
+
+## Common Mistakes
+
+### HIGH: Forgetting to wrap sidebar in UIMainLayoutContainer
+
+Wrong:
+```vue
+<UIMainSidebar>...</UIMainSidebar>
+<div>Page content</div>
+```
+
+Correct:
+```vue
+<UIMainLayoutContainer>
+  <UIMainSidebar>...</UIMainSidebar>
+  <UIMainContent>
+    <div>Page content</div>
+  </UIMainContent>
+</UIMainLayoutContainer>
+```
+
+The sidebar is absolutely positioned and needs `UIMainLayoutContainer` (which provides `h-dvh overflow-hidden`) to contain it. `UIMainContent` handles the animated padding that shifts content away from the sidebar.
+
+### MEDIUM: Placing badges/dots outside the right slot
+
+Wrong:
+```vue
+<UIMainSidebarNavigationLink :to="..." :icon="Icon" label="Projects" />
+<UIMainSidebarNavigationLinkBadge label="5" />
+```
+
+Correct:
+```vue
+<UIMainSidebarNavigationLink :to="..." :icon="Icon" label="Projects">
+  <template #right>
+    <UIMainSidebarNavigationLinkBadge label="5" />
+    <UIMainSidebarNavigationLinkStatusDot />
+  </template>
+</UIMainSidebarNavigationLink>
+```
+
+Badge and status dot components must be placed inside the `#right` slot of their parent `UIMainSidebarNavigationLink`. They rely on the navigation link context for active-state styling.
+
+### MEDIUM: Not providing onSignOut to FooterAccountCard
+
+Wrong:
+```vue
+<UIMainSidebarFooterAccountCard
+  name="Jane Doe"
+  email="jane@example.com"
+  :menu-options="[]"
+/>
+```
+
+Correct:
+```vue
+<UIMainSidebarFooterAccountCard
+  name="Jane Doe"
+  email="jane@example.com"
+  :menu-options="[]"
+  :on-sign-out="handleSignOut"
+/>
+```
+
+The `onSignOut` prop is required. The sign-out menu item is always rendered and calls this callback.
+
+### LOW: Using collapsedVariant='hidden' when minified is more appropriate
+
+Consider using `'minified'` when you want users to always see navigation icons, even when the sidebar is collapsed. Use `'hidden'` only when you want the sidebar to disappear entirely (e.g., content-focused views).
+
+## Accessibility
+
+- **Floating mode (< 960px):** Uses `reka-ui` `DialogRoot` / `DialogContent` / `DialogOverlay` for proper focus trapping, backdrop click-to-close, and screen-reader semantics. Includes a `DialogTitle` and `DialogDescription` (both `sr-only`).
+- **Sidebar toggle:** The header toggle in `DashboardPageHeaderSidebarToggle` uses `reka-ui Toggle` with dynamic `aria-label` ("collapse"/"expand") and a `Meta+B` keyboard shortcut tooltip.
+- **Navigation links:** Each link renders as a `RouterLink` (which becomes an `<a>` element). The `data-active` attribute signals the active state. Tooltips with keyboard shortcuts are shown via `ActionTooltip`.
+- **Account dropdown:** Uses `DropdownMenu` with proper focus management and keyboard navigation. Menu items support keyboard shortcuts.
+- **Reduced motion:** All animations (slide, fade, width transitions) respect `prefers-reduced-motion` via `motion-v`'s `useReducedMotion`, setting duration to 0.
+- **Keyboard navigation:** Links are focusable, the sidebar toggle is keyboard-accessible, and the dropdown menu supports full keyboard interaction.
+
+## See Also
+
+- [UILayout](../layout/) -- The outer shell (MainLayoutContainer + MainContent) that wraps the sidebar
+- [UIDashboardPage](../page/) -- The page component rendered inside UIMainContent alongside the sidebar
+- [UIDropdownMenu](../dropdown-menu/) -- Used internally by the account card
+- [Layout System](../../foundations/layout-system/) -- Foundation overview of the full layout architecture

--- a/packages/web/design-system/skills/components/sidebar/SKILL.md
+++ b/packages/web/design-system/skills/components/sidebar/SKILL.md
@@ -7,7 +7,6 @@ description: >
   sidebar becomes a dialog overlay. Use for primary app navigation in dashboard layouts.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: layout
 requires:
   - layout-system

--- a/packages/web/design-system/skills/components/skeleton-item/SKILL.md
+++ b/packages/web/design-system/skills/components/skeleton-item/SKILL.md
@@ -6,7 +6,6 @@ description: >
   when building skeleton loading screens or placeholder UIs.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/skeleton-item/SKILL.md
+++ b/packages/web/design-system/skills/components/skeleton-item/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: skeleton-item
+description: >
+  A loading placeholder element with optional shimmer animation. Renders as a
+  rounded rectangle that mimics content layout while data loads. Load this skill
+  when building skeleton loading screens or placeholder UIs.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UISkeletonItem
+---
+
+# UISkeletonItem
+
+A rectangular placeholder with optional shimmer animation used to represent loading content.
+
+## When to Use
+
+- Building skeleton screens that mimic the layout of content while it loads
+- Replacing text, images, or cards with placeholder shapes during data fetching
+- Creating staggered loading animations with multiple skeleton items
+
+**Use instead:** `UILoader` for a simple spinning indicator, or a custom loading state when the skeleton layout does not match the final content.
+
+## Import
+
+```ts
+import { UISkeletonItem } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UISkeletonItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UISkeletonItem class="h-4 w-48" :animate="true" />
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `animate` | `boolean` | `false` | Whether the skeleton item should display a shimmer animation. |
+| `animationDelayInMs` | `number` | `0` | The animation delay in milliseconds before the shimmer starts. Useful for staggering multiple skeletons. |
+
+### Slots
+
+This component has no slots.
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+This component has no built-in size or color variants. Control dimensions via CSS classes:
+
+| Shape | Classes |
+|-------|---------|
+| Text line | `class="h-4 w-48"` |
+| Short text | `class="h-4 w-24"` |
+| Heading | `class="h-6 w-64"` |
+| Avatar circle | `class="size-8 rounded-full"` |
+| Card block | `class="h-32 w-full"` |
+| Thumbnail | `class="size-16"` |
+
+## Examples
+
+### Single Skeleton Line
+
+```vue
+<script setup lang="ts">
+import { UISkeletonItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UISkeletonItem class="h-4 w-48" :animate="true" />
+</template>
+```
+
+### Skeleton Card Layout
+
+```vue
+<script setup lang="ts">
+import { UISkeletonItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex flex-col gap-md">
+    <UISkeletonItem class="h-6 w-40" :animate="true" />
+    <UISkeletonItem class="h-4 w-64" :animate="true" :animation-delay-in-ms="100" />
+    <UISkeletonItem class="h-4 w-56" :animate="true" :animation-delay-in-ms="200" />
+    <UISkeletonItem class="h-4 w-32" :animate="true" :animation-delay-in-ms="300" />
+  </div>
+</template>
+```
+
+### Skeleton with Avatar and Text
+
+```vue
+<script setup lang="ts">
+import { UISkeletonItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="flex items-center gap-md">
+    <UISkeletonItem class="size-10 shrink-0 rounded-full" :animate="true" />
+    <div class="flex flex-col gap-xs">
+      <UISkeletonItem class="h-4 w-32" :animate="true" :animation-delay-in-ms="50" />
+      <UISkeletonItem class="h-3 w-48" :animate="true" :animation-delay-in-ms="100" />
+    </div>
+  </div>
+</template>
+```
+
+### Static Skeleton (No Animation)
+
+```vue
+<script setup lang="ts">
+import { UISkeletonItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UISkeletonItem class="h-4 w-48" />
+</template>
+```
+
+## Anatomy
+
+```
+UISkeletonItem
+└── <div role="status" aria-busy="true" aria-live="polite">
+    └── <div v-if="animate" class="shimmer">  (animated overlay)
+```
+
+## Styling
+
+**Style file:** None (styles are scoped CSS in the component)
+**tv() slots:** None
+**Customization:** The outer container uses `rounded-md bg-tertiary` (light) / `bg-secondary` (dark) with `overflow-hidden`. Dimensions must be set via CSS classes on the component (e.g., `class="h-4 w-48"`). The shimmer effect is a CSS animation using a `linear-gradient` that translates horizontally over 1.5s. Override `rounded-md` with `rounded-full` for circular skeleton shapes.
+
+## Common Mistakes
+
+### HIGH: Not setting dimensions
+
+Wrong:
+```vue
+<!-- Skeleton collapses to zero size -->
+<UISkeletonItem :animate="true" />
+```
+
+Correct:
+```vue
+<UISkeletonItem class="h-4 w-48" :animate="true" />
+```
+
+UISkeletonItem has no intrinsic dimensions. You must always provide height and width via CSS classes.
+
+### MEDIUM: Not staggering animation delays
+
+Wrong:
+```vue
+<!-- All items shimmer in sync, looks unnatural -->
+<UISkeletonItem class="h-4 w-48" :animate="true" />
+<UISkeletonItem class="h-4 w-32" :animate="true" />
+<UISkeletonItem class="h-4 w-56" :animate="true" />
+```
+
+Correct:
+```vue
+<!-- Staggered delays create a wave effect -->
+<UISkeletonItem class="h-4 w-48" :animate="true" :animation-delay-in-ms="0" />
+<UISkeletonItem class="h-4 w-32" :animate="true" :animation-delay-in-ms="100" />
+<UISkeletonItem class="h-4 w-56" :animate="true" :animation-delay-in-ms="200" />
+```
+
+Staggering `animationDelayInMs` across multiple skeleton items creates a more natural wave-like shimmer effect.
+
+## Accessibility
+
+UISkeletonItem renders with `role="status"`, `aria-busy="true"`, and `aria-live="polite"`. This tells screen readers that the region is in a loading state and will announce content changes when loading completes. No keyboard interaction is needed.
+
+## See Also
+
+- [UILoader](../loader/SKILL.md) -- For a simple spinning loading indicator
+- [UICard](../card/SKILL.md) -- Often wraps skeleton layouts during loading states

--- a/packages/web/design-system/skills/components/switch/SKILL.md
+++ b/packages/web/design-system/skills/components/switch/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: switch
+description: >
+  A toggle switch for boolean on/off state with optional thumb icons, size
+  variants, and animated transitions. Built on Reka UI SwitchRoot with label,
+  hint, and error message support. Ideal for settings that take effect
+  immediately.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: form-control
+requires:
+  - input-system
+exports:
+  - UISwitch
+  - UISwitchProps
+---
+
+# UISwitch
+
+A toggle switch for boolean on/off state with optional animated thumb icons and size variants.
+
+## When to Use
+
+- Settings or preferences that take effect immediately (enable dark mode, toggle notifications)
+- Binary on/off controls where the visual metaphor of a physical switch is appropriate
+- When you want animated icon transitions inside the thumb
+
+**Use instead:** [UICheckbox](../checkbox/SKILL.md) for form fields that submit with a form (agree to terms), [UIRadioGroup](../radio-group/SKILL.md) for choosing between more than two options.
+
+## Import
+
+```ts
+import { UISwitch } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UISwitch } from '@wisemen/vue-core-design-system'
+
+const isEnabled = ref<boolean>(false)
+</script>
+
+<template>
+  <UISwitch
+    v-model="isEnabled"
+    label="Enable notifications"
+  />
+</template>
+```
+
+## API
+
+### Props
+
+> Inherits from: `Input`, `InputWrapper` (see [input-system](../../foundations/input-system/SKILL.md))
+>
+> Note: UISwitch does NOT inherit from `FieldWrapper`. It has its own switch track/thumb rendering.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `iconChecked` | `Component \| null` | `null` | Icon component displayed inside the thumb when the switch is checked (on). |
+| `iconUnchecked` | `Component \| null` | `null` | Icon component displayed inside the thumb when the switch is unchecked (off). |
+| `size` | `'md' \| 'sm'` | `'md'` | The size of the switch. |
+
+### v-model
+
+| Model | Type | Required | Description |
+|-------|------|----------|-------------|
+| `modelValue` | `boolean` | Yes | Whether the switch is on (`true`) or off (`false`). |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `left` | Content rendered to the left of the label text. |
+| `right` | Content rendered to the right of the label text. |
+
+### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `blur` | none | Emitted when the switch loses focus. |
+
+## Variants
+
+### Size
+
+| Size | Track Dimensions |
+|------|-----------------|
+| `md` | `h-5 w-9` (20x36px) -- Default |
+| `sm` | Smaller track (defined by style variants) |
+
+## Examples
+
+### Basic Usage
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UISwitch } from '@wisemen/vue-core-design-system'
+
+const darkMode = ref<boolean>(false)
+</script>
+
+<template>
+  <UISwitch
+    v-model="darkMode"
+    label="Dark mode"
+    hint="Toggle between light and dark theme"
+  />
+</template>
+```
+
+### With Formango
+
+```vue
+<script setup lang="ts">
+import { useForm } from '@wisemen/formango'
+import { UISwitch } from '@wisemen/vue-core-design-system'
+import { z } from 'zod'
+
+const { form } = useForm({
+  schema: z.object({
+    emailNotifications: z.boolean(),
+  }),
+  onSubmit(values) {
+    console.log(values)
+  },
+})
+
+const emailNotifications = form.register('emailNotifications')
+</script>
+
+<template>
+  <UISwitch
+    v-model="emailNotifications.modelValue.value"
+    :error-message="emailNotifications.isTouched.value ? emailNotifications.errors.value?._errors?.[0] ?? null : null"
+    label="Email notifications"
+    hint="Receive email alerts for important updates"
+    @blur="emailNotifications.setTouched()"
+  />
+</template>
+```
+
+### With Icons
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { CheckIcon, XCloseIcon } from '@wisemen/vue-core-icons'
+import { UISwitch } from '@wisemen/vue-core-design-system'
+
+const isActive = ref<boolean>(true)
+</script>
+
+<template>
+  <UISwitch
+    v-model="isActive"
+    :icon-checked="CheckIcon"
+    :icon-unchecked="XCloseIcon"
+    label="Active"
+  />
+</template>
+```
+
+### Disabled with Reason
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UISwitch } from '@wisemen/vue-core-design-system'
+
+const feature = ref<boolean>(false)
+</script>
+
+<template>
+  <UISwitch
+    v-model="feature"
+    :is-disabled="true"
+    disabled-reason="Upgrade to premium to enable this feature"
+    label="Premium feature"
+  />
+</template>
+```
+
+### With Error
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UISwitch } from '@wisemen/vue-core-design-system'
+
+const terms = ref<boolean>(false)
+</script>
+
+<template>
+  <UISwitch
+    v-model="terms"
+    :is-required="true"
+    :error-message="!terms ? 'You must enable this setting' : null"
+    label="Accept terms"
+  />
+</template>
+```
+
+## Anatomy
+
+```
+ActionTooltip                    (shows disabledReason when disabled)
+└── RowLayout
+    ├── RekaSwitchRoot           (Reka UI switch, handles toggle state)
+    │   └── RekaSwitchThumb      (sliding thumb)
+    │       └── SwitchThumbIcon  (animated icon inside thumb)
+    └── div
+        ├── UIRowLayout
+        │   ├── slot#left
+        │   ├── UIText (label)   (as <label> element)
+        │   └── slot#right
+        ├── InputWrapperHint     (hint text)
+        └── InputWrapperErrorMessage (error text)
+```
+
+Note: Unlike other input components, UISwitch does NOT use InputWrapper. It manually composes the label, hint, and error message. The switch track is on the left with the label and metadata on the right.
+
+## Styling
+
+**Style file:** `src/ui/switch/switch.style.ts`
+**tv() slots:**
+- `root` -- The switch track. Rounded pill shape with brand color when checked, tertiary when unchecked. Includes disabled, error, and dark mode states.
+- `thumb` -- The sliding circle inside the track. White background with shadow, translates right when checked.
+- `thumbIcon` -- The icon inside the thumb. Changes color based on checked state (gray when unchecked, brand when checked).
+
+The thumb icon uses Motion (motion-v) with AnimatePresence for animated icon transitions -- icons slide in/out with blur and opacity effects.
+
+## Common Mistakes
+
+### CRITICAL: Using UISwitch for form submission fields
+
+Wrong:
+```vue
+<!-- UISwitch for "I agree to terms" in a form -->
+<UISwitch v-model="acceptTerms" label="I agree to terms" />
+```
+
+Correct:
+```vue
+<!-- Use UICheckbox for form agreement fields -->
+<UICheckbox v-model="acceptTerms" label="I agree to terms" />
+```
+
+UISwitch is semantically for settings that take immediate effect. UICheckbox is better for form fields that submit with a form. Use UISwitch for toggles like "Enable dark mode" and UICheckbox for "I agree to terms."
+
+### HIGH: Expecting v-model to be nullable
+
+Wrong:
+```vue
+const value = ref<boolean | null>(null)
+```
+
+Correct:
+```vue
+const value = ref<boolean>(false)
+```
+
+The v-model type is `boolean`, not `boolean | null`. A switch is always either on or off.
+
+### MEDIUM: Setting icons without both iconChecked and iconUnchecked
+
+You can set just one icon (e.g., only `iconChecked`), but for the best UX, provide both so the thumb always has an icon. When only one is set, the thumb shows an empty circle in the other state, which may look inconsistent.
+
+## Accessibility
+
+- Reka UI SwitchRoot handles `role="switch"`, `aria-checked`
+- Keyboard: Space key toggles the switch
+- `data-invalid` attribute applied when `errorMessage` is present, driving error border/background
+- Disabled state prevents interaction and shows disabled-reason tooltip
+- Label is rendered as a `<label>` element associated with the switch
+- `isLabelHidden` renders the label with `sr-only` for screen reader accessibility
+- `isRequired` adds an asterisk to the label and `data-label-required` attribute
+
+## See Also
+
+- [input-system](../../foundations/input-system/SKILL.md) -- Inherited props and architecture
+- [checkbox](../checkbox/SKILL.md) -- Boolean form field for submission
+- [checkbox-group](../checkbox-group/SKILL.md) -- Multi-value selection

--- a/packages/web/design-system/skills/components/switch/SKILL.md
+++ b/packages/web/design-system/skills/components/switch/SKILL.md
@@ -7,7 +7,6 @@ description: >
   immediately.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: form-control
 requires:
   - input-system

--- a/packages/web/design-system/skills/components/tabs/SKILL.md
+++ b/packages/web/design-system/skills/components/tabs/SKILL.md
@@ -8,7 +8,6 @@ description: >
   a dropdown), and scroll-based overflow for touch devices.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: navigation
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/tabs/SKILL.md
+++ b/packages/web/design-system/skills/components/tabs/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: tabs
+description: >
+  UITabs provides value-based tabbed navigation, while UITabsRouterLink provides
+  route-based tabbed navigation integrated with Vue Router. Both support three
+  visual variants (underline, button-border, button-brand), horizontal and vertical
+  orientations, full-width mode, adaptive overflow (hiding low-priority tabs into
+  a dropdown), and scroll-based overflow for touch devices.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: navigation
+requires: []
+exports:
+  - UITabs
+  - UITabsProps
+  - UITabsItem
+  - UITabsItemProps
+  - UITabsList
+  - UITabsContent
+  - UITabsContentProps
+  - UITabsRouterLink
+  - UITabsRouterLinkItem
+  - UITabsRouterLinkItemProps
+---
+
+# UITabs
+
+Tabbed navigation with value-based and router-link modes, three visual variants, adaptive overflow, and vertical/horizontal orientations.
+
+## When to Use
+
+- Switching between content panels within a page section (value-based mode with `UITabs`).
+- Route-based tab navigation where each tab maps to a named route (with `UITabsRouterLink`).
+- When tabs may overflow the container and need adaptive collapsing into a dropdown.
+
+**Use instead:** For top-level app navigation, use `UISidebar`. For breadcrumb-style hierarchical navigation, use `UIBreadcrumbs`.
+
+## Import
+
+```ts
+// Value-based tabs
+import {
+  UITabs,
+  UITabsList,
+  UITabsItem,
+  UITabsContent,
+} from '@wisemen/vue-core-design-system'
+
+// Router-link tabs
+import {
+  UITabsRouterLink,
+  UITabsRouterLinkItem,
+} from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+### Value-based tabs
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  UITabs,
+  UITabsList,
+  UITabsItem,
+  UITabsContent,
+} from '@wisemen/vue-core-design-system'
+import { User01Icon, Settings01Icon } from '@wisemen/vue-core-icons'
+
+const selectedTab = ref<string>('general')
+</script>
+
+<template>
+  <UITabs v-model="selectedTab" variant="underline">
+    <UITabsList>
+      <UITabsItem :icon="User01Icon" label="General" value="general" />
+      <UITabsItem :icon="Settings01Icon" label="Settings" value="settings" />
+    </UITabsList>
+
+    <UITabsContent value="general">
+      <p>General content.</p>
+    </UITabsContent>
+    <UITabsContent value="settings">
+      <p>Settings content.</p>
+    </UITabsContent>
+  </UITabs>
+</template>
+```
+
+### Router-link tabs
+
+```vue
+<script setup lang="ts">
+import {
+  UITabsRouterLink,
+  UITabsRouterLinkItem,
+} from '@wisemen/vue-core-design-system'
+import { User01Icon, Inbox02Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UITabsRouterLink variant="underline">
+    <UITabsRouterLinkItem :icon="User01Icon" :to="{ name: 'general' }" label="General" />
+    <UITabsRouterLinkItem :icon="Inbox02Icon" :to="{ name: 'members' }" label="Members" />
+  </UITabsRouterLink>
+
+  <!-- Content is rendered by the router via TabsRouterLinkContent -->
+</template>
+```
+
+## API
+
+### UITabs Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `modelValue` | `string` | **(required, v-model)** | The currently selected tab value. |
+| `variant` | `'underline' \| 'button-border' \| 'button-brand'` | `'underline'` | Visual style of the tabs. |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Layout direction. |
+| `isFullWidth` | `boolean` | `false` | Whether tabs stretch to fill the container width. |
+| `underlineTabsHorizontalListPadding` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'none'` | Horizontal padding of the scroll container. Only applies to the `underline` variant. |
+
+### UITabsItem Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `string` | **(required)** | Unique identifier for the tab. |
+| `label` | `string` | **(required)** | Text label for the tab. |
+| `icon` | `Component` | `undefined` | Optional icon displayed alongside the label. |
+| `count` | `number \| null` | `null` | Badge count displayed to the right of the label. |
+| `isDisabled` | `boolean` | `false` | Disables the tab. |
+| `disabledReason` | `string \| null` | `null` | Tooltip text when the tab is disabled. |
+| `isLabelHidden` | `boolean` | `false` | Visually hides the label (sr-only). |
+
+### UITabsList
+
+No props. Renders the tab list with scroll overflow handling and adaptive content support. On non-touch devices, uses `UIAdaptiveContent` to collapse overflow tabs into a dropdown. On touch devices, shows scroll arrows.
+
+### UITabsContent Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `string` | **(required)** | The tab value this content panel corresponds to. |
+
+### UITabsContent Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | The content displayed when this tab is active. |
+
+### UITabsRouterLink Props
+
+Same as `UITabs` Props except there is no `modelValue` -- the active tab is derived from the current route name.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `variant` | `'underline' \| 'button-border' \| 'button-brand'` | `'underline'` | Visual style. |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Layout direction. |
+| `isFullWidth` | `boolean` | `false` | Stretch tabs to fill width. |
+| `underlineTabsHorizontalListPadding` | `'none' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'none'` | Scroll container padding (underline variant only). |
+
+### UITabsRouterLinkItem Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `to` | `RouteLocationRaw` | **(required)** | Vue Router destination. The resolved route name is used as the tab value. |
+| `label` | `string` | **(required)** | Text label for the tab. |
+| `icon` | `Component` | `undefined` | Optional icon. |
+| `count` | `number \| null` | `null` | Badge count. |
+| `isDisabled` | `boolean` | `false` | Disables the tab. |
+| `disabledReason` | `string \| null` | `null` | Tooltip text when disabled. |
+| `isLabelHidden` | `boolean` | `false` | Visually hides the label (sr-only). |
+
+### Emits
+
+**UITabs:** `update:modelValue` (via v-model)
+
+**UITabsRouterLink:** No custom events. Navigation is handled via `router.replace()`.
+
+## Variants
+
+### Visual variants
+
+| Variant | Description |
+|---------|-------------|
+| `underline` | Bottom border indicator, brand-colored underline on active tab. Border below the list. |
+| `button-border` | Pill-style tabs in a gray background container. Active tab has a raised white card indicator with shadow. |
+| `button-brand` | Pill-style tabs with brand-colored background on active tab. |
+
+### Orientations
+
+| Orientation | Description |
+|-------------|-------------|
+| `horizontal` | Tabs in a row. Indicator slides horizontally. Scroll overflow on touch devices. |
+| `vertical` | Tabs in a column. Indicator slides vertically. Left border for underline variant. |
+
+### Full width
+
+When `isFullWidth` is `true`, each tab gets `flex-1 justify-center` to stretch evenly.
+
+## Examples
+
+### Button-border variant with count badges
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UITabs, UITabsList, UITabsItem, UITabsContent } from '@wisemen/vue-core-design-system'
+import { Inbox02Icon } from '@wisemen/vue-core-icons'
+
+const tab = ref<string>('inbox')
+</script>
+
+<template>
+  <UITabs v-model="tab" variant="button-border">
+    <UITabsList>
+      <UITabsItem :icon="Inbox02Icon" :count="12" label="Inbox" value="inbox" />
+      <UITabsItem label="Sent" value="sent" />
+      <UITabsItem :is-disabled="true" disabled-reason="Coming soon" label="Drafts" value="drafts" />
+    </UITabsList>
+
+    <UITabsContent value="inbox">Inbox content.</UITabsContent>
+    <UITabsContent value="sent">Sent content.</UITabsContent>
+  </UITabs>
+</template>
+```
+
+### Vertical underline tabs
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UITabs, UITabsList, UITabsItem, UITabsContent } from '@wisemen/vue-core-design-system'
+
+const tab = ref<string>('general')
+</script>
+
+<template>
+  <div class="flex gap-4">
+    <UITabs v-model="tab" variant="underline" orientation="vertical">
+      <UITabsList>
+        <UITabsItem label="General" value="general" />
+        <UITabsItem label="Security" value="security" />
+        <UITabsItem label="Notifications" value="notifications" />
+      </UITabsList>
+    </UITabs>
+
+    <UITabsContent value="general">General settings.</UITabsContent>
+  </div>
+</template>
+```
+
+### Router-link tabs with content
+
+```vue
+<script setup lang="ts">
+import {
+  UITabsRouterLink,
+  UITabsRouterLinkItem,
+} from '@wisemen/vue-core-design-system'
+import { User01Icon, Settings01Icon } from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UITabsRouterLink variant="underline">
+    <UITabsRouterLinkItem :icon="User01Icon" :to="{ name: 'profile' }" label="Profile" />
+    <UITabsRouterLinkItem :icon="Settings01Icon" :to="{ name: 'settings' }" label="Settings" />
+  </UITabsRouterLink>
+
+  <!-- Router view renders the matched route component -->
+  <RouterView />
+</template>
+```
+
+Note: `UITabsRouterLink` includes a `TabsList` internally; do not wrap items in a separate `UITabsList`.
+
+## Anatomy
+
+```
+UITabs (value-based)
+  RekaTabsRoot (v-model)
+    UITabsList
+      <div> (base wrapper, overflow hidden)
+        Scroll left button (touch devices, when scrolled)
+        <div> (scroll container)
+          UIAdaptiveContent (non-touch devices)
+            RekaTabsList
+              UITabsItem (wrapped in UIAdaptiveContentBlock)
+                UIActionTooltip (for disabled reason)
+                  ClickableElement > RekaTabsTrigger
+                    Icon (optional)
+                    UIText (label)
+                    UINumberBadge (count, optional)
+              TabsIndicator (animated position indicator)
+              TabsAdaptiveContentDropdown (overflow items)
+          RekaTabsList (touch devices, no adaptive content)
+            UITabsItem
+            RekaTabsIndicator
+        Scroll right button (touch devices, when overflowing)
+    UITabsContent
+      RekaTabsContent
+        slot[default]
+
+UITabsRouterLink (route-based)
+  RekaTabsRoot (model from route name)
+    TabsList (embedded, same structure as above)
+      UITabsRouterLinkItem
+        UIAdaptiveContentBlock
+          ClickableElement > RekaTabsTrigger (as-child)
+            RouterLink (:replace="true")
+              Icon (optional)
+              UIText (label)
+              UINumberBadge (count, optional)
+```
+
+## Styling
+
+**Style file:** `src/ui/tabs/tabs.style.ts`
+
+**tv() slots:** `base`, `list`, `scrollContainer`, `item`, `indicator`, `indicatorInner`, `content`, `dropdownTrigger`, `dropdownIndicator`
+
+**Variant axes:** `variant` (`underline` | `button-border` | `button-brand`), `isFullWidth` (boolean), `underlineTabsHorizontalListPadding` (`none` | `sm` | `md` | `lg` | `xl`)
+
+**Key styling details:**
+- `underline` variant: bottom border on scroll container, `h-0.5` brand indicator, items get `rounded-md px-md py-xxs` with vertical margins
+- `button-border` variant: list has `bg-tertiary` background, indicator shows raised white card with `shadow-sm`, items have `rounded-sm px-lg py-sm`
+- `button-brand` variant: indicator is `bg-brand-primary-alt`, active text is `text-brand-secondary`
+
+## Common Mistakes
+
+### ERROR: Using UITabsList inside UITabsRouterLink
+
+```vue
+<!-- WRONG: UITabsRouterLink includes TabsList internally -->
+<UITabsRouterLink>
+  <UITabsList>
+    <UITabsRouterLinkItem ... />
+  </UITabsList>
+</UITabsRouterLink>
+
+<!-- CORRECT -->
+<UITabsRouterLink>
+  <UITabsRouterLinkItem :to="{ name: 'general' }" label="General" />
+  <UITabsRouterLinkItem :to="{ name: 'settings' }" label="Settings" />
+</UITabsRouterLink>
+```
+
+`UITabsRouterLink` renders its own `TabsList` internally. Wrapping items in another `UITabsList` causes double nesting.
+
+### ERROR: Mismatched value and content
+
+```vue
+<!-- WRONG: content value doesn't match any tab -->
+<UITabsItem label="General" value="tab1" />
+<UITabsContent value="general">...</UITabsContent>
+
+<!-- CORRECT: values must match exactly -->
+<UITabsItem label="General" value="general" />
+<UITabsContent value="general">...</UITabsContent>
+```
+
+### WARNING: underlineTabsHorizontalListPadding with non-underline variant
+
+```vue
+<!-- WRONG: padding prop only applies to underline variant -->
+<UITabs variant="button-border" underline-tabs-horizontal-list-padding="lg">
+
+<!-- CORRECT -->
+<UITabs variant="underline" underline-tabs-horizontal-list-padding="lg">
+```
+
+A console warning is emitted if `underlineTabsHorizontalListPadding` is set to a value other than `'none'` with a non-underline variant.
+
+### WARNING: Forgetting v-model on UITabs
+
+```vue
+<!-- WRONG: no v-model, tabs won't switch -->
+<UITabs variant="underline">
+
+<!-- CORRECT -->
+<UITabs v-model="selectedTab" variant="underline">
+```
+
+## Accessibility
+
+- Built on Reka UI's Tabs primitives which implement the WAI-ARIA Tabs pattern.
+- **Roles:** `tablist`, `tab`, `tabpanel` are automatically applied.
+- **Keyboard:** Arrow keys navigate between tabs, Tab moves focus out of the tab list, Enter/Space activates.
+- **aria-selected:** Active tab has `aria-selected="true"`.
+- **Disabled tabs:** Set via `isDisabled` with `disabled` attribute. `disabledReason` shows a tooltip on hover.
+- **Router-link tabs:** Use `<RouterLink>` with `replace` mode for proper link semantics. The `RekaTabsTrigger` wraps the link with `as-child` to merge accessibility attributes.
+- **Adaptive overflow:** Hidden tabs are accessible via the dropdown menu, which inherits keyboard navigation from the dropdown menu primitives.
+
+## See Also
+
+- [adaptive-content](../adaptive-content/SKILL.md) -- The priority-based overflow system used by TabsList
+- [breadcrumbs](../breadcrumbs/SKILL.md) -- Hierarchical navigation
+- [dropdown-menu](../dropdown-menu/SKILL.md) -- Used internally for overflow tab items
+- [button](../button/SKILL.md) -- For standalone action triggers

--- a/packages/web/design-system/skills/components/text-field/SKILL.md
+++ b/packages/web/design-system/skills/components/text-field/SKILL.md
@@ -7,7 +7,6 @@ description: >
   with formango for form validation.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: input
 requires:
   - input-system

--- a/packages/web/design-system/skills/components/text-field/SKILL.md
+++ b/packages/web/design-system/skills/components/text-field/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: text-field
+description: >
+  Single-line text input with label, hint, error message, and icon support.
+  Wraps a native <input> inside InputWrapper > FieldWrapper. Supports size
+  variants, multiple input types (text, email, password, etc.), and integrates
+  with formango for form validation.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: input
+requires:
+  - input-system
+exports:
+  - UITextField
+  - UITextFieldProps
+---
+
+# UITextField
+
+A single-line text input field with built-in label, hint, error message, icons, and loading state.
+
+## When to Use
+
+- Capturing short text values: names, emails, passwords, phone numbers, URLs, search queries
+- Any single-line text input that needs label, validation, and accessibility support
+- When you need built-in formango integration for form validation
+
+**Use instead:** [UITextareaField](../textarea-field/SKILL.md) for multi-line text, [UINumberField](../number-field/SKILL.md) for numeric values, [UIAutocomplete](../autocomplete/SKILL.md) for text with suggestions.
+
+## Import
+
+```ts
+import { UITextField } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UITextField } from '@wisemen/vue-core-design-system'
+
+const name = ref<string | null>(null)
+</script>
+
+<template>
+  <UITextField
+    v-model="name"
+    label="Name"
+    placeholder="Enter your name..."
+  />
+</template>
+```
+
+## API
+
+### Props
+
+> Inherits from: `Input`, `AutocompleteInput`, `InputWrapper`, `FieldWrapper` (see [input-system](../../foundations/input-system/SKILL.md))
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `size` | `'md' \| 'sm'` | `'md'` | The size of the text field. Controls height (`h-8` for md, `h-7` for sm) and horizontal padding. |
+| `type` | `'email' \| 'password' \| 'search' \| 'tel' \| 'text' \| 'time' \| 'url'` | `'text'` | The native input type attribute. |
+
+### v-model
+
+| Model | Type | Required | Description |
+|-------|------|----------|-------------|
+| `modelValue` | `string \| null` | Yes | The current text value. `null` means empty. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `label-left` | Content rendered to the left of the label text. |
+| `label-right` | Content rendered to the right of the label text. |
+| `left` | Content rendered inside the FieldWrapper, to the left of the input. |
+| `right` | Content rendered inside the FieldWrapper, to the right of the input. |
+
+### Emits
+
+This component has no custom events beyond the standard `update:modelValue`.
+
+### Exposed
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `input` | `Ref<HTMLInputElement>` | Template ref to the native `<input>` element. |
+
+## Variants
+
+### Size
+
+| Size | Height | Padding |
+|------|--------|---------|
+| `md` | `h-8` (32px) | `px-md` |
+| `sm` | `h-7` (28px) | `px-sm` |
+
+## Examples
+
+### Basic Usage
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UITextField } from '@wisemen/vue-core-design-system'
+
+const email = ref<string | null>(null)
+</script>
+
+<template>
+  <UITextField
+    v-model="email"
+    label="Email"
+    placeholder="you@example.com"
+    type="email"
+    hint="We'll never share your email"
+    :is-required="true"
+  />
+</template>
+```
+
+### With Formango
+
+```vue
+<script setup lang="ts">
+import { useForm } from '@wisemen/formango'
+import { UITextField } from '@wisemen/vue-core-design-system'
+import { z } from 'zod'
+
+const { form } = useForm({
+  schema: z.object({
+    firstName: z.string().min(1, 'First name is required'),
+    lastName: z.string().min(1, 'Last name is required'),
+  }),
+  onSubmit(values) {
+    console.log(values)
+  },
+})
+
+const firstName = form.register('firstName')
+const lastName = form.register('lastName')
+</script>
+
+<template>
+  <UITextField
+    v-model="firstName.modelValue.value"
+    :error-message="firstName.isTouched.value ? firstName.errors.value?._errors?.[0] ?? null : null"
+    :is-required="true"
+    label="First Name"
+    placeholder="John"
+    @blur="firstName.setTouched()"
+  />
+  <UITextField
+    v-model="lastName.modelValue.value"
+    :error-message="lastName.isTouched.value ? lastName.errors.value?._errors?.[0] ?? null : null"
+    :is-required="true"
+    label="Last Name"
+    placeholder="Doe"
+    @blur="lastName.setTouched()"
+  />
+</template>
+```
+
+### With Icons
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { SearchIcon, MailIcon } from '@wisemen/vue-core-icons'
+import { UITextField } from '@wisemen/vue-core-design-system'
+
+const search = ref<string | null>(null)
+</script>
+
+<template>
+  <UITextField
+    v-model="search"
+    :icon-left="SearchIcon"
+    label="Search"
+    placeholder="Search..."
+    type="search"
+  />
+</template>
+```
+
+### Small Size
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UITextField } from '@wisemen/vue-core-design-system'
+
+const value = ref<string | null>(null)
+</script>
+
+<template>
+  <UITextField
+    v-model="value"
+    size="sm"
+    label="Compact field"
+    placeholder="Smaller input..."
+  />
+</template>
+```
+
+## Anatomy
+
+```
+InputWrapper
+├── InputWrapperLabel          (label text + asterisk + help icon)
+├── FieldWrapper
+│   ├── FieldWrapperIcon       (iconLeft)
+│   ├── slot#left
+│   ├── <input>                (native input element)
+│   ├── slot#right
+│   ├── FieldWrapperIcon       (iconRight) OR FieldWrapperLoader
+│   └──
+├── InputWrapperHint           (hint text)
+└── InputWrapperErrorMessage   (error text)
+```
+
+## Styling
+
+**Style file:** `src/ui/text-field/textField.style.ts`
+**tv() slots:**
+- `input` -- The native input element. Truncated, transparent background, themed text colors. Includes placeholder, read-only, and disabled states.
+
+Size variants control horizontal padding (`px-md` for md, `px-sm` for sm).
+
+## Common Mistakes
+
+### CRITICAL: Passing errorMessage without checking touched state
+
+Wrong:
+```vue
+<UITextField
+  v-model="field.modelValue.value"
+  :error-message="field.errors.value?._errors?.[0]"
+/>
+<!-- Shows error immediately before user interacts -->
+```
+
+Correct:
+```vue
+<UITextField
+  v-model="field.modelValue.value"
+  :error-message="field.isTouched.value ? field.errors.value?._errors?.[0] ?? null : null"
+  @blur="field.setTouched()"
+/>
+```
+
+Always gate error display on `isTouched` so errors only appear after the user has interacted with the field.
+
+### HIGH: Using native HTML attributes instead of component props
+
+Wrong:
+```vue
+<UITextField v-model="val" disabled readonly required />
+```
+
+Correct:
+```vue
+<UITextField v-model="val" :is-disabled="true" :is-readonly="true" :is-required="true" />
+```
+
+The component uses `is-` prefixed boolean props to control ARIA attributes, data attributes, and disabled-reason tooltips.
+
+### MEDIUM: Forgetting v-model is required
+
+Wrong:
+```vue
+<UITextField label="Name" placeholder="Enter name..." />
+<!-- TypeScript error: v-model is required -->
+```
+
+Correct:
+```vue
+<UITextField v-model="name" label="Name" placeholder="Enter name..." />
+```
+
+The `modelValue` is required. Always bind with `v-model`.
+
+## Accessibility
+
+- `useInput` composable auto-generates: `aria-invalid`, `aria-describedby`, `aria-required`, `aria-busy`
+- `aria-describedby` links to hint and error message elements by id
+- Label is associated via `for` attribute matching the input `id` (auto-generated if not provided)
+- `isLabelHidden` renders the label with `sr-only` so it remains accessible to screen readers
+- Keyboard: fully native `<input>` behavior (Tab to focus, type to enter, etc.)
+
+## See Also
+
+- [input-system](../../foundations/input-system/SKILL.md) -- Inherited props and architecture
+- [textarea-field](../textarea-field/SKILL.md) -- Multi-line text input
+- [number-field](../number-field/SKILL.md) -- Numeric input with formatting

--- a/packages/web/design-system/skills/components/text/SKILL.md
+++ b/packages/web/design-system/skills/components/text/SKILL.md
@@ -6,7 +6,6 @@ description: >
   overflows. Load this skill when displaying text that may overflow its container.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/text/SKILL.md
+++ b/packages/web/design-system/skills/components/text/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: text
+description: >
+  Typography component with automatic truncation detection and tooltip. Renders
+  text that truncates with an ellipsis and shows a tooltip on hover when content
+  overflows. Load this skill when displaying text that may overflow its container.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UIText
+  - useIsTruncated
+---
+
+# UIText
+
+Renders text with automatic truncation and a hover tooltip when the content overflows its container.
+
+## When to Use
+
+- Displaying text that may be too long for its container (names, titles, descriptions)
+- Showing single-line truncated text with a tooltip fallback
+- Rendering multi-line clamped text (2-6 lines)
+
+**Use instead:** A plain `<span>` or `<p>` when text will never overflow, or `UIAdaptiveContent` for space-adaptive layout decisions.
+
+## Import
+
+```ts
+import { UIText } from '@wisemen/vue-core-design-system'
+// Optional: composable for custom truncation detection
+import { useIsTruncated } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIText } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="w-64">
+    <UIText text="This text will truncate if it exceeds the container width" />
+  </div>
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `text` | `string` | **(required)** | The text content to display. |
+| `as` | `string` | `'span'` | The HTML element or component to render as the text container. |
+| `class` | `string \| null` | `null` | Additional CSS classes to apply to the text element. |
+| `disableTooltip` | `boolean` | `false` | If `true`, the tooltip will be disabled even if the text is truncated. |
+| `truncate` | `boolean \| 2 \| 3 \| 4 \| 5 \| 6` | `true` | If `true`, single-line truncation. If a number (2-6), multi-line clamping. |
+
+### Slots
+
+This component has no slots. Content is set via the `text` prop.
+
+### Emits
+
+This component has no custom events.
+
+## Variants
+
+### Truncation Modes
+
+| Value | Behavior |
+|-------|----------|
+| `true` | Single-line truncation with ellipsis (`truncate` CSS class) |
+| `2` | Clamp to 2 lines (`line-clamp-2`) |
+| `3` | Clamp to 3 lines (`line-clamp-3`) |
+| `4` | Clamp to 4 lines (`line-clamp-4`) |
+| `5` | Clamp to 5 lines (`line-clamp-5`) |
+| `6` | Clamp to 6 lines (`line-clamp-6`) |
+
+## Examples
+
+### Single-Line Truncation (Default)
+
+```vue
+<script setup lang="ts">
+import { UIText } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="w-64">
+    <UIText text="This is a long piece of text that will be truncated with an ellipsis" />
+  </div>
+</template>
+```
+
+### Multi-Line Clamp
+
+```vue
+<script setup lang="ts">
+import { UIText } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="w-64">
+    <UIText
+      :truncate="3"
+      text="This is a long piece of text that will be clamped to three lines. Any content beyond the third line will be hidden with an ellipsis."
+      as="p"
+    />
+  </div>
+</template>
+```
+
+### As a Heading
+
+```vue
+<script setup lang="ts">
+import { UIText } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="w-64">
+    <UIText
+      as="h1"
+      class="text-xl font-bold"
+      text="Dashboard Overview"
+    />
+  </div>
+</template>
+```
+
+### Disabled Tooltip
+
+```vue
+<script setup lang="ts">
+import { UIText } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <div class="w-64">
+    <UIText
+      :disable-tooltip="true"
+      text="This text truncates but will not show a tooltip on hover"
+    />
+  </div>
+</template>
+```
+
+### Using the useIsTruncated Composable
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useIsTruncated } from '@wisemen/vue-core-design-system'
+
+const textRef = ref<HTMLElement | null>(null)
+const isTruncated = useIsTruncated(textRef)
+</script>
+
+<template>
+  <div class="w-64">
+    <span ref="textRef" class="truncate">
+      Custom element with truncation detection
+    </span>
+    <span v-if="isTruncated" class="text-xs text-tertiary">
+      (content is truncated)
+    </span>
+  </div>
+</template>
+```
+
+## Anatomy
+
+```
+UIText
+└── ActionTooltip  (shows full text on hover when truncated)
+    └── <Component :is="as">  (dynamic element: span, p, h1, etc.)
+            └── {{ text }}
+```
+
+## Styling
+
+**Style file:** `src/ui/text/text.style.ts`
+**tv() slots:** `text`
+**Customization:** Pass a `class` prop to add custom CSS classes (e.g., `text-xl font-bold`). The component always applies `max-w-full` as a base class. Truncation classes are applied based on the `truncate` prop value.
+
+## Common Mistakes
+
+### HIGH: Not constraining the parent container width
+
+Wrong:
+```vue
+<!-- No width constraint: text will never truncate -->
+<UIText text="Some very long text..." />
+```
+
+Correct:
+```vue
+<!-- Parent has a width constraint -->
+<div class="w-64">
+  <UIText text="Some very long text..." />
+</div>
+```
+
+The text only truncates when it overflows its container. Without a width constraint on a parent element, the text will expand to fit and never trigger truncation or the tooltip.
+
+### MEDIUM: Using a slot instead of the text prop
+
+Wrong:
+```vue
+<UIText>Some text content</UIText>
+```
+
+Correct:
+```vue
+<UIText text="Some text content" />
+```
+
+UIText does not use slots for content. The `text` prop is required because the same string is used both for rendering and for the tooltip content.
+
+## Accessibility
+
+UIText uses `ActionTooltip` internally to show the full text when truncated. The tooltip appears on hover and focus, providing keyboard-accessible access to the full content. The component uses a `ResizeObserver` to dynamically detect when text is truncated. The tooltip is only shown when content actually overflows, avoiding unnecessary tooltip noise.
+
+## See Also
+
+- [UIActionTooltip](../action-tooltip/SKILL.md) -- The tooltip component used internally
+- [UIAdaptiveContent](../adaptive-content/SKILL.md) -- For showing/hiding content based on available space

--- a/packages/web/design-system/skills/components/textarea-field/SKILL.md
+++ b/packages/web/design-system/skills/components/textarea-field/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: textarea-field
+description: >
+  Multi-line text input with auto-resize, character count, and configurable
+  resize behavior. Wraps a native <textarea> inside InputWrapper with its own
+  bordered container. Integrates with formango for form validation.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: input
+requires:
+  - input-system
+exports:
+  - UITextareaField
+  - UITextareaFieldProps
+---
+
+# UITextareaField
+
+A multi-line text input field with label, hint, error message, optional character count, and configurable resize behavior.
+
+## When to Use
+
+- Capturing multi-line text: messages, descriptions, comments, notes
+- When you need auto-growing textarea that expands with content
+- When you need a character count limit displayed to the user
+
+**Use instead:** [UITextField](../text-field/SKILL.md) for single-line text inputs.
+
+## Import
+
+```ts
+import { UITextareaField } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UITextareaField } from '@wisemen/vue-core-design-system'
+
+const message = ref<string | null>(null)
+</script>
+
+<template>
+  <UITextareaField
+    v-model="message"
+    label="Message"
+    placeholder="Write your message..."
+  />
+</template>
+```
+
+## API
+
+### Props
+
+> Inherits from: `Input`, `AutocompleteInput`, `InputWrapper`, `DisabledWithReason` (see [input-system](../../foundations/input-system/SKILL.md))
+>
+> Note: TextareaField does NOT inherit from `FieldWrapper` -- it has its own bordered container with `placeholder` defined directly on its props.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isSpellCheckEnabled` | `boolean` | `false` | Whether the textarea has spell-check enabled via the native `spellcheck` attribute. |
+| `maxHeight` | `string \| null` | `null` | Maximum height of the textarea (e.g. `'200px'`, `'10rem'`). Applied as inline style. |
+| `maxLength` | `number \| null` | `null` | Maximum number of characters. When set, a character count (e.g. `12/500`) replaces the hint text. |
+| `minHeight` | `string \| null` | `null` | Minimum height of the textarea (e.g. `'100px'`, `'5rem'`). Applied as inline style. |
+| `placeholder` | `string \| null` | `null` | Placeholder text displayed when the textarea is empty. |
+| `resize` | `'auto-vertical' \| 'none' \| 'vertical'` | `'none'` | Controls resize behavior. `auto-vertical` grows with content; `vertical` allows manual resize; `none` disables resizing. |
+
+### v-model
+
+| Model | Type | Required | Description |
+|-------|------|----------|-------------|
+| `modelValue` | `string \| null` | Yes | The current text value. `null` means empty. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `label-left` | Content rendered to the left of the label text. |
+| `label-right` | Content rendered to the right of the label text. |
+| `top` | Content rendered inside the bordered container, above the textarea. |
+| `bottom` | Content rendered inside the bordered container, below the textarea. |
+
+### Emits
+
+This component has no custom events beyond the standard `update:modelValue`.
+
+## Variants
+
+### Resize
+
+| Value | Behavior |
+|-------|----------|
+| `none` | Textarea cannot be resized. Default. |
+| `vertical` | User can drag the bottom edge to resize vertically. |
+| `auto-vertical` | Textarea auto-grows vertically to fit content. Combined with `maxHeight` to cap the growth. |
+
+## Examples
+
+### Basic Usage
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UITextareaField } from '@wisemen/vue-core-design-system'
+
+const description = ref<string | null>(null)
+</script>
+
+<template>
+  <UITextareaField
+    v-model="description"
+    label="Description"
+    placeholder="Enter a description..."
+    hint="Optional"
+  />
+</template>
+```
+
+### With Formango
+
+```vue
+<script setup lang="ts">
+import { useForm } from '@wisemen/formango'
+import { UITextareaField } from '@wisemen/vue-core-design-system'
+import { z } from 'zod'
+
+const { form } = useForm({
+  schema: z.object({
+    message: z.string().min(10, 'Message must be at least 10 characters'),
+  }),
+  onSubmit(values) {
+    console.log(values)
+  },
+})
+
+const message = form.register('message')
+</script>
+
+<template>
+  <UITextareaField
+    v-model="message.modelValue.value"
+    :error-message="message.isTouched.value ? message.errors.value?._errors?.[0] ?? null : null"
+    :is-required="true"
+    label="Message"
+    placeholder="Write your message..."
+    resize="auto-vertical"
+    @blur="message.setTouched()"
+  />
+</template>
+```
+
+### Auto-Resize with Max Height
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UITextareaField } from '@wisemen/vue-core-design-system'
+
+const notes = ref<string | null>(null)
+</script>
+
+<template>
+  <UITextareaField
+    v-model="notes"
+    label="Notes"
+    placeholder="Start typing..."
+    resize="auto-vertical"
+    max-height="300px"
+    min-height="100px"
+  />
+</template>
+```
+
+### Character Count
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UITextareaField } from '@wisemen/vue-core-design-system'
+
+const bio = ref<string | null>(null)
+</script>
+
+<template>
+  <UITextareaField
+    v-model="bio"
+    label="Bio"
+    placeholder="Tell us about yourself..."
+    :max-length="500"
+  />
+  <!-- Hint area shows "42/500" instead of custom hint text -->
+</template>
+```
+
+### Toolbar with Top/Bottom Slots
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UITextareaField } from '@wisemen/vue-core-design-system'
+
+const content = ref<string | null>(null)
+</script>
+
+<template>
+  <UITextareaField
+    v-model="content"
+    label="Content"
+    placeholder="Write here..."
+  >
+    <template #top>
+      <div class="flex gap-2 border-b border-primary p-2">
+        <!-- Toolbar buttons here -->
+      </div>
+    </template>
+  </UITextareaField>
+</template>
+```
+
+## Anatomy
+
+```
+InputWrapper
+├── InputWrapperLabel          (label text + asterisk + help icon)
+├── div.root                   (bordered container, replaces FieldWrapper)
+│   ├── slot#top
+│   ├── <textarea>             (native textarea element)
+│   └── slot#bottom
+├── InputWrapperHint           (hint text OR character count when maxLength is set)
+└── InputWrapperErrorMessage   (error text)
+```
+
+Note: Unlike TextField and NumberField, TextareaField does NOT use FieldWrapper. It has its own bordered `div.root` container that wraps the textarea, with `top` and `bottom` slots for custom content.
+
+## Styling
+
+**Style file:** `src/ui/textarea-field/textareaField.style.ts`
+**tv() slots:**
+- `root` -- The bordered container. Includes focus-visible, error, and disabled states.
+- `textarea` -- The native textarea. Themed text, placeholder, read-only, and disabled styles.
+
+Resize variants control CSS `resize` property (`resize-none` for `none` and `auto-vertical`, `resize-y` for `vertical`).
+
+The textarea has a default `min-h-20` (80px) and padding `px-md py-sm`.
+
+## Common Mistakes
+
+### CRITICAL: Passing errorMessage without checking touched state
+
+Wrong:
+```vue
+<UITextareaField
+  v-model="field.modelValue.value"
+  :error-message="field.errors.value?._errors?.[0]"
+/>
+```
+
+Correct:
+```vue
+<UITextareaField
+  v-model="field.modelValue.value"
+  :error-message="field.isTouched.value ? field.errors.value?._errors?.[0] ?? null : null"
+  @blur="field.setTouched()"
+/>
+```
+
+### HIGH: Setting maxLength without understanding hint override
+
+When `maxLength` is set, the character count (e.g. `42/500`) replaces the `hint` prop entirely. If you need both a hint and a character count, you cannot use both simultaneously -- `maxLength` takes priority.
+
+### MEDIUM: Using auto-vertical without maxHeight
+
+```vue
+<!-- Textarea grows unbounded, potentially pushing content off screen -->
+<UITextareaField v-model="val" resize="auto-vertical" />
+```
+
+Consider setting `maxHeight` when using `auto-vertical` to prevent the textarea from growing beyond a reasonable size:
+
+```vue
+<UITextareaField v-model="val" resize="auto-vertical" max-height="300px" />
+```
+
+## Accessibility
+
+- `useInput` composable auto-generates: `aria-invalid`, `aria-describedby`, `aria-required`
+- `aria-describedby` links to hint/error message elements by id
+- Label is associated via `for` attribute matching the textarea `id` (auto-generated if not provided)
+- Native `maxlength` attribute is set when `maxLength` prop is provided, preventing over-typing
+- `spellcheck` attribute controlled via `isSpellCheckEnabled`
+- Keyboard: fully native `<textarea>` behavior (Tab to focus, Enter for new line, etc.)
+
+## See Also
+
+- [input-system](../../foundations/input-system/SKILL.md) -- Inherited props and architecture
+- [text-field](../text-field/SKILL.md) -- Single-line text input

--- a/packages/web/design-system/skills/components/textarea-field/SKILL.md
+++ b/packages/web/design-system/skills/components/textarea-field/SKILL.md
@@ -6,7 +6,6 @@ description: >
   bordered container. Integrates with formango for form validation.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: input
 requires:
   - input-system

--- a/packages/web/design-system/skills/components/theme-provider/SKILL.md
+++ b/packages/web/design-system/skills/components/theme-provider/SKILL.md
@@ -6,7 +6,6 @@ description: >
   wrapper element. Supports nesting for scoped theme overrides.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: infrastructure
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/theme-provider/SKILL.md
+++ b/packages/web/design-system/skills/components/theme-provider/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: theme-provider
+description: >
+  Provides appearance (light, dark, system) and theme (named theme class) to all
+  descendant components. Applies the theme and appearance as CSS classes on a
+  wrapper element. Supports nesting for scoped theme overrides.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: infrastructure
+requires: []
+exports:
+  - UIThemeProvider
+---
+
+# UIThemeProvider
+
+Provides appearance (light/dark/system) and a named theme class to all descendant components. Applies both as CSS classes on a wrapper element, enabling scoped theme switching and nesting.
+
+## When to Use
+
+- At the application root to set the global appearance (light/dark/system) and theme
+- Nested inside the tree to override the theme or appearance for a specific section (e.g., a dark sidebar within a light app)
+- To wrap portalled content (dropdowns, modals) so they inherit the correct theme
+
+**Use instead:** Nothing -- this is the only mechanism for controlling appearance and theme in the design system.
+
+## Import
+
+```ts
+import { UIThemeProvider } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UIConfigProvider, UIThemeProvider } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIConfigProvider locale="en-US">
+    <UIThemeProvider appearance="system">
+      <RouterView />
+    </UIThemeProvider>
+  </UIConfigProvider>
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `appearance` | `'light' \| 'dark' \| 'system' \| null` | `null` | Controls the color scheme. When `null`, inherits from the parent `UIThemeProvider`. Falls back to `'light'` if no parent provides a value. |
+| `theme` | `string \| 'default' \| null` | `null` | The named theme applied as a CSS class. When `null`, inherits from the parent `UIThemeProvider`. Falls back to `'default'` if no parent provides a value. |
+| `asChild` | `boolean` | `false` | When `true`, does not render its own wrapper element -- instead applies the theme/appearance classes to the immediate child element (uses Reka UI's `Primitive` with `as-child`). |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | Application content that receives the theme and appearance. |
+
+### Emits
+
+This component has no events.
+
+## Variants
+
+### Appearance
+
+| Value | Description |
+|-------|-------------|
+| `'light'` | Light color scheme. |
+| `'dark'` | Dark color scheme. |
+| `'system'` | Follows the user's OS/browser preference (`prefers-color-scheme`). |
+
+### Theme
+
+Themes are project-specific named CSS classes (e.g., `'default'`, `'brand-a'`, `'brand-b'`). The value is applied directly as a CSS class on the wrapper element.
+
+## Examples
+
+### Application Root Setup
+
+```vue
+<script setup lang="ts">
+import { UIConfigProvider, UIThemeProvider } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIConfigProvider locale="en-US">
+    <UIThemeProvider appearance="light" theme="default">
+      <RouterView />
+    </UIThemeProvider>
+  </UIConfigProvider>
+</template>
+```
+
+### Dark Mode Toggle
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { UIThemeProvider, UIButton } from '@wisemen/vue-core-design-system'
+import type { Appearance } from '@wisemen/vue-core-design-system'
+
+const appearance = ref<Appearance>('light')
+
+function toggleAppearance(): void {
+  appearance.value = appearance.value === 'light' ? 'dark' : 'light'
+}
+</script>
+
+<template>
+  <UIThemeProvider :appearance="appearance">
+    <UIButton label="Toggle theme" @click="toggleAppearance" />
+    <RouterView />
+  </UIThemeProvider>
+</template>
+```
+
+### Nested Theme Override (Dark Sidebar)
+
+```vue
+<script setup lang="ts">
+import { UIThemeProvider } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UIThemeProvider appearance="light">
+    <div class="flex">
+      <!-- Force dark appearance on the sidebar only -->
+      <UIThemeProvider appearance="dark" :as-child="true">
+        <aside class="w-64 bg-primary text-primary">
+          Sidebar content
+        </aside>
+      </UIThemeProvider>
+
+      <main class="flex-1">
+        Main content (light)
+      </main>
+    </div>
+  </UIThemeProvider>
+</template>
+```
+
+### Using asChild to Avoid Extra Wrapper
+
+```vue
+<script setup lang="ts">
+import { UIThemeProvider } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <!-- No extra wrapper div; classes applied directly to the section -->
+  <UIThemeProvider appearance="dark" :as-child="true">
+    <section class="p-4">
+      Dark-themed section
+    </section>
+  </UIThemeProvider>
+</template>
+```
+
+## Anatomy
+
+```
+UIThemeProvider
+  Primitive (div or as-child, with class="[theme] [appearance]")
+    <slot />
+```
+
+When `asChild` is `false` (default), the component renders a `<div>` with the theme and appearance as CSS classes. When `asChild` is `true`, it applies those classes to the direct child element instead.
+
+## Styling
+
+This component has no visual styles of its own. It applies two CSS classes to its wrapper element:
+
+1. **Theme class** -- The `theme` prop value (e.g., `default`, `brand-a`). Used by your CSS to scope design tokens.
+2. **Appearance class** -- The resolved appearance (`light` or `dark`). Used by Tailwind's `dark:` variant and CSS custom properties.
+
+The component itself has no style file.
+
+## Common Mistakes
+
+### HIGH: Not wrapping portalled content
+
+Wrong:
+```vue
+<!-- Modal content renders outside the ThemeProvider via teleport -->
+<!-- It will not inherit the correct theme/appearance -->
+```
+
+The design system's dropdown and popover components already handle this internally -- `AutocompleteContent` and other portalled components wrap themselves in a `ThemeProvider`. You typically do not need to worry about this for built-in components.
+
+### MEDIUM: Using appearance="system" without understanding inheritance
+
+When nested, a child `UIThemeProvider` with `appearance="system"` will resolve based on the OS preference, not the parent's resolved appearance. If the parent is forced to `'dark'` and the child uses `'system'`, the child may render as light on a system with light preference.
+
+### LOW: Forgetting asChild when nesting inside flex/grid layouts
+
+Wrong:
+```vue
+<div class="flex">
+  <UIThemeProvider appearance="dark">
+    <!-- Adds an extra div wrapper that breaks the flex layout -->
+    <aside>Sidebar</aside>
+  </UIThemeProvider>
+</div>
+```
+
+Correct:
+```vue
+<div class="flex">
+  <UIThemeProvider appearance="dark" :as-child="true">
+    <aside>Sidebar</aside>
+  </UIThemeProvider>
+</div>
+```
+
+Without `asChild`, the component renders an extra `<div>` that may break CSS layouts. Use `:as-child="true"` when the wrapper element would interfere.
+
+## Accessibility
+
+- This component has no direct accessibility impact. It is a theming wrapper.
+- The `appearance` prop affects color contrast: ensure that both light and dark themes meet WCAG contrast requirements.
+- The `'system'` appearance respects the user's OS preference (`prefers-color-scheme`), which is the recommended default for accessibility.
+
+## See Also
+
+- [UIConfigProvider](../config-provider/) -- For locale, number formatting, and other application-wide configuration

--- a/packages/web/design-system/skills/components/timeline/SKILL.md
+++ b/packages/web/design-system/skills/components/timeline/SKILL.md
@@ -6,7 +6,6 @@ description: >
   skill when displaying chronological event sequences or activity feeds.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: display
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/timeline/SKILL.md
+++ b/packages/web/design-system/skills/components/timeline/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: timeline
+description: >
+  Vertical timeline component with indicator dots, connector lines, and content slots.
+  UITimeline wraps UITimelineItem children with shared size/variant context. Load this
+  skill when displaying chronological event sequences or activity feeds.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: display
+requires: []
+exports:
+  - UITimeline
+  - UITimelineItem
+  - UITimelineProps
+  - UITimelineItemProps
+---
+
+# UITimeline
+
+A vertical timeline that renders a sequence of events with indicator dots, connector lines, and content areas. `UITimeline` provides shared context (size, variant) to its `UITimelineItem` children.
+
+## When to Use
+
+- Displaying a chronological sequence of events (activity feeds, audit logs)
+- Showing step-by-step progress indicators
+- Rendering change history or version timelines
+
+**Use instead:** A plain ordered list when you do not need visual indicators or connectors. `UIBadge` for standalone status labels.
+
+## Import
+
+```ts
+import { UITimeline, UITimelineItem } from '@wisemen/vue-core-design-system'
+import type { UITimelineProps, UITimelineItemProps } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UITimeline, UITimelineItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UITimeline>
+    <UITimelineItem>
+      <p>First event</p>
+    </UITimelineItem>
+    <UITimelineItem>
+      <p>Second event</p>
+    </UITimelineItem>
+    <UITimelineItem :is-last="true">
+      <p>Latest event</p>
+    </UITimelineItem>
+  </UITimeline>
+</template>
+```
+
+## API
+
+### UITimeline Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `size` | `'md' \| 'sm'` | `'md'` | Controls the indicator size, connector width, gap, and content padding for all items. |
+| `variant` | `'outline' \| 'solid' \| 'subtle'` | `'solid'` | Visual style of the indicator dots for all items. |
+
+### UITimeline Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | `UITimelineItem` components representing each event in the timeline. |
+
+### UITimeline Emits
+
+This component has no custom events.
+
+### UITimelineItem Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isLast` | `boolean` | `false` | When `true`, hides the connector line below this item and removes bottom padding. Set on the final item. |
+| `icon` | `Component` | `undefined` | An optional icon component displayed inside the indicator circle. Rendered at `size-4`. |
+
+### UITimelineItem Slots
+
+| Slot | Description |
+|------|-------------|
+| `default` | The event content displayed to the right of the indicator and connector. |
+| `indicator` | Overrides the indicator content. When not provided and `icon` is set, the icon is rendered. When neither is provided, an empty indicator circle is shown. |
+
+### UITimelineItem Emits
+
+This component has no custom events.
+
+## Variants
+
+### Sizes
+
+| Size | Indicator | Gap | Content padding |
+|------|-----------|-----|-----------------|
+| `md` | `size-8` (32px) | `gap-md` | `pb-lg` |
+| `sm` | `size-6` (24px) | `gap-sm` | `pb-md` |
+
+### Visual Variants
+
+| Variant | Indicator style |
+|---------|----------------|
+| `solid` | `bg-brand-primary-alt` with `text-fg-brand-primary-alt` |
+| `outline` | `border border-secondary bg-primary` (hollow circle) |
+| `subtle` | `bg-tertiary text-secondary` |
+
+## Examples
+
+### Timeline with Icons
+
+```vue
+<script setup lang="ts">
+import { UITimeline, UITimelineItem } from '@wisemen/vue-core-design-system'
+import {
+  CheckCircleIcon,
+  MessageSquare01Icon,
+  User01Icon,
+} from '@wisemen/vue-core-icons'
+</script>
+
+<template>
+  <UITimeline size="md" variant="solid">
+    <UITimelineItem :icon="CheckCircleIcon">
+      <p class="text-xs font-medium">Task completed</p>
+      <p class="text-xs text-tertiary">The setup has been completed.</p>
+    </UITimelineItem>
+
+    <UITimelineItem :icon="MessageSquare01Icon">
+      <p class="text-xs font-medium">Comment added</p>
+      <p class="text-xs text-tertiary">Phoenix Baker left a comment.</p>
+    </UITimelineItem>
+
+    <UITimelineItem :icon="User01Icon" :is-last="true">
+      <p class="text-xs font-medium">User joined</p>
+      <p class="text-xs text-tertiary">A new member joined the project.</p>
+    </UITimelineItem>
+  </UITimeline>
+</template>
+```
+
+### Small Outline Timeline
+
+```vue
+<script setup lang="ts">
+import { UITimeline, UITimelineItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UITimeline size="sm" variant="outline">
+    <UITimelineItem>
+      <p class="text-xs">Step one</p>
+    </UITimelineItem>
+    <UITimelineItem>
+      <p class="text-xs">Step two</p>
+    </UITimelineItem>
+    <UITimelineItem :is-last="true">
+      <p class="text-xs">Step three</p>
+    </UITimelineItem>
+  </UITimeline>
+</template>
+```
+
+### Custom Indicator Slot
+
+```vue
+<script setup lang="ts">
+import { UITimeline, UITimelineItem } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UITimeline variant="outline">
+    <UITimelineItem>
+      <template #indicator>
+        <span class="text-xs font-bold">1</span>
+      </template>
+      <p>First step</p>
+    </UITimelineItem>
+    <UITimelineItem :is-last="true">
+      <template #indicator>
+        <span class="text-xs font-bold">2</span>
+      </template>
+      <p>Second step</p>
+    </UITimelineItem>
+  </UITimeline>
+</template>
+```
+
+## Anatomy
+
+```
+UITimeline
+  div.flex.flex-col                   (root)
+    UITimelineItem * N
+      div.flex                        (item)
+        div.flex.flex-col.items-center (itemTrack)
+          div.rounded-full            (indicator)
+            <slot name="indicator">
+              <icon />?
+            </slot>
+          div.bg-quaternary           (connector line, hidden when isLast)
+        div.flex.flex-col             (content)
+          <slot />
+```
+
+## Styling
+
+**Style file:** `src/ui/timeline/timeline.style.ts`
+**tv() slots:** `connector`, `content`, `indicator`, `item`, `itemTrack`, `root`
+
+The `connector` is a 1px-wide vertical line (`bg-quaternary`) that stretches between indicators. When `isLast` is `true`, the connector is set to `invisible` and content padding is removed.
+
+## Common Mistakes
+
+### HIGH: Forgetting isLast on the final item
+
+Wrong:
+```vue
+<UITimeline>
+  <UITimelineItem>First</UITimelineItem>
+  <UITimelineItem>Last</UITimelineItem>
+</UITimeline>
+```
+
+Correct:
+```vue
+<UITimeline>
+  <UITimelineItem>First</UITimelineItem>
+  <UITimelineItem :is-last="true">Last</UITimelineItem>
+</UITimeline>
+```
+
+Without `isLast`, the final item renders a dangling connector line below its indicator with extra bottom padding. Always set `:is-last="true"` on the last `UITimelineItem`.
+
+### MEDIUM: Nesting UITimelineItem outside UITimeline
+
+Wrong:
+```vue
+<UITimelineItem>Standalone event</UITimelineItem>
+```
+
+Correct:
+```vue
+<UITimeline>
+  <UITimelineItem :is-last="true">Standalone event</UITimelineItem>
+</UITimeline>
+```
+
+`UITimelineItem` injects context from `UITimeline` (size, variant). Using it without a parent `UITimeline` will throw a context injection error.
+
+## Accessibility
+
+- The timeline renders as plain `div` elements. For semantic meaning, consider wrapping it in an `<ol>` or adding `role="list"` with `role="listitem"` on items.
+- Icons inside indicators are purely decorative. Meaningful event information should be in the content slot.
+- The connector line is visual only and does not affect screen reader output.
+
+## See Also
+
+- [UIBadge](../badge/) -- For standalone status labels that can accompany timeline content

--- a/packages/web/design-system/skills/components/tooltip/SKILL.md
+++ b/packages/web/design-system/skills/components/tooltip/SKILL.md
@@ -7,7 +7,6 @@ description: >
   Load this skill for informational hover hints on buttons, icons, or interactive elements.
 type: component
 library: vue-core-design-system
-library_version: "0.8.0"
 category: overlay
 requires: []
 exports:

--- a/packages/web/design-system/skills/components/tooltip/SKILL.md
+++ b/packages/web/design-system/skills/components/tooltip/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: tooltip
+description: >
+  A hover/focus-triggered floating label built on Reka UI TooltipRoot. Supports
+  configurable delay, side positioning, arrow visibility, and custom content via slots.
+  Also exports UITooltipProvider, UITooltipContent, and UITooltipText helpers.
+  Load this skill for informational hover hints on buttons, icons, or interactive elements.
+type: component
+library: vue-core-design-system
+library_version: "0.8.0"
+category: overlay
+requires: []
+exports:
+  - UITooltip
+  - UITooltipProps
+  - UITooltipContent
+  - UITooltipProvider
+  - UITooltipText
+---
+
+# UITooltip
+
+A floating label that appears on hover or keyboard focus, providing brief informational text about a trigger element.
+
+## When to Use
+
+- Adding descriptive text to icon-only buttons
+- Explaining the purpose of a UI element on hover
+- Showing supplementary info that does not require interaction
+
+**Use instead:** `UIActionTooltip` for tooltips with a keyboard shortcut badge, `UIPopover` for interactive floating content, `UIDialog` for complex content that requires user action.
+
+## Import
+
+```ts
+import { UITooltip, UITooltipContent, UITooltipProvider, UITooltipText } from '@wisemen/vue-core-design-system'
+```
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { UITooltip, UIButton } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UITooltip :popover-side-offset="4">
+    <template #trigger>
+      <UIButton label="Hover me" />
+    </template>
+    <template #content>
+      <div class="flex px-sm py-xs">
+        <p class="text-xs text-secondary">Tooltip text</p>
+      </div>
+    </template>
+  </UITooltip>
+</template>
+```
+
+## API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isOpen` | `boolean` | `false` | Controls the open state (v-model). |
+| `isDisabled` | `boolean` | `false` | When true, the tooltip is hidden and will not appear. |
+| `delayDuration` | `number` | `300` | Milliseconds to wait before showing the tooltip on hover. |
+| `disableCloseOnTriggerClick` | `boolean` | `false` | When true, clicking the trigger will not close the tooltip. |
+| `disableHoverableContent` | `boolean` | `false` | When true, hovering the tooltip content closes it as the pointer leaves the trigger. |
+| `isPopoverArrowVisible` | `boolean` | `false` | Shows an arrow pointing to the trigger. |
+| `popoverAlign` | `'center' \| 'start' \| 'end'` | `'center'` | Alignment relative to the trigger. |
+| `popoverAlignOffset` | `number` | `0` | Offset in pixels from the alignment edge. |
+| `popoverAnchorReferenceElement` | `ReferenceElement \| null` | `null` | Custom anchor element. |
+| `popoverAnimationName` | `string \| null` | `null` | Custom animation name. Falls back to `'tooltip-default'`. |
+| `popoverCollisionPadding` | `number` | `0` | Padding for collision detection. |
+| `popoverContainerElement` | `HTMLElement \| null` | `null` | Boundary element for collision detection. |
+| `popoverSide` | `'top' \| 'right' \| 'bottom' \| 'left'` | `'top'` | Which side the tooltip appears on. |
+| `popoverSideOffset` | `number` | `0` | Distance in pixels between the tooltip and the trigger. |
+| `popoverWidth` | `'anchor-width' \| 'available-width' \| null` | `null` | Width behavior of the tooltip content. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `trigger` | The element that activates the tooltip on hover/focus. Must be a single root element. |
+| `content` | The content rendered inside the tooltip panel. |
+
+### Emits
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `update:isOpen` | `boolean` | Fired when the open state changes. |
+
+## Sub-Components
+
+### UITooltipProvider
+
+Wraps the app (or a section) to share tooltip delay behavior across nested tooltips. Built on Reka UI `TooltipProvider`.
+
+```vue
+<UITooltipProvider>
+  <slot />
+</UITooltipProvider>
+```
+
+No props. Place at the app root or around a group of tooltips.
+
+### UITooltipContent
+
+A pre-styled content wrapper for simple tooltip text. Applies `flex px-sm py-xs` padding.
+
+```vue
+<template #content>
+  <UITooltipContent>
+    Your text here
+  </UITooltipContent>
+</template>
+```
+
+No props. Has a default slot.
+
+### UITooltipText
+
+A text component for tooltip labels. Renders centered, truncation-disabled text at `text-xs text-secondary` with `max-w-xs`.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `text` | `string` | -- (required) | The text to display. |
+
+## Variants
+
+This component has no size/variant options. Styling is controlled via the `tv()` style file.
+
+**popoverWidth variants:**
+| Value | Effect |
+|-------|--------|
+| `'anchor-width'` | Matches the trigger element width. |
+| `'available-width'` | Expands to available viewport width. |
+| `null` | Uses natural content width. |
+
+## Examples
+
+### Simple Text Tooltip
+
+```vue
+<script setup lang="ts">
+import { UITooltip, UITooltipContent, UITooltipText, UIButton } from '@wisemen/vue-core-design-system'
+</script>
+
+<template>
+  <UITooltip :popover-side-offset="4" popover-side="top">
+    <template #trigger>
+      <UIButton label="Hover me" />
+    </template>
+    <template #content>
+      <UITooltipContent>
+        <UITooltipText text="Helpful information" />
+      </UITooltipContent>
+    </template>
+  </UITooltip>
+</template>
+```
+
+### With Arrow
+
+```vue
+<UITooltip :is-popover-arrow-visible="true" :popover-side-offset="4">
+  <template #trigger>
+    <UIButton label="Hover me" />
+  </template>
+  <template #content>
+    <div class="flex px-sm py-xs">
+      <p class="text-xs text-secondary">Tooltip with arrow</p>
+    </div>
+  </template>
+</UITooltip>
+```
+
+### Disabled Tooltip
+
+```vue
+<UITooltip :is-disabled="true">
+  <template #trigger>
+    <UIButton label="No tooltip here" />
+  </template>
+  <template #content>
+    <div class="flex px-sm py-xs">
+      <p class="text-xs text-secondary">You will not see this</p>
+    </div>
+  </template>
+</UITooltip>
+```
+
+### Rich Content
+
+```vue
+<UITooltip :popover-side-offset="4">
+  <template #trigger>
+    <UIButton label="Hover me" />
+  </template>
+  <template #content>
+    <div class="p-sm">
+      <p class="flex max-w-xs text-center text-xs font-medium text-secondary">
+        Tooltip title
+      </p>
+      <p class="mt-xs max-w-xs text-xs text-tertiary">
+        Additional description with more detail about this element.
+      </p>
+    </div>
+  </template>
+</UITooltip>
+```
+
+### All Sides
+
+```vue
+<UITooltip popover-side="top" :popover-side-offset="4">...</UITooltip>
+<UITooltip popover-side="right" :popover-side-offset="4">...</UITooltip>
+<UITooltip popover-side="bottom" :popover-side-offset="4">...</UITooltip>
+<UITooltip popover-side="left" :popover-side-offset="4">...</UITooltip>
+```
+
+## Anatomy
+
+```
+UITooltip
+├── RekaTooltipRoot (v-model:open, delay, disabled)
+│   ├── RekaTooltipTrigger (as-child)
+│   │   └── <slot name="trigger" />
+│   └── RekaTooltipPortal (to="body")
+│       └── ThemeProvider
+│           └── RekaTooltipContent (positioned, animated)
+│               ├── <div> (border, bg, shadow container)
+│               │   └── <slot name="content" />
+│               └── TooltipArrow (if isPopoverArrowVisible)
+```
+
+## Styling
+
+**Style file:** `src/ui/tooltip/tooltip.style.ts`
+**tv() slots:**
+- `content` -- `rounded-sm border border-secondary bg-primary shadow-lg`
+- `contentWrapper` -- `z-tooltip will-change-[transform,filter,opacity]`
+
+**Animations:** CSS keyframes `tooltipFadeIn` / `tooltipFadeOut` with blur effect. Duration: 150ms ease-in-out.
+
+## Common Mistakes
+
+### MEDIUM: Missing popoverSideOffset
+
+Without an offset, the tooltip overlaps the trigger:
+
+```vue
+<!-- Wrong -->
+<UITooltip popover-side="bottom">
+
+<!-- Correct -->
+<UITooltip popover-side="bottom" :popover-side-offset="4">
+```
+
+### LOW: Not wrapping with UITooltipProvider for shared delay
+
+When using many tooltips, wrapping with `UITooltipProvider` at the app root gives a smoother experience -- once one tooltip opens, others in the group open immediately without waiting for the delay.
+
+## Accessibility
+
+- Built on Reka UI Tooltip primitives with proper ARIA attributes.
+- Shows on keyboard focus (`ignoreNonKeyboardFocus` is true -- only keyboard focus triggers the tooltip, not programmatic focus).
+- Dismissed with Escape key.
+- Content is associated with the trigger via `aria-describedby`.
+- The tooltip is a non-interactive overlay; use `UIPopover` for interactive content.
+
+## See Also
+
+- [action-tooltip](../action-tooltip/SKILL.md) -- Pre-built tooltip with label and keyboard shortcut
+- [popover](../popover/SKILL.md) -- For interactive floating content triggered by click

--- a/packages/web/design-system/skills/foundations/architecture/SKILL.md
+++ b/packages/web/design-system/skills/foundations/architecture/SKILL.md
@@ -8,7 +8,6 @@ description: >
 type: foundation
 category: architecture
 library: vue-core-design-system
-library_version: "0.8.0"
 sources:
   - "packages/web/design-system/src/composables/context.composable.ts"
   - "packages/web/design-system/src/ui/badge/badge.context.ts"

--- a/packages/web/design-system/skills/foundations/architecture/SKILL.md
+++ b/packages/web/design-system/skills/foundations/architecture/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: architecture
+description: >
+  Core architecture patterns for @wisemen/vue-core-design-system: the parts pattern
+  (Root/Content/Icon sub-components), context system (useContext + provide/inject),
+  PropsToComputed utility, toComputedRefs, file naming conventions, and export
+  conventions (UI prefix). Load before building or extending any component.
+type: foundation
+category: architecture
+library: vue-core-design-system
+library_version: "0.8.0"
+sources:
+  - "packages/web/design-system/src/composables/context.composable.ts"
+  - "packages/web/design-system/src/ui/badge/badge.context.ts"
+  - "packages/web/design-system/src/ui/button/button/button.props.ts"
+---
+
+# Architecture
+
+Core patterns underlying every component in the design system.
+
+## Overview
+
+Every component follows a consistent **parts-based architecture** where a main wrapper component composes smaller sub-components (parts). Props flow from the root part to children via Vue's provide/inject context system, not prop drilling.
+
+## File Structure Convention
+
+Each component directory follows this layout:
+
+```
+component-name/
+├── ComponentName.vue           # Main wrapper — composes parts
+├── componentName.props.ts      # Props interface (PascalCase type, camelCase file)
+├── componentName.style.ts      # Tailwind Variants definition via tv()
+├── componentName.context.ts    # Context provider/injector pair
+├── parts/                      # Sub-components (optional)
+│   ├── ComponentNameRoot.vue   # Root part — provides context, applies base styles
+│   ├── ComponentNameContent.vue
+│   └── ComponentNameIcon.vue
+├── stories/                    # Storybook stories (optional)
+│   ├── componentName.story.ts
+│   └── ComponentNamePlayground.vue
+└── index.ts                    # Public exports
+```
+
+**Naming rules:**
+- Vue files: `PascalCase.vue`
+- TypeScript files: `camelCase.suffix.ts` (where suffix is `props`, `style`, `context`, `type`, `composable`)
+- Directories: `kebab-case`
+- Export prefix: `UI` (e.g., `UIButton`, `UITextField`)
+- Props type export: `UIComponentNameProps` (e.g., `UIButtonProps`)
+
+## Context System
+
+The `useContext` factory creates a matched provide/inject pair for any component:
+
+```ts
+import { useContext } from '@/composables/context.composable'
+
+interface BadgeContext {
+  color: ComputedRef<string>
+  size: ComputedRef<string>
+  style: ComputedRef<CreateBadgeStyle>
+  onRemove: () => void
+}
+
+export const [useProvideBadgeContext, useInjectBadgeContext] =
+  useContext<BadgeContext>('badgeContext')
+```
+
+### How useContext Works
+
+```ts
+function useContext<TContext>(contextName: string) {
+  const contextKey: InjectionKey<TContext> = Symbol(contextName)
+
+  function useProvideContext(context: TContext): TContext {
+    provide(contextKey, context)
+    return context
+  }
+
+  function useInjectContext<TFallback extends TContext | null = TContext>(
+    fallback?: TFallback
+  ): TFallback extends null ? TContext | null : TContext {
+    const context = inject(contextKey, fallback ?? undefined)
+    if (context === undefined && fallback === undefined) {
+      throw new Error(`${contextName} context is not provided.`)
+    }
+    return (context ?? null) as any
+  }
+
+  return [useProvideContext, useInjectContext] as const
+}
+```
+
+**Key behaviors:**
+- No fallback provided: throws if context missing (strict mode)
+- Fallback of `null`: returns `null` if context missing (optional mode)
+- Context is keyed by `Symbol`, so multiple components can use `useContext` independently
+
+### PropsToComputed
+
+Converts a props object to an object of `ComputedRef` values. Functions are passed through as-is (event handlers, callbacks).
+
+```ts
+type PropsToComputed<T> = {
+  [K in keyof Required<T>]: IsFunction<Exclude<T[K], undefined>> extends true
+    ? T[K]
+    : ComputedRef<Exclude<T[K], undefined>>;
+}
+```
+
+### toComputedRefs
+
+Runtime helper that wraps each prop in `computed()`:
+
+```ts
+function toComputedRefs<T>(props: T): PropsToComputed<T>
+```
+
+**Usage in Root component:**
+
+```vue
+<script setup lang="ts">
+const props = withDefaults(defineProps<BadgeProps>(), {
+  size: 'md',
+})
+
+useProvideBadgeContext({
+  ...toComputedRefs(props),
+  style: badgeStyle,
+  onRemove,
+})
+</script>
+```
+
+## Parts Pattern
+
+### Root Part (Provider)
+
+The Root part sets up context and applies the base element:
+
+```vue
+<!-- BadgeRoot.vue -->
+<script setup lang="ts">
+import { computed } from 'vue'
+import { toComputedRefs } from '@/composables/context.composable'
+import { useProvideBadgeContext } from '../badge.context'
+import { createBadgeStyle } from '../badge.style'
+
+const props = withDefaults(defineProps<BadgeProps>(), {
+  size: 'md',
+  icon: null,
+})
+
+const badgeStyle = computed(() => createBadgeStyle({
+  color: props.color,
+  size: props.size,
+  variant: props.variant,
+}))
+
+useProvideBadgeContext({
+  ...toComputedRefs(props),
+  style: badgeStyle,
+  onRemove,
+})
+</script>
+
+<template>
+  <div :class="badgeStyle.root()">
+    <slot />
+  </div>
+</template>
+```
+
+### Child Part (Consumer)
+
+Child parts inject the context and use computed values:
+
+```vue
+<!-- BadgeIcon.vue -->
+<script setup lang="ts">
+import { useInjectBadgeContext } from '../badge.context'
+
+const { icon, style } = useInjectBadgeContext()
+</script>
+
+<template>
+  <component
+    :is="icon"
+    v-if="icon"
+    :class="style.icon()"
+  />
+</template>
+```
+
+### Main Wrapper (Composition)
+
+The main component composes parts with slots:
+
+```vue
+<!-- Badge.vue -->
+<script setup lang="ts">
+const props = defineProps<BadgeProps>()
+const emit = defineEmits<BadgeEmits>()
+</script>
+
+<template>
+  <BadgeRoot v-bind="props" @remove="emit('remove')">
+    <BadgeIcon />
+    <slot name="left" />
+    <slot />
+    <slot name="right" />
+    <BadgeRemoveButton />
+  </BadgeRoot>
+</template>
+```
+
+## Export Convention
+
+Every `index.ts` exports:
+1. The main component with `UI` prefix
+2. Props type with `UI` prefix
+3. Individual parts with `UI` prefix (for advanced composition)
+4. Style factory function (for extending styles)
+
+```ts
+// badge/index.ts
+export { type BadgeProps as UIBadgeProps } from './badge.props'
+export { default as UIBadge } from './Badge.vue'
+```
+
+Consumers import from the package:
+
+```ts
+import { UIBadge } from '@wisemen/vue-core-design-system'
+import type { UIBadgeProps } from '@wisemen/vue-core-design-system'
+```
+
+## Common Mistakes
+
+### CRITICAL: Forgetting to provide context in Root
+
+Wrong:
+```vue
+<!-- Root component without useProvideContext -->
+<script setup lang="ts">
+const props = defineProps<BadgeProps>()
+// Missing: useProvideBadgeContext(...)
+</script>
+```
+
+Child parts will throw: `"badgeContext context is not provided."`
+
+Correct: Always call `useProvideContext` in the Root part's setup.
+
+### HIGH: Mutating context values directly
+
+Wrong:
+```ts
+const { size } = useInjectBadgeContext()
+size.value = 'lg' // Don't mutate injected ComputedRef
+```
+
+Context values are `ComputedRef` — read-only by design. Change props on the Root instead.
+
+### MEDIUM: Using wrong import path
+
+Wrong:
+```ts
+import { UIBadge } from '@wisemen/vue-core-design-system/src/ui/badge'
+```
+
+Correct:
+```ts
+import { UIBadge } from '@wisemen/vue-core-design-system'
+```
+
+Always import from the package root.
+
+## See Also
+
+- [Styling](../styling/SKILL.md) — How tv() and design tokens work
+- [Input System](../input-system/SKILL.md) — How input components extend this architecture

--- a/packages/web/design-system/skills/foundations/input-system/SKILL.md
+++ b/packages/web/design-system/skills/foundations/input-system/SKILL.md
@@ -10,7 +10,6 @@ description: >
 type: foundation
 category: input-architecture
 library: vue-core-design-system
-library_version: "0.8.0"
 sources:
   - "packages/web/design-system/src/types/input.type.ts"
   - "packages/web/design-system/src/types/disabledWithReason.type.ts"

--- a/packages/web/design-system/skills/foundations/input-system/SKILL.md
+++ b/packages/web/design-system/skills/foundations/input-system/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: input-system
+description: >
+  The InputWrapper > FieldWrapper > native element architecture shared by all
+  input components (TextField, TextareaField, NumberField, Select, Autocomplete,
+  Checkbox, etc.). Covers the Input, InputWrapper, FieldWrapper, AutocompleteInput
+  interfaces, their default constants, the useInput composable for ARIA generation,
+  and the DisabledWithReason pattern. Load before implementing or modifying any
+  input or form control component.
+type: foundation
+category: input-architecture
+library: vue-core-design-system
+library_version: "0.8.0"
+sources:
+  - "packages/web/design-system/src/types/input.type.ts"
+  - "packages/web/design-system/src/types/disabledWithReason.type.ts"
+  - "packages/web/design-system/src/composables/input.composable.ts"
+  - "packages/web/design-system/src/ui/input-wrapper/InputWrapper.vue"
+  - "packages/web/design-system/src/ui/field-wrapper/FieldWrapper.vue"
+---
+
+# Input System
+
+The shared architecture underlying all input and form control components.
+
+## Overview
+
+Every input component is built on a three-layer composition stack:
+
+```
+InputWrapper          (label, hint, error message, help text)
+  └── FieldWrapper    (border, icons, loading spinner, placeholder)
+        └── <input>   (native element or custom control)
+```
+
+Props flow through this stack via interface inheritance. A component like `TextFieldProps` extends `Input`, `AutocompleteInput`, `InputWrapper`, and `FieldWrapper` — inheriting all their props automatically.
+
+## Interfaces
+
+### Input
+
+Shared properties for the native input element itself.
+
+```ts
+interface Input extends DisabledWithReason {
+  id?: string | null              // Element id (auto-generated if null)
+  isReadonly?: boolean            // Read-only mode
+  isRequired?: boolean           // Required field (shows asterisk)
+  name?: string | null           // Native name attribute
+  class?: string | null          // Additional CSS classes
+  style?: Record<string, string> | null  // Additional inline styles
+}
+```
+
+### InputWrapper
+
+Properties for the label/hint/error area that wraps around the field.
+
+```ts
+interface InputWrapper extends DisabledWithReason {
+  isHorizontal?: boolean         // Horizontal layout (label left, input right)
+  isLabelHidden?: boolean        // Visually hidden label (sr-only)
+  isRequired?: boolean           // Shows asterisk next to label
+  errorMessage?: string | null   // Error text below input
+  for?: string | null            // Label for attribute
+  helpText?: string | null       // Tooltip text next to label (shows help icon)
+  hideErrorMessage?: boolean     // Hide error text (border still shows)
+  hint?: string | null           // Help text below input
+  label?: string | null          // Label text above input
+}
+```
+
+### FieldWrapper
+
+Properties for the bordered input area with icons and loading state.
+
+```ts
+interface FieldWrapper {
+  isDisabled?: boolean           // Disables the input
+  isLoading?: boolean            // Shows loading spinner
+  isReadonly?: boolean           // Read-only state
+  iconLeft?: Component | null    // Left icon component
+  iconRight?: Component | null   // Right icon component
+  placeholder?: string | null    // Placeholder text
+}
+```
+
+### AutocompleteInput
+
+```ts
+interface AutocompleteInput {
+  autocomplete?: string          // Native autocomplete attribute (default: 'off')
+}
+```
+
+### DisabledWithReason
+
+Adds tooltip explanation when a field is disabled.
+
+```ts
+interface DisabledWithReason {
+  isDisabled?: boolean           // Whether the element is disabled
+  disabledReason?: string | null // Tooltip shown on hover when disabled
+}
+```
+
+## Default Constants
+
+Use these when setting `withDefaults()` in components:
+
+```ts
+const INPUT_DEFAULTS = {
+  id: null,
+  isDisabled: false,
+  disabledReason: null,
+  isReadonly: false,
+  isRequired: false,
+  name: null,
+  class: null,
+  style: null,
+}
+
+const INPUT_META_DEFAULTS = {
+  isDisabled: false,
+  disabledReason: null,
+  isHorizontal: false,
+  isLabelHidden: false,
+  isRequired: false,
+  errorMessage: null,
+  for: null,
+  helpText: null,
+  hideErrorMessage: false,
+  hint: null,
+  label: null,
+}
+
+const INPUT_FIELD_DEFAULTS = {
+  isDisabled: false,
+  isLoading: false,
+  isReadonly: false,
+  iconLeft: null,
+  iconRight: null,
+  placeholder: null,
+}
+
+const AUTOCOMPLETE_INPUT_DEFAULTS = {
+  autocomplete: 'off',
+}
+```
+
+## useInput Composable
+
+Generates ARIA attributes for accessibility:
+
+```ts
+function useInput(id: string, options: Input & InputWrapper & FieldWrapper) {
+  return {
+    isError: ComputedRef<boolean>,        // true when errorMessage is set
+    ariaBusy: ComputedRef<'true' | undefined>,
+    ariaDescribedBy: ComputedRef<string | undefined>,
+    ariaInvalid: ComputedRef<'true' | undefined>,
+    ariaRequired: ComputedRef<'true' | undefined>,
+  }
+}
+```
+
+**ARIA mapping:**
+- `errorMessage` set -> `aria-invalid="true"`, `aria-describedby` includes `{id}-error-message`
+- `hint` set -> `aria-describedby` includes `{id}-hint`
+- `isRequired` -> `aria-required="true"`
+- `isLoading` -> `aria-busy="true"`
+
+## How Components Compose
+
+A typical input component (e.g., TextField):
+
+```vue
+<script setup lang="ts">
+import type { TextFieldProps } from './textField.props'
+
+const props = withDefaults(defineProps<TextFieldProps>(), {
+  ...INPUT_DEFAULTS,
+  ...INPUT_META_DEFAULTS,
+  ...INPUT_FIELD_DEFAULTS,
+  ...AUTOCOMPLETE_INPUT_DEFAULTS,
+  size: 'md',
+  type: 'text',
+})
+
+const modelValue = defineModel<string | null>({ required: true })
+</script>
+
+<template>
+  <InputWrapper v-bind="inputWrapperProps">
+    <FieldWrapper v-bind="fieldWrapperProps">
+      <input
+        v-model="modelValue"
+        :type="props.type"
+        :aria-invalid="ariaInvalid"
+        :aria-describedby="ariaDescribedBy"
+      />
+    </FieldWrapper>
+  </InputWrapper>
+</template>
+```
+
+### Anatomy (TextField example)
+
+```
+InputWrapper
+├── InputWrapperLabel          (label text + asterisk + help icon)
+├── FieldWrapper
+│   ├── FieldWrapperIcon       (iconLeft)
+│   ├── <input>                (native element)
+│   ├── FieldWrapperIcon       (iconRight) OR FieldWrapperLoader
+│   └── slot#right
+├── InputWrapperHint           (hint text)
+└── InputWrapperErrorMessage   (error text)
+```
+
+## Common Mistakes
+
+### CRITICAL: Not spreading all default objects
+
+Wrong:
+```ts
+const props = withDefaults(defineProps<TextFieldProps>(), {
+  size: 'md',
+  // Missing INPUT_DEFAULTS, INPUT_META_DEFAULTS, etc.
+})
+```
+
+Correct:
+```ts
+const props = withDefaults(defineProps<TextFieldProps>(), {
+  ...INPUT_DEFAULTS,
+  ...INPUT_META_DEFAULTS,
+  ...INPUT_FIELD_DEFAULTS,
+  ...AUTOCOMPLETE_INPUT_DEFAULTS,
+  size: 'md',
+  type: 'text',
+})
+```
+
+Missing defaults cause `undefined` values that break null checks in InputWrapper/FieldWrapper.
+
+### HIGH: Using native `disabled` attribute instead of `isDisabled` prop
+
+Wrong:
+```vue
+<UITextField v-model="val" disabled />
+```
+
+Correct:
+```vue
+<UITextField v-model="val" :is-disabled="true" />
+```
+
+The component uses `isDisabled` to also control tooltips, ARIA attributes, and styling via data attributes.
+
+### HIGH: Passing errorMessage without checking touched state
+
+Wrong:
+```vue
+<UITextField
+  v-model="field.modelValue.value"
+  :error-message="field.errors.value?._errors?.[0]"
+/>
+<!-- Shows error immediately before user interacts -->
+```
+
+Correct:
+```vue
+<UITextField
+  v-model="field.modelValue.value"
+  :error-message="field.isTouched.value ? field.errors.value?._errors?.[0] : null"
+/>
+```
+
+### MEDIUM: Setting both iconRight and isLoading
+
+When `isLoading` is true, the loading spinner replaces `iconRight`. Don't expect both to show simultaneously — the loader takes priority.
+
+## See Also
+
+- [Architecture](../architecture/SKILL.md) — The parts pattern these components follow
+- [text-field](../../components/text-field/SKILL.md) — Simplest input component using this system
+- [select](../../components/select/SKILL.md) — Complex input with dropdown overlay

--- a/packages/web/design-system/skills/foundations/layout-system/SKILL.md
+++ b/packages/web/design-system/skills/foundations/layout-system/SKILL.md
@@ -9,7 +9,6 @@ description: >
 type: foundation
 category: layout-architecture
 library: vue-core-design-system
-library_version: "0.8.0"
 sources:
   - "packages/web/design-system/src/ui/row-layout/RowLayout.vue"
   - "packages/web/design-system/src/ui/column-layout/ColumnLayout.vue"

--- a/packages/web/design-system/skills/foundations/layout-system/SKILL.md
+++ b/packages/web/design-system/skills/foundations/layout-system/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: layout-system
+description: >
+  Layout primitives and page composition for @wisemen/vue-core-design-system.
+  Covers UIRowLayout and UIColumnLayout (flex containers with gap/align/justify),
+  the DashboardPage system (header, actions, detail pane, loading state),
+  and UIMainSidebar (navigation groups, links, global search). Load before
+  building page layouts or navigation.
+type: foundation
+category: layout-architecture
+library: vue-core-design-system
+library_version: "0.8.0"
+sources:
+  - "packages/web/design-system/src/ui/row-layout/RowLayout.vue"
+  - "packages/web/design-system/src/ui/column-layout/ColumnLayout.vue"
+  - "packages/web/design-system/src/ui/page/DashboardPage.vue"
+  - "packages/web/design-system/src/ui/sidebar/MainSidebar.vue"
+---
+
+# Layout System
+
+Flex primitives, page composition, and navigation sidebar.
+
+## Overview
+
+The layout system has three tiers:
+
+1. **Primitives** — `UIRowLayout` (horizontal) and `UIColumnLayout` (vertical) for basic flex composition
+2. **Page System** — `UIDashboardPage` and its sub-components for full page layouts with headers, actions, and detail panes
+3. **Navigation** — `UIMainSidebar` for the primary navigation sidebar with groups, links, and global search
+
+## Flex Primitives
+
+### UIRowLayout
+
+Horizontal flex container:
+
+```vue
+<UIRowLayout gap="lg" align="center" justify="between">
+  <UIButton label="Cancel" variant="secondary" />
+  <UIButton label="Save" variant="primary" />
+</UIRowLayout>
+```
+
+### UIColumnLayout
+
+Vertical flex container:
+
+```vue
+<UIColumnLayout gap="xl">
+  <UITextField v-model="name" label="Name" />
+  <UITextField v-model="email" label="Email" type="email" />
+</UIColumnLayout>
+```
+
+**Shared props:**
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `gap` | Spacing token (`none` through `11xl`) | Gap between children |
+| `align` | UIRowLayout: `start \| center \| end \| baseline`, UIColumnLayout: `start \| center \| end` | Cross-axis alignment |
+| `justify` | `start \| center \| end \| between` | Main-axis distribution |
+| `as` | `string` (default `'div'`) | HTML element to render |
+
+## DashboardPage System
+
+A full page layout with 8+ sub-components. `UIDashboardPage` is the root orchestrator -- it receives `title`, `breadcrumbs`, `tabs`, `actions`, and `detailPane` as props and composes the header, content, and detail pane internally.
+
+```
+UIDashboardPage (root, receives title/breadcrumbs/tabs/detailPane props)
+  ├── DashboardPageHeader (internal, uses UIDashboardPageContainer)
+  │   ├── title / breadcrumbs / tab slots
+  │   ├── header-action-left/center/right slots
+  │   └── header-master-actions slot
+  │       └── UIDashboardPageDetailPaneToggle (if detail pane)
+  ├── UIDashboardPageActions (optional, between header and content)
+  ├── UIDashboardPageContent (scrollable main content)
+  ├── UIDashboardPageLoadingState (full-page skeleton)
+  └── DashboardPageDetailPane (if detailPane prop + #detail-pane slot)
+```
+
+### Basic Page Layout
+
+```vue
+<template>
+  <UIDashboardPage title="Users">
+    <UIDashboardPageActions>
+      <template #right>
+        <UIButton label="Add User" @click="openCreateDialog" />
+      </template>
+    </UIDashboardPageActions>
+
+    <UIDashboardPageContent>
+      <!-- Table, list, or other content -->
+    </UIDashboardPageContent>
+  </UIDashboardPage>
+</template>
+```
+
+### With Detail Pane
+
+```vue
+<template>
+  <UIDashboardPage
+    v-model:is-detail-pane-open="isDetailOpen"
+    :detail-pane="{ variant: 'bordered-overlay' }"
+    title="Users"
+  >
+    <UIDashboardPageContent>
+      <!-- Master list -->
+    </UIDashboardPageContent>
+
+    <template #detail-pane>
+      <UserDetailPane :user="selectedUser" />
+    </template>
+  </UIDashboardPage>
+</template>
+```
+
+### Loading State
+
+```vue
+<UIDashboardPageLoadingState
+  v-if="isLoading"
+  :breadcrumbs="breadcrumbs"
+/>
+<UIDashboardPage
+  v-else
+  :breadcrumbs="breadcrumbs"
+  title="Projects"
+>
+  <UIDashboardPageContent>...</UIDashboardPageContent>
+</UIDashboardPage>
+```
+
+## MainSidebar System
+
+Navigation sidebar with groups, links, badges, and search.
+
+### Components
+
+| Component | Purpose |
+|-----------|---------|
+| `UIMainSidebar` | Root sidebar container |
+| `UIMainSidebarHeaderLogoWithText` | Logo in header |
+| `UIMainSidebarGlobalSearch` | Search trigger |
+| `UIMainSidebarNavigationGroup` | Section of links |
+| `UIMainSidebarNavigationLink` | Single nav link |
+| `UIMainSidebarNavigationLinkBadge` | Badge on a link |
+| `UIMainSidebarNavigationLinkStatusDot` | Status dot on a link |
+| `UIMainSidebarFooterAccountCard` | User account card |
+| `UIMainSidebarFooterFeaturedCard` | Promotional/featured card |
+
+### useMainSidebar Composable
+
+```ts
+import { useMainSidebar } from '@wisemen/vue-core-design-system'
+
+const { isSidebarOpen, isFloatingSidebar, closeIfFloatingSidebar } = useMainSidebar()
+```
+
+### Basic Sidebar
+
+```vue
+<template>
+  <UIMainSidebar collapsed-variant="minified">
+    <template #header>
+      <UIMainSidebarHeaderLogoWithText url="/logo.png" name="My App" />
+    </template>
+
+    <template #navigation>
+      <UIMainSidebarNavigationGroup label="Main">
+        <UIMainSidebarNavigationLink
+          :to="{ name: 'dashboard' }"
+          :icon="DashboardIcon"
+          label="Dashboard"
+        />
+        <UIMainSidebarNavigationLink
+          :to="{ name: 'users' }"
+          :icon="UsersIcon"
+          label="Users"
+        >
+          <template #right>
+            <UIMainSidebarNavigationLinkBadge label="5" />
+          </template>
+        </UIMainSidebarNavigationLink>
+      </UIMainSidebarNavigationGroup>
+    </template>
+
+    <template #footer>
+      <UIMainSidebarFooterAccountCard
+        name="Jane Doe"
+        email="jane@example.com"
+        :menu-options="[]"
+        :on-sign-out="handleLogout"
+      />
+    </template>
+  </UIMainSidebar>
+</template>
+```
+
+### Sidebar Types
+
+```ts
+interface DashboardSidebarNavLink {
+  icon: Component
+  label: string
+  to: RouteLocationRaw
+  isActive?: (route: RouteLocationNormalized) => boolean
+  keyboardShortcut?: string | null
+  onClick?: () => void
+}
+
+interface DashboardSidebarGroup {
+  label?: string
+  links: DashboardSidebarNavLink[]
+}
+```
+
+## Common Mistakes
+
+### HIGH: Using DashboardPage without the layout shell
+
+Wrong:
+```vue
+<UIDashboardPage title="Users">
+  <UIDashboardPageContent>...</UIDashboardPageContent>
+</UIDashboardPage>
+```
+
+Correct:
+```vue
+<UIMainLayoutContainer>
+  <UIMainSidebar>...</UIMainSidebar>
+  <UIMainContent>
+    <UIDashboardPage title="Users">
+      <UIDashboardPageContent>...</UIDashboardPageContent>
+    </UIDashboardPage>
+  </UIMainContent>
+</UIMainLayoutContainer>
+```
+
+`UIDashboardPage` should be rendered inside `UIMainContent`, which is part of the `UIMainLayoutContainer` shell that manages sidebar positioning and content padding.
+
+### MEDIUM: Using raw flexbox instead of Row/ColumnLayout
+
+Wrong:
+```html
+<div class="flex flex-row items-center gap-4">
+```
+
+Correct:
+```vue
+<UIRowLayout gap="xl" align="center">
+```
+
+The layout components ensure consistent spacing using the design token scale.
+
+## See Also
+
+- [row-layout](../../components/row-layout/SKILL.md) — UIRowLayout component details
+- [column-layout](../../components/column-layout/SKILL.md) — UIColumnLayout component details
+- [page](../../components/page/SKILL.md) — DashboardPage full API
+- [sidebar](../../components/sidebar/SKILL.md) — MainSidebar full API

--- a/packages/web/design-system/skills/foundations/overlay-system/SKILL.md
+++ b/packages/web/design-system/skills/foundations/overlay-system/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: overlay-system
+description: >
+  Imperative overlay management for @wisemen/vue-core-design-system. Covers the
+  useOverlay composable (create, open, close, patch, closeAll), DialogContainer
+  for rendering overlays, promise-based dialog results, and the useDialogTriggerProps
+  helper. Load before working with Dialog, ConfirmDialog, FormDialog, or any
+  imperative overlay pattern.
+type: foundation
+category: overlay-architecture
+library: vue-core-design-system
+library_version: "0.8.0"
+sources:
+  - "packages/web/design-system/src/ui/dialog/dialogOverlay.composable.ts"
+  - "packages/web/design-system/src/ui/dialog/DialogContainer.vue"
+  - "packages/web/design-system/src/ui/dialog/dialogTriggerProps.composable.ts"
+---
+
+# Overlay System
+
+Imperative overlay management for dialogs, confirm dialogs, and form dialogs.
+
+## Overview
+
+The overlay system provides an imperative API for creating, opening, and closing dialogs from anywhere in your application. It is built on `createSharedComposable` from VueUse, meaning all components share a single overlay state.
+
+**Two approaches to dialogs:**
+1. **Template-driven** — use `v-model` on `UIDialog` directly (simple cases)
+2. **Imperative** — use `useOverlay()` to create/open/close programmatically (complex workflows, awaiting results)
+
+## useOverlay API
+
+```ts
+import { useOverlay } from '@wisemen/vue-core-design-system'
+
+const overlay = useOverlay()
+```
+
+### create(component, options?)
+
+Registers an overlay instance. Call once (typically at module scope or in setup).
+
+```ts
+const dialog = overlay.create(MyDialog, {
+  defaultOpen: false,       // Start open? (default: false)
+  destroyOnClose: false,    // Remove from DOM on close? (default: false)
+  props: { title: 'Edit' }, // Initial props passed to the component
+})
+```
+
+Returns an `OverlayInstance` with `open`, `close`, and `patch` methods.
+
+### open(props?)
+
+Opens the overlay. Optionally merges new props. Returns a promise-like object that resolves when the dialog emits `close`.
+
+```ts
+const result = dialog.open({ title: 'Edit User', userId: '123' })
+const value = await result  // Resolves with the close event argument
+```
+
+If called with props, they merge with `originalProps` (from `create`). If called without props, the original props are used.
+
+### close(value?)
+
+Closes the overlay and resolves the open promise with the given value.
+
+```ts
+dialog.close('confirmed')  // Resolves the awaiting open() call with 'confirmed'
+dialog.close()             // Resolves with undefined
+```
+
+### patch(props)
+
+Updates the overlay's props without closing/reopening.
+
+```ts
+dialog.patch({ title: 'Updated Title' })
+```
+
+### closeAll()
+
+Closes all registered overlays.
+
+```ts
+overlay.closeAll()
+```
+
+## DialogContainer
+
+Renders all managed overlays. Place once at the app root.
+
+```vue
+<!-- App.vue -->
+<template>
+  <UIConfigProvider>
+    <UIDialogContainer />
+    <RouterView />
+  </UIConfigProvider>
+</template>
+```
+
+## Complete Example: Imperative Dialog
+
+### Step 1: Create the dialog component
+
+```vue
+<!-- ConfirmDeleteDialog.vue -->
+<script setup lang="ts">
+import { UIDialog, UIDialogHeader, UIDialogBody, UIDialogFooter,
+         UIDialogFooterCancel, UIDialogFooterPrimary } from '@wisemen/vue-core-design-system'
+
+const props = defineProps<{
+  itemName: string
+}>()
+
+const emit = defineEmits<{
+  close: [confirmed: boolean]
+}>()
+</script>
+
+<template>
+  <UIDialog @close="emit('close', false)">
+    <UIDialogHeader title="Delete Item" />
+    <UIDialogBody>
+      Are you sure you want to delete "{{ itemName }}"?
+    </UIDialogBody>
+    <UIDialogFooter>
+      <UIDialogFooterCancel @click="emit('close', false)" />
+      <UIDialogFooterPrimary
+        label="Delete"
+        variant="destructive-primary"
+        @click="emit('close', true)"
+      />
+    </UIDialogFooter>
+  </UIDialog>
+</template>
+```
+
+### Step 2: Use overlay to manage it
+
+```vue
+<script setup lang="ts">
+import { useOverlay } from '@wisemen/vue-core-design-system'
+import ConfirmDeleteDialog from './ConfirmDeleteDialog.vue'
+
+const overlay = useOverlay()
+const deleteDialog = overlay.create(ConfirmDeleteDialog)
+
+async function handleDelete(item: Item) {
+  const confirmed = await deleteDialog.open({ itemName: item.name })
+
+  if (confirmed) {
+    await deleteItem(item.id)
+  }
+}
+</script>
+
+<template>
+  <UIButton label="Delete" @click="handleDelete(item)" />
+</template>
+```
+
+## useDialogTriggerProps
+
+Helper for connecting a trigger element to a dialog's open state:
+
+```ts
+import { useDialogTriggerProps } from '@wisemen/vue-core-design-system'
+
+const { triggerProps } = useDialogTriggerProps()
+```
+
+Used internally by components that need to pass trigger-related props to dialogs.
+
+## Template-Driven Approach
+
+For simple cases, use `v-model` directly:
+
+```vue
+<script setup lang="ts">
+const isOpen = ref(false)
+</script>
+
+<template>
+  <UIButton label="Open" @click="isOpen = true" />
+  <UIDialog v-model="isOpen">
+    <UIDialogHeader title="Simple Dialog" />
+    <UIDialogBody>Content here</UIDialogBody>
+  </UIDialog>
+</template>
+```
+
+## Common Mistakes
+
+### CRITICAL: Missing DialogContainer in app root
+
+Wrong:
+```vue
+<!-- App.vue — no DialogContainer -->
+<template>
+  <RouterView />
+</template>
+```
+
+Imperative overlays are created but never rendered. Nothing shows up.
+
+Correct:
+```vue
+<template>
+  <UIDialogContainer />
+  <RouterView />
+</template>
+```
+
+### HIGH: Creating overlay inside a loop or render function
+
+Wrong:
+```ts
+function openDialog(item: Item) {
+  const overlay = useOverlay()
+  const dialog = overlay.create(MyDialog)  // Creates a new instance every call!
+  dialog.open({ item })
+}
+```
+
+Correct:
+```ts
+const overlay = useOverlay()
+const dialog = overlay.create(MyDialog)  // Create once
+
+function openDialog(item: Item) {
+  dialog.open({ item })  // Reuse the instance
+}
+```
+
+`create()` registers a new overlay each time. Call it once in setup, then reuse with `open()`.
+
+### HIGH: Forgetting to emit 'close' from the dialog component
+
+Wrong:
+```vue
+<!-- Dialog component that never emits 'close' -->
+<UIDialogFooterPrimary label="Save" @click="save()" />
+```
+
+The overlay's `open()` promise never resolves.
+
+Correct:
+```vue
+<UIDialogFooterPrimary label="Save" @click="save(); emit('close', result)" />
+```
+
+### MEDIUM: Not handling promise rejection
+
+The `open()` promise resolves when `close()` is called. If the user dismisses the dialog (clicks backdrop, presses Escape), the close event fires with `undefined`. Always handle this case.
+
+```ts
+const result = await dialog.open()
+if (result === undefined) return  // User dismissed
+```
+
+## See Also
+
+- [dialog](../../components/dialog/SKILL.md) — UIDialog component and sub-components
+- [confirm-dialog](../../components/confirm-dialog/SKILL.md) — Pre-built confirmation dialog
+- [form-dialog](../../components/form-dialog/SKILL.md) — Dialog with form integration

--- a/packages/web/design-system/skills/foundations/overlay-system/SKILL.md
+++ b/packages/web/design-system/skills/foundations/overlay-system/SKILL.md
@@ -9,7 +9,6 @@ description: >
 type: foundation
 category: overlay-architecture
 library: vue-core-design-system
-library_version: "0.8.0"
 sources:
   - "packages/web/design-system/src/ui/dialog/dialogOverlay.composable.ts"
   - "packages/web/design-system/src/ui/dialog/DialogContainer.vue"

--- a/packages/web/design-system/skills/foundations/styling/SKILL.md
+++ b/packages/web/design-system/skills/foundations/styling/SKILL.md
@@ -9,7 +9,6 @@ description: >
 type: foundation
 category: styling
 library: vue-core-design-system
-library_version: "0.8.0"
 sources:
   - "packages/web/design-system/src/styles/tailwindVariants.lib.ts"
   - "packages/web/design-system/src/styles/core/tokens.css"

--- a/packages/web/design-system/skills/foundations/styling/SKILL.md
+++ b/packages/web/design-system/skills/foundations/styling/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: styling
+description: >
+  Design token system and component styling for @wisemen/vue-core-design-system.
+  Covers the custom tv() instance (Tailwind Variants with twMerge), design tokens
+  (spacing, colors, typography, shadows, radii, z-index), semantic color system
+  (fg/text/bg/border), light/dark theming, and data-attribute-driven styling.
+  Load when customizing component styles or understanding the token system.
+type: foundation
+category: styling
+library: vue-core-design-system
+library_version: "0.8.0"
+sources:
+  - "packages/web/design-system/src/styles/tailwindVariants.lib.ts"
+  - "packages/web/design-system/src/styles/core/tokens.css"
+  - "packages/web/design-system/src/styles/core/colors.css"
+  - "packages/web/design-system/src/styles/themes/default.css"
+---
+
+# Styling
+
+Design tokens, Tailwind Variants, and theming system.
+
+## Overview
+
+All component styles use `tv()` (Tailwind Variants) with a custom configuration. Colors and spacing are defined as CSS custom properties (design tokens) with semantic naming. Themes (light/dark) swap token values via CSS classes.
+
+## tv() — Custom Tailwind Variants Instance
+
+```ts
+// src/styles/tailwindVariants.lib.ts
+import { createTV } from 'tailwind-variants'
+
+export const tv = createTV({
+  twMerge: true,
+  twMergeConfig: {
+    extend: {
+      classGroups: {
+        'font-size': [{ text: ['xxs'] }],
+      },
+      theme: {
+        spacing: [
+          'none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl',
+          '2xl', '3xl', '4xl', '5xl', '6xl', '7xl', '8xl', '9xl', '10xl', '11xl',
+        ],
+      },
+    },
+  },
+})
+```
+
+**Key points:**
+- `twMerge: true` — later classes override earlier ones (e.g., `px-4 px-6` resolves to `px-6`)
+- Custom spacing scale (`none` through `11xl`) is registered so twMerge understands them
+- Custom font size `xxs` (11px) is registered
+
+## Component Style Pattern
+
+Every component defines a style factory using `tv()`:
+
+```ts
+// button.style.ts
+import { tv } from '@/styles/tailwindVariants.lib'
+
+export const createButtonStyle = tv({
+  slots: {
+    root: 'inline-flex items-center justify-center rounded-lg font-semibold',
+    icon: 'size-5',
+    loader: 'size-5',
+  },
+  variants: {
+    variant: {
+      primary: { root: 'bg-brand-solid text-primary-on-brand' },
+      secondary: { root: 'bg-primary border border-primary text-secondary' },
+      tertiary: { root: 'text-tertiary' },
+    },
+    size: {
+      xs: { root: 'h-8 gap-xs px-lg text-xs', icon: 'size-4' },
+      sm: { root: 'h-9 gap-xs px-lg text-sm' },
+      md: { root: 'h-10 gap-xs px-xl text-sm' },
+      lg: { root: 'h-11 gap-sm px-xl text-md' },
+    },
+  },
+  defaultVariants: {
+    variant: 'primary',
+    size: 'md',
+  },
+})
+```
+
+**Usage in component:**
+
+```vue
+<script setup lang="ts">
+const style = computed(() => createButtonStyle({
+  variant: props.variant,
+  size: props.size,
+}))
+</script>
+
+<template>
+  <button :class="style.root()">
+    <component :is="iconLeft" :class="style.icon()" />
+    <slot />
+  </button>
+</template>
+```
+
+### Slots
+
+The `slots` object defines named CSS class groups — one per visual element in the component. Use `style.slotName()` to get the resolved classes.
+
+### Variants
+
+Each variant key maps to a set of slot overrides. When `createButtonStyle({ variant: 'primary', size: 'md' })` is called, it merges the base slot classes with the variant-specific classes.
+
+### Data-Attribute Styling
+
+Components use `data-*` attributes for state-driven styling instead of dynamic class binding:
+
+```ts
+// In the template
+<div :data-disabled="isDisabled || undefined" :data-error="isError || undefined">
+
+// In the style definition
+root: 'border-primary data-disabled:border-disabled data-disabled:bg-disabled-subtle data-error:border-error'
+```
+
+Common data attributes: `data-disabled`, `data-error`, `data-interactive`, `data-loading`, `data-active`, `data-checked`, `data-variant`.
+
+## Design Tokens
+
+### Spacing Scale
+
+| Token | Value | Pixels |
+|-------|-------|--------|
+| `--spacing-none` | 0rem | 0px |
+| `--spacing-xxs` | 0.125rem | 2px |
+| `--spacing-xs` | 0.25rem | 4px |
+| `--spacing-sm` | 0.375rem | 6px |
+| `--spacing-md` | 0.5rem | 8px |
+| `--spacing-lg` | 0.75rem | 12px |
+| `--spacing-xl` | 1rem | 16px |
+| `--spacing-2xl` | 1.25rem | 20px |
+| `--spacing-3xl` | 1.5rem | 24px |
+| `--spacing-4xl` | 2rem | 32px |
+| `--spacing-5xl` | 2.5rem | 40px |
+| `--spacing-6xl` | 3rem | 48px |
+| `--spacing-7xl` | 4rem | 64px |
+| `--spacing-8xl` | 5rem | 80px |
+| `--spacing-9xl` | 6rem | 96px |
+| `--spacing-10xl` | 8rem | 128px |
+| `--spacing-11xl` | 10rem | 160px |
+
+In Tailwind classes, use directly: `p-md`, `gap-xl`, `m-3xl`.
+
+### Typography Scale
+
+| Token | Size | Line Height |
+|-------|------|-------------|
+| `text-xxs` | 11px | 18px |
+| `text-xs` | 12px | 18px |
+| `text-sm` | 14px | 20px |
+| `text-md` | 16px | 24px |
+| `text-lg` | 18px | 28px |
+| `text-xl` | 20px | 32px |
+| `text-2xl` | 24px | 32px |
+| `text-3xl` | 30px | 38px |
+| `text-4xl` | 36px | 44px |
+| `text-5xl` | 48px | 60px |
+| `text-6xl` | 60px | 72px |
+| `text-7xl` | 72px | 90px |
+
+Font weights: `font-regular` (400), `font-medium` (500), `font-semibold` (600), `font-bold` (700).
+
+### Border Radius
+
+| Token | Value |
+|-------|-------|
+| `rounded-none` | 0 |
+| `rounded-xxs` | 2px |
+| `rounded-xs` | 4px |
+| `rounded-sm` | 6px |
+| `rounded-md` | 8px |
+| `rounded-lg` | 10px |
+| `rounded-xl` | 12px |
+| `rounded-2xl` | 16px |
+| `rounded-3xl` | 20px |
+| `rounded-4xl` | 24px |
+| `rounded-full` | 1000px |
+
+### Shadows
+
+| Token | Usage |
+|-------|-------|
+| `shadow-xs` | Subtle elevation (inputs, cards) |
+| `shadow-sm` | Low elevation (dropdowns) |
+| `shadow` | Medium elevation (popovers) |
+| `shadow-lg` | High elevation (modals) |
+
+### Z-Index
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `z-sticky` | 10 | Sticky headers |
+| `z-overlay` | 30 | Overlays |
+| `z-modal` | 40 | Modal dialogs |
+| `z-tooltip` | 50 | Tooltips |
+
+## Semantic Color System
+
+Colors are organized in semantic layers. Use semantic tokens, not raw color values.
+
+### Foreground (`fg-*`)
+
+For icons and interactive indicators:
+`fg-primary`, `fg-secondary`, `fg-tertiary`, `fg-quaternary`, `fg-disabled`, `fg-brand-primary`, `fg-error-primary`, `fg-warning-primary`, `fg-success-primary`
+
+### Text (`text-*`)
+
+For text content:
+`text-primary`, `text-secondary`, `text-tertiary`, `text-quaternary`, `text-disabled`, `text-placeholder`, `text-brand-primary`, `text-error-primary`, `text-primary-on-brand`
+
+### Background (`bg-*`)
+
+For surfaces:
+`bg-primary`, `bg-secondary`, `bg-tertiary`, `bg-active`, `bg-disabled`, `bg-disabled-subtle`, `bg-overlay`, `bg-brand-primary`, `bg-brand-solid`, `bg-error-primary`, `bg-success-primary`
+
+### Border (`border-*`)
+
+For borders:
+`border-primary`, `border-secondary`, `border-tertiary`, `border-disabled`, `border-brand`, `border-error`
+
+## Theming
+
+Themes are applied via CSS classes on a wrapper element (typically `<body>` or a provider):
+
+```css
+.light {
+  --fg-primary: var(--gray-900);
+  --bg-primary: var(--white);
+  --border-primary: var(--gray-300);
+  /* ... */
+}
+
+.dark {
+  --fg-primary: var(--gray-50);
+  --bg-primary: var(--gray-950);
+  --border-primary: var(--gray-700);
+  /* ... */
+}
+```
+
+Use `UIThemeProvider` to manage theme switching. See [theme-provider](../../components/theme-provider/SKILL.md).
+
+## Color Palette
+
+Raw colors available (each has shades 25-950):
+`brand`, `error`, `warning`, `success`, `blue`, `pink`, `purple`, `gray`
+
+Always prefer semantic tokens (`text-primary`, `bg-brand-solid`) over raw colors (`gray-900`, `brand-600`). Semantic tokens automatically adapt to light/dark themes.
+
+## Common Mistakes
+
+### CRITICAL: Using raw Tailwind colors instead of semantic tokens
+
+Wrong:
+```html
+<div class="text-gray-900 bg-white border-gray-300">
+```
+
+Correct:
+```html
+<div class="text-primary bg-primary border-primary">
+```
+
+Raw colors don't switch in dark mode. Semantic tokens do.
+
+### HIGH: Forgetting twMerge handles custom spacing
+
+Wrong (thinking custom spacing conflicts):
+```ts
+// Manually removing classes before adding new ones
+root: props.compact ? 'p-sm' : 'p-xl'
+```
+
+Correct (twMerge resolves it):
+```ts
+// Just merge — twMerge knows the custom scale
+<div :class="style.root({ class: 'p-sm' })" />
+```
+
+The custom `tv()` instance registers the full spacing scale in twMerge.
+
+### MEDIUM: Using inline styles for token values
+
+Wrong:
+```html
+<div style="padding: 8px; color: #344054;">
+```
+
+Correct:
+```html
+<div class="p-md text-primary">
+```
+
+Always use Tailwind utility classes that reference the token system.
+
+## See Also
+
+- [Architecture](../architecture/SKILL.md) — How components use tv() in the parts pattern
+- [Input System](../input-system/SKILL.md) — How input components apply styles

--- a/packages/web/design-system/skills/manifest.json
+++ b/packages/web/design-system/skills/manifest.json
@@ -1,0 +1,410 @@
+{
+  "version": 1,
+  "generatedBy": "@wisemen/skills-cli",
+  "skills": [
+    {
+      "name": "action-tooltip",
+      "description": "A pre-built tooltip that displays a text label and an optional keyboard shortcut badge. Wraps UITooltip with UITooltipText and UIKeyboardShortcut in a row layout. Load this skill when you need a standardized tooltip for buttons or actions with shortcut hints.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/action-tooltip/SKILL.md"
+    },
+    {
+      "name": "adaptive-content",
+      "description": "A container that conditionally renders child blocks based on available horizontal space and an explicit priority order. Lower-priority blocks are progressively hidden when the container overflows, exposing a hidden-block count for building overflow indicators.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/adaptive-content/SKILL.md"
+    },
+    {
+      "name": "architecture",
+      "description": "Core architecture patterns for @wisemen/vue-core-design-system: the parts pattern (Root/Content/Icon sub-components), context system (useContext + provide/inject), PropsToComputed utility, toComputedRefs, file naming conventions, and export conventions (UI prefix). Load before building or extending any component.\n",
+      "type": "foundation",
+      "library_version": "0.8.0",
+      "path": "foundations/architecture/SKILL.md"
+    },
+    {
+      "name": "autocomplete",
+      "description": "Typeahead input that filters a dropdown list as the user types. Supports local client-side filtering and remote server-side search with debouncing. Uses the input-system foundation for labels, errors, and field wrappers.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "input-system"
+      ],
+      "path": "components/autocomplete/SKILL.md"
+    },
+    {
+      "name": "avatar",
+      "description": "Avatar system with four components: UIAvatar (image or initials), UIAvatarGroup (stacked row with overflow), UIAvatarGroupAddButton (dashed add action), and UIAvatarLabel (avatar with name and supporting text). Load this skill when displaying user profile pictures, grouped users, or labeled identity elements.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/avatar/SKILL.md"
+    },
+    {
+      "name": "badge",
+      "description": "Versatile badge component with support for labels, icons, dots, avatars, and separators. Includes BadgeGroup for wrapping collections and BadgeGroupTruncate for overflow handling. Load this skill when displaying status indicators, tags, or categorization labels.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/badge/SKILL.md"
+    },
+    {
+      "name": "breadcrumbs",
+      "description": "UIBreadcrumbs is a composite navigation component built from UIBreadcrumbRoot, UIBreadcrumbItems, UIBreadcrumbItem, and UIBreadcrumbSeparator parts. It renders a horizontal breadcrumb trail with optional icons, router links, and accessible label-hiding for icon-only items.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/breadcrumbs/SKILL.md"
+    },
+    {
+      "name": "button",
+      "description": "UIButton, UIIconButton, and UILink -- the three action trigger variants. UIButton renders a labeled button, UIIconButton renders an icon-only button with an accessible label, and UILink renders a navigation element styled like a button using either Vue Router or a plain anchor.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/button/SKILL.md"
+    },
+    {
+      "name": "card",
+      "description": "Simple bordered container with rounded corners for grouping related content. Has no props -- content goes in the default slot. Load this skill when you need a visual card or panel wrapper.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/card/SKILL.md"
+    },
+    {
+      "name": "checkbox",
+      "description": "A single boolean checkbox with label, hint, error message, and animated check indicator. Built on Reka UI CheckboxRoot with InputWrapper in horizontal layout. Integrates with formango for form validation and with UICheckboxGroup for multi-select scenarios.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "input-system"
+      ],
+      "path": "components/checkbox/SKILL.md"
+    },
+    {
+      "name": "checkbox-group",
+      "description": "A group of checkboxes for multi-value selection with an optional indeterminate \"select all\" checkbox. Built on Reka UI CheckboxGroupRoot with a context-based registration system. Supports vertical and horizontal orientations and disabled state with reason tooltip.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "input-system"
+      ],
+      "path": "components/checkbox-group/SKILL.md"
+    },
+    {
+      "name": "clickable-element",
+      "description": "Low-level wrapper that applies consistent focus-visible outline and cursor styles to any interactive element. Uses Reka UI Primitive with as-child for zero extra DOM nodes. Load this skill when building custom clickable primitives or understanding the focus ring system.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/clickable-element/SKILL.md"
+    },
+    {
+      "name": "column-layout",
+      "description": "Vertical flex container with configurable gap, alignment, and justification using design-token spacing. Renders as a customizable HTML element and provides a default slot for child content. Use for any vertical stacking of elements.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "layout-system"
+      ],
+      "path": "components/column-layout/SKILL.md"
+    },
+    {
+      "name": "config-provider",
+      "description": "Application-level configuration provider that supplies locale, number formatting, hour cycle, teleport target, and Google Maps API key to all design system components via Vue's provide/inject. Must wrap the entire application.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/config-provider/SKILL.md"
+    },
+    {
+      "name": "confirm-dialog",
+      "description": "A pre-built confirmation dialog with title, description, icon, cancel button, and confirm button. Supports destructive styling and async confirm callbacks with automatic loading state. Uses the dialog sub-components internally. Load this skill for yes/no or delete confirmation prompts.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "overlay-system"
+      ],
+      "path": "components/confirm-dialog/SKILL.md"
+    },
+    {
+      "name": "design-system-index",
+      "description": "Master index for @wisemen/vue-core-design-system. Read this first to find the right skill for any component or pattern. Lists all skills organized by category with a decision tree for component selection.\n",
+      "type": "index",
+      "library_version": "0.8.0",
+      "path": "_index/SKILL.md"
+    },
+    {
+      "name": "dialog",
+      "description": "Modal dialog system with header, body, footer, and close button sub-components. Built on Reka UI DialogRoot with animated overlay, scroll-aware separators, and a chin feature for contextual actions. Supports both template-driven (v-model) and imperative (useOverlay) patterns. Also exports useOverlay composable and useDialogTriggerProps helper. Load this skill for any modal dialog implementation.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "overlay-system"
+      ],
+      "path": "components/dialog/SKILL.md"
+    },
+    {
+      "name": "dot",
+      "description": "Small colored circle used as a status indicator. Supports 8 color variants and 3 sizes. Load this skill when you need a visual status dot, online/offline indicator, or colored bullet point.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/dot/SKILL.md"
+    },
+    {
+      "name": "dropdown-menu",
+      "description": "UIDropdownMenu is a popover-based menu triggered by a button or custom element. Built on Reka UI's DropdownMenu primitives, it supports items with icons and keyboard shortcuts, groups, headers, separators, and radio groups for single-select options. Content is portalled to the body with configurable positioning.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/dropdown-menu/SKILL.md"
+    },
+    {
+      "name": "form",
+      "description": "Form wrapper that integrates with formango's Form object to provide submit handling, unsaved changes detection with route-leave guards, and a context for child components like FormSubmitButton. Always pair with a formango useForm() call.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/form/SKILL.md"
+    },
+    {
+      "name": "form-dialog",
+      "description": "A dialog with integrated formango form handling. Wraps UIDialog with form context, automatic form ID generation, and optional unsaved-changes prompt. Uses FormDialogForm internally to connect to formango's Form type. Load this skill when building dialogs that contain validated forms.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "overlay-system"
+      ],
+      "path": "components/form-dialog/SKILL.md"
+    },
+    {
+      "name": "input-system",
+      "description": "The InputWrapper > FieldWrapper > native element architecture shared by all input components (TextField, TextareaField, NumberField, Select, Autocomplete, Checkbox, etc.). Covers the Input, InputWrapper, FieldWrapper, AutocompleteInput interfaces, their default constants, the useInput composable for ARIA generation, and the DisabledWithReason pattern. Load before implementing or modifying any input or form control component.\n",
+      "type": "foundation",
+      "library_version": "0.8.0",
+      "path": "foundations/input-system/SKILL.md"
+    },
+    {
+      "name": "interactable",
+      "description": "Low-level renderless wrapper that applies focus-visible outline and cursor styles to interactive elements. Similar to UIClickableElement but with a different outline approach. Load this skill when building custom interactive primitives.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/interactable/SKILL.md"
+    },
+    {
+      "name": "keyboard-shortcut",
+      "description": "Renders a keyboard shortcut as styled key badges. Parses a shortcut string (e.g., \"meta_k\", \"g-d\") into individual keys with platform-aware symbols (macOS vs Windows). Load this skill when displaying keyboard shortcuts in tooltips, menus, or help panels.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/keyboard-shortcut/SKILL.md"
+    },
+    {
+      "name": "layout",
+      "description": "Top-level application shell components that provide the outermost page structure. UIMainLayoutContainer is the full-screen flex wrapper, and UIMainContent is the sidebar-aware content area with animated padding. Use these as the root of every page in a dashboard application.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "layout-system"
+      ],
+      "path": "components/layout/SKILL.md"
+    },
+    {
+      "name": "layout-system",
+      "description": "Layout primitives and page composition for @wisemen/vue-core-design-system. Covers UIRowLayout and UIColumnLayout (flex containers with gap/align/justify), the DashboardPage system (header, actions, detail pane, loading state), and UIMainSidebar (navigation groups, links, global search). Load before building page layouts or navigation.\n",
+      "type": "foundation",
+      "library_version": "0.8.0",
+      "path": "foundations/layout-system/SKILL.md"
+    },
+    {
+      "name": "loader",
+      "description": "Animated SVG loading spinner that inherits size and color from its parent. Has no props -- sized via CSS classes and colored via currentColor. Load this skill when you need a spinning loading indicator.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/loader/SKILL.md"
+    },
+    {
+      "name": "logo",
+      "description": "Displays a brand or app logo image with optional text label. UILogo renders a sized image with fallback placeholder on error. UILogoWithText combines the logo with a name label. Load this skill for brand identity elements in headers or sidebars.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/logo/SKILL.md"
+    },
+    {
+      "name": "menu-item",
+      "description": "UIMenuItem is a flexible content layout component for items in dropdown menus, lists, and selectable options. It supports icons, avatars, dots, descriptions, right-side content (text, icons, keyboard shortcuts), and a right slot. Used as the content layer inside UIDropdownMenuItem and select/autocomplete items.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/menu-item/SKILL.md"
+    },
+    {
+      "name": "number-badge",
+      "description": "Small pill-shaped badge that displays a numeric value with color and variant options. Useful for counts, notification indicators, and numeric status labels. Load this skill when you need to show a number inside a colored badge.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/number-badge/SKILL.md"
+    },
+    {
+      "name": "number-field",
+      "description": "Numeric input with locale-aware formatting, optional increment/decrement controls, min/max bounds, and step snapping. Built on Reka UI NumberField with InputWrapper > FieldWrapper composition. Integrates with formango for form validation.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "input-system"
+      ],
+      "path": "components/number-field/SKILL.md"
+    },
+    {
+      "name": "overlay-system",
+      "description": "Imperative overlay management for @wisemen/vue-core-design-system. Covers the useOverlay composable (create, open, close, patch, closeAll), DialogContainer for rendering overlays, promise-based dialog results, and the useDialogTriggerProps helper. Load before working with Dialog, ConfirmDialog, FormDialog, or any imperative overlay pattern.\n",
+      "type": "foundation",
+      "library_version": "0.8.0",
+      "path": "foundations/overlay-system/SKILL.md"
+    },
+    {
+      "name": "page",
+      "description": "Full dashboard page system with header, breadcrumbs, action bars, content area, loading state, and a resizable detail pane. UIDashboardPage is the root orchestrator that composes 8+ sub-components. Use for any page inside the dashboard layout shell.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "layout-system"
+      ],
+      "path": "components/page/SKILL.md"
+    },
+    {
+      "name": "popover",
+      "description": "A floating content panel anchored to a trigger element. Built on Reka UI PopoverRoot with configurable alignment, side, collision handling, and animated open/close transitions. Load this skill when you need interactive floating panels that appear on click.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "overlay-system"
+      ],
+      "path": "components/popover/SKILL.md"
+    },
+    {
+      "name": "radio-group",
+      "description": "A radio group for single-value selection from multiple options. Built on Reka UI RadioGroupRoot with context-based item registration. Supports standard radio items and card-style items with descriptions. Includes vertical/horizontal orientation and disabled state with reason tooltip.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "input-system"
+      ],
+      "path": "components/radio-group/SKILL.md"
+    },
+    {
+      "name": "row-layout",
+      "description": "Horizontal flex container with configurable gap, alignment, and justification using design-token spacing. Renders as a customizable HTML element and provides a default slot for child content. Use for any horizontal arrangement of elements.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "layout-system"
+      ],
+      "path": "components/row-layout/SKILL.md"
+    },
+    {
+      "name": "scrollable",
+      "description": "Scrollable container that shows gradient fade indicators at the top/bottom when content overflows. Supports infinite scroll via an onNext callback. Load this skill when building scrollable lists, panels, or any container that needs visual scroll cues.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/scrollable/SKILL.md"
+    },
+    {
+      "name": "select",
+      "description": "Dropdown select component supporting single and multi-select modes with optional search (local or remote), pagination, and rich option rendering via getItemConfig. Determines single vs multi mode from the v-model type (value vs array).\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "input-system"
+      ],
+      "path": "components/select/SKILL.md"
+    },
+    {
+      "name": "separator",
+      "description": "A horizontal or vertical divider line built on Reka UI's Separator primitive. Supports horizontal and vertical orientations. Load this skill when you need a visual divider between sections or inline elements.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/separator/SKILL.md"
+    },
+    {
+      "name": "sidebar",
+      "description": "Main navigation sidebar with collapsible behavior, navigation groups, links with badges and status dots, global search trigger, header logo, footer account card, and featured card. Includes the useMainSidebar composable for programmatic control. On small screens, the sidebar becomes a dialog overlay. Use for primary app navigation in dashboard layouts.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "layout-system"
+      ],
+      "path": "components/sidebar/SKILL.md"
+    },
+    {
+      "name": "skeleton-item",
+      "description": "A loading placeholder element with optional shimmer animation. Renders as a rounded rectangle that mimics content layout while data loads. Load this skill when building skeleton loading screens or placeholder UIs.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/skeleton-item/SKILL.md"
+    },
+    {
+      "name": "styling",
+      "description": "Design token system and component styling for @wisemen/vue-core-design-system. Covers the custom tv() instance (Tailwind Variants with twMerge), design tokens (spacing, colors, typography, shadows, radii, z-index), semantic color system (fg/text/bg/border), light/dark theming, and data-attribute-driven styling. Load when customizing component styles or understanding the token system.\n",
+      "type": "foundation",
+      "library_version": "0.8.0",
+      "path": "foundations/styling/SKILL.md"
+    },
+    {
+      "name": "switch",
+      "description": "A toggle switch for boolean on/off state with optional thumb icons, size variants, and animated transitions. Built on Reka UI SwitchRoot with label, hint, and error message support. Ideal for settings that take effect immediately.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "input-system"
+      ],
+      "path": "components/switch/SKILL.md"
+    },
+    {
+      "name": "tabs",
+      "description": "UITabs provides value-based tabbed navigation, while UITabsRouterLink provides route-based tabbed navigation integrated with Vue Router. Both support three visual variants (underline, button-border, button-brand), horizontal and vertical orientations, full-width mode, adaptive overflow (hiding low-priority tabs into a dropdown), and scroll-based overflow for touch devices.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/tabs/SKILL.md"
+    },
+    {
+      "name": "text",
+      "description": "Typography component with automatic truncation detection and tooltip. Renders text that truncates with an ellipsis and shows a tooltip on hover when content overflows. Load this skill when displaying text that may overflow its container.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/text/SKILL.md"
+    },
+    {
+      "name": "text-field",
+      "description": "Single-line text input with label, hint, error message, and icon support. Wraps a native <input> inside InputWrapper > FieldWrapper. Supports size variants, multiple input types (text, email, password, etc.), and integrates with formango for form validation.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "input-system"
+      ],
+      "path": "components/text-field/SKILL.md"
+    },
+    {
+      "name": "textarea-field",
+      "description": "Multi-line text input with auto-resize, character count, and configurable resize behavior. Wraps a native <textarea> inside InputWrapper with its own bordered container. Integrates with formango for form validation.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "requires": [
+        "input-system"
+      ],
+      "path": "components/textarea-field/SKILL.md"
+    },
+    {
+      "name": "theme-provider",
+      "description": "Provides appearance (light, dark, system) and theme (named theme class) to all descendant components. Applies the theme and appearance as CSS classes on a wrapper element. Supports nesting for scoped theme overrides.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/theme-provider/SKILL.md"
+    },
+    {
+      "name": "timeline",
+      "description": "Vertical timeline component with indicator dots, connector lines, and content slots. UITimeline wraps UITimelineItem children with shared size/variant context. Load this skill when displaying chronological event sequences or activity feeds.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/timeline/SKILL.md"
+    },
+    {
+      "name": "tooltip",
+      "description": "A hover/focus-triggered floating label built on Reka UI TooltipRoot. Supports configurable delay, side positioning, arrow visibility, and custom content via slots. Also exports UITooltipProvider, UITooltipContent, and UITooltipText helpers. Load this skill for informational hover hints on buttons, icons, or interactive elements.\n",
+      "type": "component",
+      "library_version": "0.8.0",
+      "path": "components/tooltip/SKILL.md"
+    }
+  ]
+}

--- a/packages/web/design-system/skills/manifest.json
+++ b/packages/web/design-system/skills/manifest.json
@@ -6,28 +6,24 @@
       "name": "action-tooltip",
       "description": "A pre-built tooltip that displays a text label and an optional keyboard shortcut badge. Wraps UITooltip with UITooltipText and UIKeyboardShortcut in a row layout. Load this skill when you need a standardized tooltip for buttons or actions with shortcut hints.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/action-tooltip/SKILL.md"
     },
     {
       "name": "adaptive-content",
       "description": "A container that conditionally renders child blocks based on available horizontal space and an explicit priority order. Lower-priority blocks are progressively hidden when the container overflows, exposing a hidden-block count for building overflow indicators.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/adaptive-content/SKILL.md"
     },
     {
       "name": "architecture",
       "description": "Core architecture patterns for @wisemen/vue-core-design-system: the parts pattern (Root/Content/Icon sub-components), context system (useContext + provide/inject), PropsToComputed utility, toComputedRefs, file naming conventions, and export conventions (UI prefix). Load before building or extending any component.\n",
       "type": "foundation",
-      "library_version": "0.8.0",
       "path": "foundations/architecture/SKILL.md"
     },
     {
       "name": "autocomplete",
       "description": "Typeahead input that filters a dropdown list as the user types. Supports local client-side filtering and remote server-side search with debouncing. Uses the input-system foundation for labels, errors, and field wrappers.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "input-system"
       ],
@@ -37,42 +33,36 @@
       "name": "avatar",
       "description": "Avatar system with four components: UIAvatar (image or initials), UIAvatarGroup (stacked row with overflow), UIAvatarGroupAddButton (dashed add action), and UIAvatarLabel (avatar with name and supporting text). Load this skill when displaying user profile pictures, grouped users, or labeled identity elements.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/avatar/SKILL.md"
     },
     {
       "name": "badge",
       "description": "Versatile badge component with support for labels, icons, dots, avatars, and separators. Includes BadgeGroup for wrapping collections and BadgeGroupTruncate for overflow handling. Load this skill when displaying status indicators, tags, or categorization labels.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/badge/SKILL.md"
     },
     {
       "name": "breadcrumbs",
       "description": "UIBreadcrumbs is a composite navigation component built from UIBreadcrumbRoot, UIBreadcrumbItems, UIBreadcrumbItem, and UIBreadcrumbSeparator parts. It renders a horizontal breadcrumb trail with optional icons, router links, and accessible label-hiding for icon-only items.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/breadcrumbs/SKILL.md"
     },
     {
       "name": "button",
       "description": "UIButton, UIIconButton, and UILink -- the three action trigger variants. UIButton renders a labeled button, UIIconButton renders an icon-only button with an accessible label, and UILink renders a navigation element styled like a button using either Vue Router or a plain anchor.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/button/SKILL.md"
     },
     {
       "name": "card",
       "description": "Simple bordered container with rounded corners for grouping related content. Has no props -- content goes in the default slot. Load this skill when you need a visual card or panel wrapper.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/card/SKILL.md"
     },
     {
       "name": "checkbox",
       "description": "A single boolean checkbox with label, hint, error message, and animated check indicator. Built on Reka UI CheckboxRoot with InputWrapper in horizontal layout. Integrates with formango for form validation and with UICheckboxGroup for multi-select scenarios.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "input-system"
       ],
@@ -82,7 +72,6 @@
       "name": "checkbox-group",
       "description": "A group of checkboxes for multi-value selection with an optional indeterminate \"select all\" checkbox. Built on Reka UI CheckboxGroupRoot with a context-based registration system. Supports vertical and horizontal orientations and disabled state with reason tooltip.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "input-system"
       ],
@@ -92,14 +81,12 @@
       "name": "clickable-element",
       "description": "Low-level wrapper that applies consistent focus-visible outline and cursor styles to any interactive element. Uses Reka UI Primitive with as-child for zero extra DOM nodes. Load this skill when building custom clickable primitives or understanding the focus ring system.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/clickable-element/SKILL.md"
     },
     {
       "name": "column-layout",
       "description": "Vertical flex container with configurable gap, alignment, and justification using design-token spacing. Renders as a customizable HTML element and provides a default slot for child content. Use for any vertical stacking of elements.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "layout-system"
       ],
@@ -109,14 +96,12 @@
       "name": "config-provider",
       "description": "Application-level configuration provider that supplies locale, number formatting, hour cycle, teleport target, and Google Maps API key to all design system components via Vue's provide/inject. Must wrap the entire application.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/config-provider/SKILL.md"
     },
     {
       "name": "confirm-dialog",
       "description": "A pre-built confirmation dialog with title, description, icon, cancel button, and confirm button. Supports destructive styling and async confirm callbacks with automatic loading state. Uses the dialog sub-components internally. Load this skill for yes/no or delete confirmation prompts.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "overlay-system"
       ],
@@ -126,14 +111,12 @@
       "name": "design-system-index",
       "description": "Master index for @wisemen/vue-core-design-system. Read this first to find the right skill for any component or pattern. Lists all skills organized by category with a decision tree for component selection.\n",
       "type": "index",
-      "library_version": "0.8.0",
       "path": "_index/SKILL.md"
     },
     {
       "name": "dialog",
       "description": "Modal dialog system with header, body, footer, and close button sub-components. Built on Reka UI DialogRoot with animated overlay, scroll-aware separators, and a chin feature for contextual actions. Supports both template-driven (v-model) and imperative (useOverlay) patterns. Also exports useOverlay composable and useDialogTriggerProps helper. Load this skill for any modal dialog implementation.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "overlay-system"
       ],
@@ -143,28 +126,24 @@
       "name": "dot",
       "description": "Small colored circle used as a status indicator. Supports 8 color variants and 3 sizes. Load this skill when you need a visual status dot, online/offline indicator, or colored bullet point.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/dot/SKILL.md"
     },
     {
       "name": "dropdown-menu",
       "description": "UIDropdownMenu is a popover-based menu triggered by a button or custom element. Built on Reka UI's DropdownMenu primitives, it supports items with icons and keyboard shortcuts, groups, headers, separators, and radio groups for single-select options. Content is portalled to the body with configurable positioning.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/dropdown-menu/SKILL.md"
     },
     {
       "name": "form",
       "description": "Form wrapper that integrates with formango's Form object to provide submit handling, unsaved changes detection with route-leave guards, and a context for child components like FormSubmitButton. Always pair with a formango useForm() call.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/form/SKILL.md"
     },
     {
       "name": "form-dialog",
       "description": "A dialog with integrated formango form handling. Wraps UIDialog with form context, automatic form ID generation, and optional unsaved-changes prompt. Uses FormDialogForm internally to connect to formango's Form type. Load this skill when building dialogs that contain validated forms.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "overlay-system"
       ],
@@ -174,28 +153,24 @@
       "name": "input-system",
       "description": "The InputWrapper > FieldWrapper > native element architecture shared by all input components (TextField, TextareaField, NumberField, Select, Autocomplete, Checkbox, etc.). Covers the Input, InputWrapper, FieldWrapper, AutocompleteInput interfaces, their default constants, the useInput composable for ARIA generation, and the DisabledWithReason pattern. Load before implementing or modifying any input or form control component.\n",
       "type": "foundation",
-      "library_version": "0.8.0",
       "path": "foundations/input-system/SKILL.md"
     },
     {
       "name": "interactable",
       "description": "Low-level renderless wrapper that applies focus-visible outline and cursor styles to interactive elements. Similar to UIClickableElement but with a different outline approach. Load this skill when building custom interactive primitives.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/interactable/SKILL.md"
     },
     {
       "name": "keyboard-shortcut",
       "description": "Renders a keyboard shortcut as styled key badges. Parses a shortcut string (e.g., \"meta_k\", \"g-d\") into individual keys with platform-aware symbols (macOS vs Windows). Load this skill when displaying keyboard shortcuts in tooltips, menus, or help panels.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/keyboard-shortcut/SKILL.md"
     },
     {
       "name": "layout",
       "description": "Top-level application shell components that provide the outermost page structure. UIMainLayoutContainer is the full-screen flex wrapper, and UIMainContent is the sidebar-aware content area with animated padding. Use these as the root of every page in a dashboard application.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "layout-system"
       ],
@@ -205,42 +180,36 @@
       "name": "layout-system",
       "description": "Layout primitives and page composition for @wisemen/vue-core-design-system. Covers UIRowLayout and UIColumnLayout (flex containers with gap/align/justify), the DashboardPage system (header, actions, detail pane, loading state), and UIMainSidebar (navigation groups, links, global search). Load before building page layouts or navigation.\n",
       "type": "foundation",
-      "library_version": "0.8.0",
       "path": "foundations/layout-system/SKILL.md"
     },
     {
       "name": "loader",
       "description": "Animated SVG loading spinner that inherits size and color from its parent. Has no props -- sized via CSS classes and colored via currentColor. Load this skill when you need a spinning loading indicator.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/loader/SKILL.md"
     },
     {
       "name": "logo",
       "description": "Displays a brand or app logo image with optional text label. UILogo renders a sized image with fallback placeholder on error. UILogoWithText combines the logo with a name label. Load this skill for brand identity elements in headers or sidebars.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/logo/SKILL.md"
     },
     {
       "name": "menu-item",
       "description": "UIMenuItem is a flexible content layout component for items in dropdown menus, lists, and selectable options. It supports icons, avatars, dots, descriptions, right-side content (text, icons, keyboard shortcuts), and a right slot. Used as the content layer inside UIDropdownMenuItem and select/autocomplete items.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/menu-item/SKILL.md"
     },
     {
       "name": "number-badge",
       "description": "Small pill-shaped badge that displays a numeric value with color and variant options. Useful for counts, notification indicators, and numeric status labels. Load this skill when you need to show a number inside a colored badge.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/number-badge/SKILL.md"
     },
     {
       "name": "number-field",
       "description": "Numeric input with locale-aware formatting, optional increment/decrement controls, min/max bounds, and step snapping. Built on Reka UI NumberField with InputWrapper > FieldWrapper composition. Integrates with formango for form validation.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "input-system"
       ],
@@ -250,14 +219,12 @@
       "name": "overlay-system",
       "description": "Imperative overlay management for @wisemen/vue-core-design-system. Covers the useOverlay composable (create, open, close, patch, closeAll), DialogContainer for rendering overlays, promise-based dialog results, and the useDialogTriggerProps helper. Load before working with Dialog, ConfirmDialog, FormDialog, or any imperative overlay pattern.\n",
       "type": "foundation",
-      "library_version": "0.8.0",
       "path": "foundations/overlay-system/SKILL.md"
     },
     {
       "name": "page",
       "description": "Full dashboard page system with header, breadcrumbs, action bars, content area, loading state, and a resizable detail pane. UIDashboardPage is the root orchestrator that composes 8+ sub-components. Use for any page inside the dashboard layout shell.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "layout-system"
       ],
@@ -267,7 +234,6 @@
       "name": "popover",
       "description": "A floating content panel anchored to a trigger element. Built on Reka UI PopoverRoot with configurable alignment, side, collision handling, and animated open/close transitions. Load this skill when you need interactive floating panels that appear on click.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "overlay-system"
       ],
@@ -277,7 +243,6 @@
       "name": "radio-group",
       "description": "A radio group for single-value selection from multiple options. Built on Reka UI RadioGroupRoot with context-based item registration. Supports standard radio items and card-style items with descriptions. Includes vertical/horizontal orientation and disabled state with reason tooltip.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "input-system"
       ],
@@ -287,7 +252,6 @@
       "name": "row-layout",
       "description": "Horizontal flex container with configurable gap, alignment, and justification using design-token spacing. Renders as a customizable HTML element and provides a default slot for child content. Use for any horizontal arrangement of elements.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "layout-system"
       ],
@@ -297,14 +261,12 @@
       "name": "scrollable",
       "description": "Scrollable container that shows gradient fade indicators at the top/bottom when content overflows. Supports infinite scroll via an onNext callback. Load this skill when building scrollable lists, panels, or any container that needs visual scroll cues.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/scrollable/SKILL.md"
     },
     {
       "name": "select",
       "description": "Dropdown select component supporting single and multi-select modes with optional search (local or remote), pagination, and rich option rendering via getItemConfig. Determines single vs multi mode from the v-model type (value vs array).\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "input-system"
       ],
@@ -314,14 +276,12 @@
       "name": "separator",
       "description": "A horizontal or vertical divider line built on Reka UI's Separator primitive. Supports horizontal and vertical orientations. Load this skill when you need a visual divider between sections or inline elements.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/separator/SKILL.md"
     },
     {
       "name": "sidebar",
       "description": "Main navigation sidebar with collapsible behavior, navigation groups, links with badges and status dots, global search trigger, header logo, footer account card, and featured card. Includes the useMainSidebar composable for programmatic control. On small screens, the sidebar becomes a dialog overlay. Use for primary app navigation in dashboard layouts.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "layout-system"
       ],
@@ -331,21 +291,18 @@
       "name": "skeleton-item",
       "description": "A loading placeholder element with optional shimmer animation. Renders as a rounded rectangle that mimics content layout while data loads. Load this skill when building skeleton loading screens or placeholder UIs.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/skeleton-item/SKILL.md"
     },
     {
       "name": "styling",
       "description": "Design token system and component styling for @wisemen/vue-core-design-system. Covers the custom tv() instance (Tailwind Variants with twMerge), design tokens (spacing, colors, typography, shadows, radii, z-index), semantic color system (fg/text/bg/border), light/dark theming, and data-attribute-driven styling. Load when customizing component styles or understanding the token system.\n",
       "type": "foundation",
-      "library_version": "0.8.0",
       "path": "foundations/styling/SKILL.md"
     },
     {
       "name": "switch",
       "description": "A toggle switch for boolean on/off state with optional thumb icons, size variants, and animated transitions. Built on Reka UI SwitchRoot with label, hint, and error message support. Ideal for settings that take effect immediately.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "input-system"
       ],
@@ -355,21 +312,18 @@
       "name": "tabs",
       "description": "UITabs provides value-based tabbed navigation, while UITabsRouterLink provides route-based tabbed navigation integrated with Vue Router. Both support three visual variants (underline, button-border, button-brand), horizontal and vertical orientations, full-width mode, adaptive overflow (hiding low-priority tabs into a dropdown), and scroll-based overflow for touch devices.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/tabs/SKILL.md"
     },
     {
       "name": "text",
       "description": "Typography component with automatic truncation detection and tooltip. Renders text that truncates with an ellipsis and shows a tooltip on hover when content overflows. Load this skill when displaying text that may overflow its container.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/text/SKILL.md"
     },
     {
       "name": "text-field",
       "description": "Single-line text input with label, hint, error message, and icon support. Wraps a native <input> inside InputWrapper > FieldWrapper. Supports size variants, multiple input types (text, email, password, etc.), and integrates with formango for form validation.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "input-system"
       ],
@@ -379,7 +333,6 @@
       "name": "textarea-field",
       "description": "Multi-line text input with auto-resize, character count, and configurable resize behavior. Wraps a native <textarea> inside InputWrapper with its own bordered container. Integrates with formango for form validation.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "requires": [
         "input-system"
       ],
@@ -389,21 +342,18 @@
       "name": "theme-provider",
       "description": "Provides appearance (light, dark, system) and theme (named theme class) to all descendant components. Applies the theme and appearance as CSS classes on a wrapper element. Supports nesting for scoped theme overrides.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/theme-provider/SKILL.md"
     },
     {
       "name": "timeline",
       "description": "Vertical timeline component with indicator dots, connector lines, and content slots. UITimeline wraps UITimelineItem children with shared size/variant context. Load this skill when displaying chronological event sequences or activity feeds.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/timeline/SKILL.md"
     },
     {
       "name": "tooltip",
       "description": "A hover/focus-triggered floating label built on Reka UI TooltipRoot. Supports configurable delay, side positioning, arrow visibility, and custom content via slots. Also exports UITooltipProvider, UITooltipContent, and UITooltipText helpers. Load this skill for informational hover hints on buttons, icons, or interactive elements.\n",
       "type": "component",
-      "library_version": "0.8.0",
       "path": "components/tooltip/SKILL.md"
     }
   ]


### PR DESCRIPTION
## Summary

- Remove duplicated API documentation (props tables, variants table, anatomy diagram, styling section, accessibility prose) that mirrors content already in `.props.ts` and `.style.ts` source files
- Add **Source Files** section pointing directly to authoritative source files
- Keep all high-value content: Quick Start, examples, common mistakes, when-to-use guidance

**360 → 176 lines (-51%)**

This is the **template PR** for the lean skills initiative. Please review the format carefully — all other component skills will follow this same pattern.

## Why

Props tables in skills are lossy copies of TypeScript interfaces that go stale when components change. The `.props.ts` files with JSDoc are richer (optionality markers, exact types, `@default` tags) and are the actual source of truth. Removing the duplication means **zero skill maintenance when props change**.

## What stays
- Quick Start example (working code)
- 3 composition examples (icons, loading/disabled, router links)
- All 3 Common Mistakes (wrong/correct pairs)
- When to Use guidance
- See Also cross-links

## What's removed
- Props/slots/emits tables (86 lines) → replaced by Source Files pointers (5 lines)
- Variants/sizes tables (21 lines)
- Anatomy ASCII diagram (30 lines)
- Styling section (12 lines)
- Accessibility prose (7 lines)

Tracking issue: #918

## Test plan

- [ ] Review the lean format — is the remaining content sufficient for AI to generate correct button usage?
- [ ] Verify Source Files paths point to real files
- [ ] Agree on this format before applying to remaining 43 skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)