### PR TITLE
feat(datewise): add `from` factory function on response and specify inclusivity on parse

### DIFF
--- a/.changeset/early-glasses-do.md
+++ b/.changeset/early-glasses-do.md
@@ -1,0 +1,6 @@
+---
+"@wisemen/datewise": patch
+---
+
+feat: allow caller specified inclusivity on parse of range dtos
+feat: add static `from` factory function which deals with `null` types on range responses

--- a/packages/api/datewise/lib/date-range/date-range.dto.ts
+++ b/packages/api/datewise/lib/date-range/date-range.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger'
 import { FilterQuery } from '@wisemen/pagination'
 import { IsPlainDate } from '../plain-date/index.js'
 import { DateRange } from './date-range.js'
+import { InclusivityString } from '../common/inclusivity.js'
 
 export class DateRangeDto extends FilterQuery {
   @ApiProperty({ format: 'date' })
@@ -12,7 +13,11 @@ export class DateRangeDto extends FilterQuery {
   @IsPlainDate()
   endDate: string
 
-  parse (): DateRange {
-    return new DateRange(this.startDate, this.endDate)
+  /**
+   * Parse this dto into a DateRange instance.
+   * @param inclusivity defaults to `[]`
+   */
+  parse (inclusivity: InclusivityString = '[]'): DateRange {
+    return new DateRange(this.startDate, this.endDate, inclusivity)
   }
 }

--- a/packages/api/datewise/lib/date-range/date-range.response.ts
+++ b/packages/api/datewise/lib/date-range/date-range.response.ts
@@ -2,6 +2,12 @@ import { PlainDateApiProperty } from '../plain-date/index.js'
 import { DateRange } from './date-range.js'
 
 export class DateRangeResponse {
+  static from (range: DateRange): DateRangeResponse
+  static from (range: null): | null
+  static from (range: DateRange | null): DateRangeResponse | null {
+    return range !== null ? new DateRangeResponse(range) : null
+  }
+
   @PlainDateApiProperty()
   startDate: string
 

--- a/packages/api/datewise/lib/date-range/tests/date-range.dto.unit.test.ts
+++ b/packages/api/datewise/lib/date-range/tests/date-range.dto.unit.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test'
+import { expect } from 'expect'
+import { DateRangeDto } from '../date-range.dto.js'
+import { DateRange } from '../date-range.js'
+import { plainDate } from '../../plain-date/index.js'
+
+describe('DateRangeDto unit tests', () => {
+  describe('parse method', () => {
+    it('Parses a dto into a DateRange with default inclusivity []', () => {
+      const dto = new DateRangeDto()
+      dto.startDate = '2024-01-01'
+      dto.endDate = '2024-01-31'
+
+      const range = dto.parse()
+
+      expect(range).toBeInstanceOf(DateRange)
+      expect(range.startDate.toString()).toBe('2024-01-01')
+      expect(range.endDate.toString()).toBe('2024-01-31')
+    })
+
+    it('Parses a dto into a DateRange with custom inclusivity [)', () => {
+      const dto = new DateRangeDto()
+      dto.startDate = '2024-01-01'
+      dto.endDate = '2024-01-31'
+
+      const range = dto.parse('[)')
+
+      expect(range).toBeInstanceOf(DateRange)
+      expect(range.startDate.toString()).toBe('2024-01-01')
+      // With [) inclusivity, the end date should be adjusted
+      expect(range.endDate.toString()).toBe('2024-01-30')
+    })
+
+    it('Parses a dto into a DateRange with custom inclusivity (]', () => {
+      const dto = new DateRangeDto()
+      dto.startDate = '2024-01-01'
+      dto.endDate = '2024-01-31'
+
+      const range = dto.parse('(]')
+
+      expect(range).toBeInstanceOf(DateRange)
+      // With (] inclusivity, the start date should be adjusted
+      expect(range.startDate.toString()).toBe('2024-01-02')
+      expect(range.endDate.toString()).toBe('2024-01-31')
+    })
+
+    it('Parses a dto into a DateRange with custom inclusivity ()', () => {
+      const dto = new DateRangeDto()
+      dto.startDate = '2024-01-01'
+      dto.endDate = '2024-01-31'
+
+      const range = dto.parse('()')
+
+      expect(range).toBeInstanceOf(DateRange)
+      // With () inclusivity, both dates should be adjusted
+      expect(range.startDate.toString()).toBe('2024-01-02')
+      expect(range.endDate.toString()).toBe('2024-01-30')
+    })
+
+    it('Handles a dto with same start and end date', () => {
+      const dto = new DateRangeDto()
+      dto.startDate = '2024-03-15'
+      dto.endDate = '2024-03-15'
+
+      const range = dto.parse()
+
+      expect(range).toBeInstanceOf(DateRange)
+      expect(range.startDate.toString()).toBe('2024-03-15')
+      expect(range.endDate.toString()).toBe('2024-03-15')
+    })
+
+    it('Handles a dto spanning multiple years', () => {
+      const dto = new DateRangeDto()
+      dto.startDate = '2023-12-25'
+      dto.endDate = '2024-01-05'
+
+      const range = dto.parse()
+
+      expect(range).toBeInstanceOf(DateRange)
+      expect(range.startDate.toString()).toBe('2023-12-25')
+      expect(range.endDate.toString()).toBe('2024-01-05')
+    })
+
+    it('Explicitly passing [] inclusivity behaves the same as default', () => {
+      const dto = new DateRangeDto()
+      dto.startDate = '2024-06-01'
+      dto.endDate = '2024-06-30'
+
+      const rangeDefault = dto.parse()
+      const rangeExplicit = dto.parse('[]')
+
+      expect(rangeDefault.startDate.toString()).toBe(rangeExplicit.startDate.toString())
+      expect(rangeDefault.endDate.toString()).toBe(rangeExplicit.endDate.toString())
+    })
+  })
+})

--- a/packages/api/datewise/lib/date-range/tests/date-range.dto.unit.test.ts
+++ b/packages/api/datewise/lib/date-range/tests/date-range.dto.unit.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from 'node:test'
 import { expect } from 'expect'
 import { DateRangeDto } from '../date-range.dto.js'
 import { DateRange } from '../date-range.js'
-import { plainDate } from '../../plain-date/index.js'
 
 describe('DateRangeDto unit tests', () => {
   describe('parse method', () => {

--- a/packages/api/datewise/lib/date-range/tests/date-range.response.unit.test.ts
+++ b/packages/api/datewise/lib/date-range/tests/date-range.response.unit.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from 'node:test'
+import { expect } from 'expect'
+import { DateRange } from '../date-range.js'
+import { DateRangeResponse } from '../date-range.response.js'
+import { plainDate } from '../../plain-date/index.js'
+
+describe('DateRangeResponse unit tests', () => {
+  describe('constructor', () => {
+    it('Creates a DateRangeResponse from a DateRange', () => {
+      const range = new DateRange(
+        plainDate('2024-01-01'),
+        plainDate('2024-01-31')
+      )
+
+      const response = new DateRangeResponse(range)
+
+      expect(response.startDate).toBe('2024-01-01')
+      expect(response.endDate).toBe('2024-01-31')
+    })
+
+    it('Converts PlainDate objects to ISO date strings', () => {
+      const range = new DateRange(
+        plainDate('2024-06-15'),
+        plainDate('2024-06-20')
+      )
+
+      const response = new DateRangeResponse(range)
+
+      expect(response.startDate).toBe('2024-06-15')
+      expect(response.endDate).toBe('2024-06-20')
+    })
+  })
+
+  describe('from static method', () => {
+    it('Creates a DateRangeResponse from a non-null DateRange', () => {
+      const range = new DateRange(
+        plainDate('2024-01-01'),
+        plainDate('2024-12-31')
+      )
+
+      const response = DateRangeResponse.from(range)
+
+      expect(response).toBeInstanceOf(DateRangeResponse)
+      expect(response?.startDate).toBe('2024-01-01')
+      expect(response?.endDate).toBe('2024-12-31')
+    })
+
+    it('Returns null when given null', () => {
+      const response = DateRangeResponse.from(null)
+
+      expect(response).toBeNull()
+    })
+
+    it('Handles DateRange with same start and end date', () => {
+      const range = new DateRange(
+        plainDate('2024-03-15'),
+        plainDate('2024-03-15')
+      )
+
+      const response = DateRangeResponse.from(range)
+
+      expect(response).toBeInstanceOf(DateRangeResponse)
+      expect(response?.startDate).toBe('2024-03-15')
+      expect(response?.endDate).toBe('2024-03-15')
+    })
+
+    it('Handles DateRange spanning multiple years', () => {
+      const range = new DateRange(
+        plainDate('2023-12-25'),
+        plainDate('2024-01-05')
+      )
+
+      const response = DateRangeResponse.from(range)
+
+      expect(response).toBeInstanceOf(DateRangeResponse)
+      expect(response?.startDate).toBe('2023-12-25')
+      expect(response?.endDate).toBe('2024-01-05')
+    })
+  })
+})

--- a/packages/api/datewise/lib/date-time-range/date-time-range.dto.ts
+++ b/packages/api/datewise/lib/date-time-range/date-time-range.dto.ts
@@ -1,6 +1,7 @@
 import { FilterQuery } from '@wisemen/pagination'
 import { IsTimestamp, TimestampApiProperty } from '../timestamp/index.js'
 import { DateTimeRange } from './date-time-range.js'
+import { InclusivityString } from '../common/inclusivity.js'
 
 export class DateTimeRangeDto extends FilterQuery {
   @TimestampApiProperty({ description: 'start of the range, inclusive' })
@@ -11,7 +12,11 @@ export class DateTimeRangeDto extends FilterQuery {
   @IsTimestamp({ isAfter: (dto: DateTimeRangeDto) => dto.from })
   until: string
 
-  parse (): DateTimeRange {
-    return new DateTimeRange(this.from, this.until)
+  /**
+   * Parse this dto into a DateRange instance.
+   * @param inclusivity defaults to `[)`
+   */
+  parse (inclusivity: InclusivityString = '[)'): DateTimeRange {
+    return new DateTimeRange(this.from, this.until, inclusivity)
   }
 }

--- a/packages/api/datewise/lib/date-time-range/date-time-range.response.ts
+++ b/packages/api/datewise/lib/date-time-range/date-time-range.response.ts
@@ -2,6 +2,12 @@ import { TimestampApiProperty } from '../timestamp/index.js'
 import { DateTimeRange } from './date-time-range.js'
 
 export class DateTimeRangeResponse {
+  static from (range: DateTimeRange): DateTimeRangeResponse
+  static from (range: null): | null
+  static from (range: DateTimeRange | null): DateTimeRangeResponse | null {
+    return range !== null ? new DateTimeRangeResponse(range) : null
+  }
+
   @TimestampApiProperty({ description: 'start of the range, inclusive' })
   from: string
 

--- a/packages/api/datewise/lib/date-time-range/tests/date-time-range.dto.unit.test.ts
+++ b/packages/api/datewise/lib/date-time-range/tests/date-time-range.dto.unit.test.ts
@@ -2,7 +2,6 @@ import { before, describe, it } from 'node:test'
 import { expect } from 'expect'
 import { DateTimeRangeDto } from '../date-time-range.dto.js'
 import { DateTimeRange } from '../date-time-range.js'
-import { timestamp } from '../../timestamp/index.js'
 import { initDayjs } from '../../common/init-dayjs.js'
 
 describe('DateTimeRangeDto unit tests', () => {

--- a/packages/api/datewise/lib/date-time-range/tests/date-time-range.dto.unit.test.ts
+++ b/packages/api/datewise/lib/date-time-range/tests/date-time-range.dto.unit.test.ts
@@ -1,0 +1,114 @@
+import { before, describe, it } from 'node:test'
+import { expect } from 'expect'
+import { DateTimeRangeDto } from '../date-time-range.dto.js'
+import { DateTimeRange } from '../date-time-range.js'
+import { timestamp } from '../../timestamp/index.js'
+import { initDayjs } from '../../common/init-dayjs.js'
+
+describe('DateTimeRangeDto unit tests', () => {
+  before(() => {
+    initDayjs()
+  })
+
+  describe('parse method', () => {
+    it('Parses a dto into a DateTimeRange with default inclusivity [)', () => {
+      const dto = new DateTimeRangeDto()
+      dto.from = '2024-01-01T00:00:00.000Z'
+      dto.until = '2024-01-31T23:59:59.999Z'
+
+      const range = dto.parse()
+
+      expect(range).toBeInstanceOf(DateTimeRange)
+      expect(range.inclLower.toISOString()).toBe('2024-01-01T00:00:00.000Z')
+      expect(range.exclUpper.toISOString()).toBe('2024-01-31T23:59:59.999Z')
+    })
+
+    it('Parses a dto into a DateTimeRange with custom inclusivity []', () => {
+      const dto = new DateTimeRangeDto()
+      dto.from = '2024-01-01T00:00:00.000Z'
+      dto.until = '2024-01-31T23:59:59.999Z'
+
+      const range = dto.parse('[]')
+
+      expect(range).toBeInstanceOf(DateTimeRange)
+      expect(range.inclLower.toISOString()).toBe('2024-01-01T00:00:00.000Z')
+      // With [] inclusivity, the upper bound is inclusive, so exclUpper is 1ms after
+      expect(range.exclUpper.toISOString()).toBe('2024-02-01T00:00:00.000Z')
+    })
+
+    it('Parses a dto into a DateTimeRange with custom inclusivity (]', () => {
+      const dto = new DateTimeRangeDto()
+      dto.from = '2024-01-01T00:00:00.000Z'
+      dto.until = '2024-01-31T23:59:59.999Z'
+
+      const range = dto.parse('(]')
+
+      expect(range).toBeInstanceOf(DateTimeRange)
+      // With (] inclusivity, the lower bound is exclusive, so inclLower is 1ms after
+      expect(range.inclLower.toISOString()).toBe('2024-01-01T00:00:00.001Z')
+      // Upper bound is inclusive, so exclUpper is 1ms after
+      expect(range.exclUpper.toISOString()).toBe('2024-02-01T00:00:00.000Z')
+    })
+
+    it('Parses a dto into a DateTimeRange with custom inclusivity ()', () => {
+      const dto = new DateTimeRangeDto()
+      dto.from = '2024-01-01T00:00:00.000Z'
+      dto.until = '2024-01-31T23:59:59.999Z'
+
+      const range = dto.parse('()')
+
+      expect(range).toBeInstanceOf(DateTimeRange)
+      // With () inclusivity, both bounds are exclusive
+      expect(range.inclLower.toISOString()).toBe('2024-01-01T00:00:00.001Z')
+      expect(range.exclUpper.toISOString()).toBe('2024-01-31T23:59:59.999Z')
+    })
+
+    it('Handles millisecond precision', () => {
+      const dto = new DateTimeRangeDto()
+      dto.from = '2024-03-15T10:20:30.123Z'
+      dto.until = '2024-03-15T10:20:30.456Z'
+
+      const range = dto.parse()
+
+      expect(range).toBeInstanceOf(DateTimeRange)
+      expect(range.inclLower.toISOString()).toBe('2024-03-15T10:20:30.123Z')
+      expect(range.exclUpper.toISOString()).toBe('2024-03-15T10:20:30.456Z')
+    })
+
+    it('Handles a dto spanning year boundary', () => {
+      const dto = new DateTimeRangeDto()
+      dto.from = '2023-12-31T22:00:00.000Z'
+      dto.until = '2024-01-01T02:00:00.000Z'
+
+      const range = dto.parse()
+
+      expect(range).toBeInstanceOf(DateTimeRange)
+      expect(range.inclLower.toISOString()).toBe('2023-12-31T22:00:00.000Z')
+      expect(range.exclUpper.toISOString()).toBe('2024-01-01T02:00:00.000Z')
+    })
+
+    it('Explicitly passing [) inclusivity behaves the same as default', () => {
+      const dto = new DateTimeRangeDto()
+      dto.from = '2024-06-01T10:00:00.000Z'
+      dto.until = '2024-06-30T18:00:00.000Z'
+
+      const rangeDefault = dto.parse()
+      const rangeExplicit = dto.parse('[)')
+
+      expect(rangeDefault.inclLower.toISOString()).toBe(rangeExplicit.inclLower.toISOString())
+      expect(rangeDefault.exclUpper.toISOString()).toBe(rangeExplicit.exclUpper.toISOString())
+    })
+
+    it('Handles short duration ranges', () => {
+      const dto = new DateTimeRangeDto()
+      dto.from = '2024-05-15T14:30:00.000Z'
+      dto.until = '2024-05-15T14:30:01.000Z'
+
+      const range = dto.parse()
+
+      expect(range).toBeInstanceOf(DateTimeRange)
+      expect(range.inclLower.toISOString()).toBe('2024-05-15T14:30:00.000Z')
+      expect(range.exclUpper.toISOString()).toBe('2024-05-15T14:30:01.000Z')
+    })
+  })
+})

--- a/packages/api/datewise/lib/date-time-range/tests/date-time-range.response.unit.test.ts
+++ b/packages/api/datewise/lib/date-time-range/tests/date-time-range.response.unit.test.ts
@@ -1,0 +1,110 @@
+import { before, describe, it } from 'node:test'
+import { expect } from 'expect'
+import { DateTimeRange } from '../date-time-range.js'
+import { DateTimeRangeResponse } from '../date-time-range.response.js'
+import { timestamp } from '../../timestamp/index.js'
+import { initDayjs } from '../../common/init-dayjs.js'
+
+describe('DateTimeRangeResponse unit tests', () => {
+  before(() => {
+    initDayjs()
+  })
+
+  describe('constructor', () => {
+    it('Creates a DateTimeRangeResponse from a DateTimeRange', () => {
+      const range = new DateTimeRange(
+        timestamp('2024-01-01T00:00:00.000Z'),
+        timestamp('2024-01-31T23:59:59.999Z')
+      )
+
+      const response = new DateTimeRangeResponse(range)
+
+      expect(response.from).toBe('2024-01-01T00:00:00.000Z')
+      expect(response.until).toBe('2024-01-31T23:59:59.999Z')
+    })
+
+    it('Converts Timestamp objects to ISO strings', () => {
+      const range = new DateTimeRange(
+        timestamp('2024-06-15T12:30:00.000Z'),
+        timestamp('2024-06-20T18:45:00.000Z')
+      )
+
+      const response = new DateTimeRangeResponse(range)
+
+      expect(response.from).toBe('2024-06-15T12:30:00.000Z')
+      expect(response.until).toBe('2024-06-20T18:45:00.000Z')
+    })
+
+    it('Handles millisecond precision', () => {
+      const range = new DateTimeRange(
+        timestamp('2024-03-15T10:20:30.123Z'),
+        timestamp('2024-03-15T10:20:30.456Z')
+      )
+
+      const response = new DateTimeRangeResponse(range)
+
+      expect(response.from).toBe('2024-03-15T10:20:30.123Z')
+      expect(response.until).toBe('2024-03-15T10:20:30.456Z')
+    })
+  })
+
+  describe('from static method', () => {
+    it('Creates a DateTimeRangeResponse from a non-null DateTimeRange', () => {
+      const range = new DateTimeRange(
+        timestamp('2024-01-01T00:00:00.000Z'),
+        timestamp('2024-12-31T23:59:59.999Z')
+      )
+
+      const response = DateTimeRangeResponse.from(range)
+
+      expect(response).toBeInstanceOf(DateTimeRangeResponse)
+      expect(response?.from).toBe('2024-01-01T00:00:00.000Z')
+      expect(response?.until).toBe('2024-12-31T23:59:59.999Z')
+    })
+
+    it('Returns null when given null', () => {
+      const response = DateTimeRangeResponse.from(null)
+
+      expect(response).toBeNull()
+    })
+
+    it('Handles DateTimeRange spanning different timezones', () => {
+      const range = new DateTimeRange(
+        timestamp('2024-03-10T08:00:00.000Z'),
+        timestamp('2024-03-11T20:00:00.000Z')
+      )
+
+      const response = DateTimeRangeResponse.from(range)
+
+      expect(response).toBeInstanceOf(DateTimeRangeResponse)
+      expect(response?.from).toBe('2024-03-10T08:00:00.000Z')
+      expect(response?.until).toBe('2024-03-11T20:00:00.000Z')
+    })
+
+    it('Handles DateTimeRange spanning year boundary', () => {
+      const range = new DateTimeRange(
+        timestamp('2023-12-31T22:00:00.000Z'),
+        timestamp('2024-01-01T02:00:00.000Z')
+      )
+
+      const response = DateTimeRangeResponse.from(range)
+
+      expect(response).toBeInstanceOf(DateTimeRangeResponse)
+      expect(response?.from).toBe('2023-12-31T22:00:00.000Z')
+      expect(response?.until).toBe('2024-01-01T02:00:00.000Z')
+    })
+
+    it('Handles short duration ranges', () => {
+      const range = new DateTimeRange(
+        timestamp('2024-05-15T14:30:00.000Z'),
+        timestamp('2024-05-15T14:30:01.000Z')
+      )
+
+      const response = DateTimeRangeResponse.from(range)
+
+      expect(response).toBeInstanceOf(DateTimeRangeResponse)
+      expect(response?.from).toBe('2024-05-15T14:30:00.000Z')
+      expect(response?.until).toBe('2024-05-15T14:30:01.000Z')
+    })
+  })
+})


### PR DESCRIPTION


### Description
feat: allow caller specified inclusivity on parse of range dtos
feat: add static `from` factory function which deals with `null` types on range responses