### PR TITLE
feat(datewise): add expand method

### DIFF
--- a/.changeset/fruity-planes-hide.md
+++ b/.changeset/fruity-planes-hide.md
@@ -1,0 +1,7 @@
+---
+"@wisemen/datewise": minor
+---
+
+feat: add `expand` on `DateRange` and `DateTimeRange` to symmetrically move both boundaries outwards by a specified duration
+feat: add `addDuration` and `subtractDuration` on `PlainDate`
+rework: rename `setFrom` and similar methods to `withFrom` to better indicate the immutability of the instances

--- a/.changeset/fruity-planes-hide.md
+++ b/.changeset/fruity-planes-hide.md
@@ -1,7 +1,7 @@
 ---
-"@wisemen/datewise": minor
+"@wisemen/datewise": major
 ---
 
-feat: add `expand` on `DateRange` and `DateTimeRange` to symmetrically move both boundaries outwards by a specified duration
+feat: add `expanded` on `DateRange` and `DateTimeRange` to symmetrically move both boundaries outwards by a specified duration
 feat: add `addDuration` and `subtractDuration` on `PlainDate`
 rework: rename `setFrom` and similar methods to `withFrom` to better indicate the immutability of the instances

--- a/packages/api/datewise/lib/date-range/date-range.ts
+++ b/packages/api/datewise/lib/date-range/date-range.ts
@@ -3,6 +3,7 @@ import { PlainDate, PlainDateInput } from '../plain-date/plain-date.js'
 import { plainDate } from '../plain-date/index.js'
 import { DatePeriod } from '../common/date-period.enum.js'
 import { InvalidDateRangeBounds, NoDateRangeOverlap } from './date-range-errors.js'
+import { Duration } from '@wisemen/quantity'
 
 /**
  * DateRange only works with inclusive ranges internally, except for infinities
@@ -195,17 +196,31 @@ export class DateRange {
     return this.toString()
   }
 
-  setEndDate (endDate: PlainDateInput): DateRange {
+  /** Returns a new date range instance with the new end date */
+  withEndDate (endDate: PlainDateInput): DateRange {
     return new DateRange(this.startDate, endDate)
   }
 
-  setStartDate (startDate: PlainDateInput): DateRange {
+  /** Returns a new date range instance with the new start date */
+  withStartDate (startDate: PlainDateInput): DateRange {
     return new DateRange(startDate, this.endDate)
   }
 
   /** Returns true if this range ends before the other range starts */
   isStrictlyBefore (other: DateRange): boolean {
     return this.endDate.isBefore(other.startDate)
+  }
+
+  /** 
+   * Returns a new date range with both boundaries expanded \
+   *    - start date = this.startDate.subtractDuration(duration)
+   *    - end date = this.endDate.addDuration(duration)
+   */
+  expanded(duration: Duration): DateRange {
+    return new DateRange(
+      this.startDate.subtractDuration(duration),
+      this.endDate.addDuration(duration)
+    )
   }
 
   /** Returns true if this range starts after the other range ends */
@@ -237,9 +252,9 @@ export class DateRange {
 
   merge (withOther: DateRange): DateRange {
     if (this.isPrecededBy(withOther)) {
-      return this.setStartDate(withOther.startDate)
+      return this.withStartDate(withOther.startDate)
     } else if (this.isSucceededBy(withOther)) {
-      return this.setEndDate(withOther.endDate)
+      return this.withEndDate(withOther.endDate)
     } else {
       throw new Error('cannot merge non adjacent date ranges')
     }

--- a/packages/api/datewise/lib/date-range/date-range.ts
+++ b/packages/api/datewise/lib/date-range/date-range.ts
@@ -216,10 +216,17 @@ export class DateRange {
    *    - start date = this.startDate.subtractDuration(duration)
    *    - end date = this.endDate.addDuration(duration)
    */
-  expanded(duration: Duration): DateRange {
+  expand(duration: Duration): DateRange
+  /** 
+   * Returns a new date range with both boundaries expanded \
+   *    - start date = this.startDate.subtractDuration(lower)
+   *    - end date = this.endDate.addDuration(upper)
+   */
+  expand(lower: Duration, upper: Duration): DateRange
+  expand(duration: Duration, upper?: Duration): DateRange {
     return new DateRange(
       this.startDate.subtractDuration(duration),
-      this.endDate.addDuration(duration)
+      this.endDate.addDuration(upper ?? duration)
     )
   }
 

--- a/packages/api/datewise/lib/date-range/tests/date-range.unit.test.ts
+++ b/packages/api/datewise/lib/date-range/tests/date-range.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test'
 import { expect } from 'expect'
+import { Duration, DurationUnit } from '@wisemen/quantity'
 import { InvalidDateRangeBounds } from '../date-range-errors.js'
 import { DateRange } from '../date-range.js'
 import { Inclusivity } from '../../common/inclusivity.js'
@@ -1207,6 +1208,55 @@ describe('DateRange unit tests', () => {
       const result = range1.compare(range2)
 
       expect(result).toBe(0)
+    })
+  })
+
+  describe('expanded', () => {
+    it('expands both boundaries by the given duration', () => {
+      const range = new DateRange(plainDate('2024-01-10'), plainDate('2024-01-20'))
+      const expanded = range.expanded(new Duration(3, DurationUnit.DAYS))
+
+      expect(expanded.startDate.toString()).toBe('2024-01-07')
+      expect(expanded.endDate.toString()).toBe('2024-01-23')
+    })
+
+    it('expanding by zero days returns an equal range', () => {
+      const range = new DateRange(plainDate('2024-01-10'), plainDate('2024-01-20'))
+      const expanded = range.expanded(new Duration(0, DurationUnit.DAYS))
+
+      expect(expanded.isSame(range)).toBe(true)
+    })
+
+    it('expanding by one day moves each boundary by exactly one day', () => {
+      const range = new DateRange(plainDate('2024-06-01'), plainDate('2024-06-30'))
+      const expanded = range.expanded(new Duration(1, DurationUnit.DAYS))
+
+      expect(expanded.startDate.toString()).toBe('2024-05-31')
+      expect(expanded.endDate.toString()).toBe('2024-07-01')
+    })
+
+    it('expanding preserves the original range unchanged', () => {
+      const range = new DateRange(plainDate('2024-01-10'), plainDate('2024-01-20'))
+      range.expanded(new Duration(5, DurationUnit.DAYS))
+
+      expect(range.startDate.toString()).toBe('2024-01-10')
+      expect(range.endDate.toString()).toBe('2024-01-20')
+    })
+
+    it('expanding a range with a past-infinity start keeps start as past-infinity', () => {
+      const range = new DateRange(new PastInfinityDate(), plainDate('2024-01-20'))
+      const expanded = range.expanded(new Duration(5, DurationUnit.DAYS))
+
+      expect(expanded.startDate.isPastInfinity()).toBe(true)
+      expect(expanded.endDate.toString()).toBe('2024-01-25')
+    })
+
+    it('expanding a range with a future-infinity end keeps end as future-infinity', () => {
+      const range = new DateRange(plainDate('2024-01-10'), new FutureInfinityDate())
+      const expanded = range.expanded(new Duration(5, DurationUnit.DAYS))
+
+      expect(expanded.startDate.toString()).toBe('2024-01-05')
+      expect(expanded.endDate.isFutureInfinity()).toBe(true)
     })
   })
 })

--- a/packages/api/datewise/lib/date-range/tests/date-range.unit.test.ts
+++ b/packages/api/datewise/lib/date-range/tests/date-range.unit.test.ts
@@ -1211,10 +1211,10 @@ describe('DateRange unit tests', () => {
     })
   })
 
-  describe('expanded', () => {
-    it('expands both boundaries by the given duration', () => {
+  describe('expand', () => {
+    it('expands both boundaries symmetrically by the given duration', () => {
       const range = new DateRange(plainDate('2024-01-10'), plainDate('2024-01-20'))
-      const expanded = range.expanded(new Duration(3, DurationUnit.DAYS))
+      const expanded = range.expand(new Duration(3, DurationUnit.DAYS))
 
       expect(expanded.startDate.toString()).toBe('2024-01-07')
       expect(expanded.endDate.toString()).toBe('2024-01-23')
@@ -1222,14 +1222,14 @@ describe('DateRange unit tests', () => {
 
     it('expanding by zero days returns an equal range', () => {
       const range = new DateRange(plainDate('2024-01-10'), plainDate('2024-01-20'))
-      const expanded = range.expanded(new Duration(0, DurationUnit.DAYS))
+      const expanded = range.expand(new Duration(0, DurationUnit.DAYS))
 
       expect(expanded.isSame(range)).toBe(true)
     })
 
     it('expanding by one day moves each boundary by exactly one day', () => {
       const range = new DateRange(plainDate('2024-06-01'), plainDate('2024-06-30'))
-      const expanded = range.expanded(new Duration(1, DurationUnit.DAYS))
+      const expanded = range.expand(new Duration(1, DurationUnit.DAYS))
 
       expect(expanded.startDate.toString()).toBe('2024-05-31')
       expect(expanded.endDate.toString()).toBe('2024-07-01')
@@ -1237,7 +1237,7 @@ describe('DateRange unit tests', () => {
 
     it('expanding preserves the original range unchanged', () => {
       const range = new DateRange(plainDate('2024-01-10'), plainDate('2024-01-20'))
-      range.expanded(new Duration(5, DurationUnit.DAYS))
+      range.expand(new Duration(5, DurationUnit.DAYS))
 
       expect(range.startDate.toString()).toBe('2024-01-10')
       expect(range.endDate.toString()).toBe('2024-01-20')
@@ -1245,7 +1245,7 @@ describe('DateRange unit tests', () => {
 
     it('expanding a range with a past-infinity start keeps start as past-infinity', () => {
       const range = new DateRange(new PastInfinityDate(), plainDate('2024-01-20'))
-      const expanded = range.expanded(new Duration(5, DurationUnit.DAYS))
+      const expanded = range.expand(new Duration(5, DurationUnit.DAYS))
 
       expect(expanded.startDate.isPastInfinity()).toBe(true)
       expect(expanded.endDate.toString()).toBe('2024-01-25')
@@ -1253,10 +1253,41 @@ describe('DateRange unit tests', () => {
 
     it('expanding a range with a future-infinity end keeps end as future-infinity', () => {
       const range = new DateRange(plainDate('2024-01-10'), new FutureInfinityDate())
-      const expanded = range.expanded(new Duration(5, DurationUnit.DAYS))
+      const expanded = range.expand(new Duration(5, DurationUnit.DAYS))
 
       expect(expanded.startDate.toString()).toBe('2024-01-05')
       expect(expanded.endDate.isFutureInfinity()).toBe(true)
+    })
+
+    it('expands boundaries asymmetrically when two durations are given', () => {
+      const range = new DateRange(plainDate('2024-01-10'), plainDate('2024-01-20'))
+      const expanded = range.expand(new Duration(2, DurationUnit.DAYS), new Duration(5, DurationUnit.DAYS))
+
+      expect(expanded.startDate.toString()).toBe('2024-01-08')
+      expect(expanded.endDate.toString()).toBe('2024-01-25')
+    })
+
+    it('expanding with two durations of zero returns an equal range', () => {
+      const range = new DateRange(plainDate('2024-01-10'), plainDate('2024-01-20'))
+      const expanded = range.expand(new Duration(0, DurationUnit.DAYS), new Duration(0, DurationUnit.DAYS))
+
+      expect(expanded.isSame(range)).toBe(true)
+    })
+
+    it('can expand only the start by passing zero for the upper duration', () => {
+      const range = new DateRange(plainDate('2024-01-10'), plainDate('2024-01-20'))
+      const expanded = range.expand(new Duration(3, DurationUnit.DAYS), new Duration(0, DurationUnit.DAYS))
+
+      expect(expanded.startDate.toString()).toBe('2024-01-07')
+      expect(expanded.endDate.toString()).toBe('2024-01-20')
+    })
+
+    it('can expand only the end by passing zero for the lower duration', () => {
+      const range = new DateRange(plainDate('2024-01-10'), plainDate('2024-01-20'))
+      const expanded = range.expand(new Duration(0, DurationUnit.DAYS), new Duration(3, DurationUnit.DAYS))
+
+      expect(expanded.startDate.toString()).toBe('2024-01-10')
+      expect(expanded.endDate.toString()).toBe('2024-01-23')
     })
   })
 })

--- a/packages/api/datewise/lib/date-time-range/date-time-range.ts
+++ b/packages/api/datewise/lib/date-time-range/date-time-range.ts
@@ -323,14 +323,21 @@ export class DateTimeRange {
   }
 
   /** 
-   * Returns a new date range with both boundaries expanded \
+   * Returns a new date time range with both boundaries expanded \
    *    - from = this.from.subtractDuration(duration)
    *    - until = this.until.addDuration(duration)
    */
-  expanded(duration: Duration): DateTimeRange {
+  expand(duration: Duration): DateTimeRange
+  /** 
+   * Returns a new date time range with both boundaries expanded \
+   *    - from = this.from.subtractDuration(lower)
+   *    - until = this.until.addDuration(upper)
+   */
+  expand(lower: Duration, upper: Duration): DateTimeRange
+  expand(duration: Duration, upper?: Duration): DateTimeRange {
     return new DateTimeRange(
       this.from.subtractDuration(duration),
-      this.until.addDuration(duration)
+      this.until.addDuration(upper ?? duration)
     )
   }
 

--- a/packages/api/datewise/lib/date-time-range/date-time-range.ts
+++ b/packages/api/datewise/lib/date-time-range/date-time-range.ts
@@ -3,6 +3,7 @@ import { timestamp } from '../timestamp/index.js'
 import { Timestamp, TimestampInput } from '../timestamp/timestamp.js'
 import { MultiDateTimeRange } from '../multi-date-time-range/multi-date-time-range.js'
 import { InvalidDateTimeRangeBounds, NoDateTimeRangeOverlap } from './date-time-range.errors.js'
+import { Duration } from '@wisemen/quantity'
 
 /**
  * DateTimeRange only works with [) ranges internally, except for infinities
@@ -308,17 +309,29 @@ export class DateTimeRange {
   }
 
   /** Returns a new DateTimeRange with updated end boundary. */
-  setUntil (until: TimestampInput): DateTimeRange {
+  withUntil (until: TimestampInput): DateTimeRange {
     until = timestamp(until)
 
     return new DateTimeRange(this.lower, until)
   }
 
   /** Returns a new DateTimeRange with updated start boundary. */
-  setFrom (from: TimestampInput): DateTimeRange {
+  withFrom (from: TimestampInput): DateTimeRange {
     from = timestamp(from)
 
     return new DateTimeRange(from, this.upper)
+  }
+
+  /** 
+   * Returns a new date range with both boundaries expanded \
+   *    - from = this.from.subtractDuration(duration)
+   *    - until = this.until.addDuration(duration)
+   */
+  expanded(duration: Duration): DateTimeRange {
+    return new DateTimeRange(
+      this.from.subtractDuration(duration),
+      this.until.addDuration(duration)
+    )
   }
 
   /** Returns true if this range ends before the other range starts */
@@ -402,9 +415,9 @@ export class DateTimeRange {
   /** Merges two adjacent ranges into one; throws if not adjacent. */
   mergeAdjacent (withOther: DateTimeRange): DateTimeRange {
     if (this.isPrecededBy(withOther)) {
-      return this.setFrom(withOther.lower)
+      return this.withFrom(withOther.lower)
     } else if (this.isSucceededBy(withOther)) {
-      return this.setUntil(withOther.upper)
+      return this.withUntil(withOther.upper)
     } else {
       throw new Error('cannot merge non adjacent date time ranges')
     }

--- a/packages/api/datewise/lib/date-time-range/tests/date-time-range.unit.test.ts
+++ b/packages/api/datewise/lib/date-time-range/tests/date-time-range.unit.test.ts
@@ -1533,11 +1533,11 @@ describe('DateTimeRange unit tests', () => {
     })
   })
 
-  describe('expanded', () => {
-    it('expands both boundaries by the given duration', () => {
+  describe('expand', () => {
+    it('expands both boundaries symmetrically by the given duration', () => {
       const now = timestamp('2024-01-10T12:00:00.000Z')
       const range = new DateTimeRange(now, now.add(1, 'hour'))
-      const expanded = range.expanded(new Duration(30, DurationUnit.MINUTES))
+      const expanded = range.expand(new Duration(30, DurationUnit.MINUTES))
 
       expect(expanded.from.isSame(now.subtract(30, 'minute'))).toBe(true)
       expect(expanded.until.isSame(now.add(90, 'minute'))).toBe(true)
@@ -1546,7 +1546,7 @@ describe('DateTimeRange unit tests', () => {
     it('expanding by zero duration returns an equal range', () => {
       const now = timestamp('2024-01-10T12:00:00.000Z')
       const range = new DateTimeRange(now, now.add(1, 'hour'))
-      const expanded = range.expanded(new Duration(0, DurationUnit.MILLISECONDS))
+      const expanded = range.expand(new Duration(0, DurationUnit.MILLISECONDS))
 
       expect(expanded.isSame(range)).toBe(true)
     })
@@ -1554,7 +1554,7 @@ describe('DateTimeRange unit tests', () => {
     it('expanding by one hour moves each boundary by exactly one hour', () => {
       const now = timestamp('2024-06-01T10:00:00.000Z')
       const range = new DateTimeRange(now, now.add(2, 'hours'))
-      const expanded = range.expanded(new Duration(1, DurationUnit.HOURS))
+      const expanded = range.expand(new Duration(1, DurationUnit.HOURS))
 
       expect(expanded.from.isSame(now.subtract(1, 'hour'))).toBe(true)
       expect(expanded.until.isSame(now.add(3, 'hours'))).toBe(true)
@@ -1563,7 +1563,7 @@ describe('DateTimeRange unit tests', () => {
     it('expanding by milliseconds works at fine-grained precision', () => {
       const now = timestamp('2024-01-01T00:00:00.000Z')
       const range = new DateTimeRange(now, now.add(1, 'second'))
-      const expanded = range.expanded(new Duration(500, DurationUnit.MILLISECONDS))
+      const expanded = range.expand(new Duration(500, DurationUnit.MILLISECONDS))
 
       expect(expanded.from.isSame(now.subtract(500, 'ms'))).toBe(true)
       expect(expanded.until.isSame(now.add(1500, 'ms'))).toBe(true)
@@ -1572,7 +1572,7 @@ describe('DateTimeRange unit tests', () => {
     it('preserves the original range unchanged', () => {
       const now = timestamp('2024-01-10T12:00:00.000Z')
       const range = new DateTimeRange(now, now.add(1, 'hour'))
-      range.expanded(new Duration(30, DurationUnit.MINUTES))
+      range.expand(new Duration(30, DurationUnit.MINUTES))
 
       expect(range.from.isSame(now)).toBe(true)
       expect(range.until.isSame(now.add(1, 'hour'))).toBe(true)
@@ -1581,7 +1581,7 @@ describe('DateTimeRange unit tests', () => {
     it('expanding a range with a past-infinity lower bound keeps lower bound as past-infinity', () => {
       const now = timestamp('2024-01-10T12:00:00.000Z')
       const range = new DateTimeRange(new PastInfinity(), now)
-      const expanded = range.expanded(new Duration(1, DurationUnit.HOURS))
+      const expanded = range.expand(new Duration(1, DurationUnit.HOURS))
 
       expect(expanded.from.isPastInfinity()).toBe(true)
       expect(expanded.until.isSame(now.add(1, 'hour'))).toBe(true)
@@ -1590,10 +1590,45 @@ describe('DateTimeRange unit tests', () => {
     it('expanding a range with a future-infinity upper bound keeps upper bound as future-infinity', () => {
       const now = timestamp('2024-01-10T12:00:00.000Z')
       const range = new DateTimeRange(now, new FutureInfinity())
-      const expanded = range.expanded(new Duration(1, DurationUnit.HOURS))
+      const expanded = range.expand(new Duration(1, DurationUnit.HOURS))
 
       expect(expanded.from.isSame(now.subtract(1, 'hour'))).toBe(true)
       expect(expanded.until.isFutureInfinity()).toBe(true)
+    })
+
+    it('expands boundaries asymmetrically when two durations are given', () => {
+      const now = timestamp('2024-01-10T12:00:00.000Z')
+      const range = new DateTimeRange(now, now.add(2, 'hours'))
+      const expanded = range.expand(new Duration(30, DurationUnit.MINUTES), new Duration(1, DurationUnit.HOURS))
+
+      expect(expanded.from.isSame(now.subtract(30, 'minute'))).toBe(true)
+      expect(expanded.until.isSame(now.add(3, 'hours'))).toBe(true)
+    })
+
+    it('expanding with two durations of zero returns an equal range', () => {
+      const now = timestamp('2024-01-10T12:00:00.000Z')
+      const range = new DateTimeRange(now, now.add(1, 'hour'))
+      const expanded = range.expand(new Duration(0, DurationUnit.MILLISECONDS), new Duration(0, DurationUnit.MILLISECONDS))
+
+      expect(expanded.isSame(range)).toBe(true)
+    })
+
+    it('can expand only the start by passing zero for the upper duration', () => {
+      const now = timestamp('2024-01-10T12:00:00.000Z')
+      const range = new DateTimeRange(now, now.add(1, 'hour'))
+      const expanded = range.expand(new Duration(30, DurationUnit.MINUTES), new Duration(0, DurationUnit.MILLISECONDS))
+
+      expect(expanded.from.isSame(now.subtract(30, 'minute'))).toBe(true)
+      expect(expanded.until.isSame(now.add(1, 'hour'))).toBe(true)
+    })
+
+    it('can expand only the end by passing zero for the lower duration', () => {
+      const now = timestamp('2024-01-10T12:00:00.000Z')
+      const range = new DateTimeRange(now, now.add(1, 'hour'))
+      const expanded = range.expand(new Duration(0, DurationUnit.MILLISECONDS), new Duration(30, DurationUnit.MINUTES))
+
+      expect(expanded.from.isSame(now)).toBe(true)
+      expect(expanded.until.isSame(now.add(90, 'minute'))).toBe(true)
     })
   })
 })

--- a/packages/api/datewise/lib/date-time-range/tests/date-time-range.unit.test.ts
+++ b/packages/api/datewise/lib/date-time-range/tests/date-time-range.unit.test.ts
@@ -1,5 +1,6 @@
 import { before, describe, it } from 'node:test'
 import { expect } from 'expect'
+import { Duration, DurationUnit } from '@wisemen/quantity'
 import { DateTimeRange } from '../date-time-range.js'
 import { InvalidDateTimeRangeBounds } from '../date-time-range.errors.js'
 import { initDayjs } from '../../common/init-dayjs.js'
@@ -1028,7 +1029,7 @@ describe('DateTimeRange unit tests', () => {
       const range = new DateTimeRange(now, later)
       const newUntil = now.add(2, 'minute')
 
-      const newRange = range.setUntil(newUntil)
+      const newRange = range.withUntil(newUntil)
 
       expect(newRange.inclLower.isSame(range.inclLower)).toBe(true)
       expect(newRange.exclUpper.isSame(newUntil)).toBe(true)
@@ -1040,7 +1041,7 @@ describe('DateTimeRange unit tests', () => {
       const range = new DateTimeRange(now, later)
       const newUntil = now.add(2, 'minute').toDate()
 
-      const newRange = range.setUntil(newUntil)
+      const newRange = range.withUntil(newUntil)
 
       expect(newRange.exclUpper.isSame(timestamp(newUntil))).toBe(true)
     })
@@ -1053,7 +1054,7 @@ describe('DateTimeRange unit tests', () => {
       const range = new DateTimeRange(now, later)
       const newFrom = now.subtract(1, 'minute')
 
-      const newRange = range.setFrom(newFrom)
+      const newRange = range.withFrom(newFrom)
 
       expect(newRange.inclLower.isSame(newFrom)).toBe(true)
       expect(newRange.exclUpper.isSame(range.exclUpper)).toBe(true)
@@ -1065,7 +1066,7 @@ describe('DateTimeRange unit tests', () => {
       const range = new DateTimeRange(now, later)
       const newFrom = now.subtract(1, 'minute').toDate()
 
-      const newRange = range.setFrom(newFrom)
+      const newRange = range.withFrom(newFrom)
 
       expect(newRange.inclLower.isSame(timestamp(newFrom))).toBe(true)
     })
@@ -1529,6 +1530,70 @@ describe('DateTimeRange unit tests', () => {
       expect(sorted[0]).toBe(range3) // Ends at 30 minutes
       expect(sorted[1]).toBe(range1) // Ends at 1 hour
       expect(sorted[2]).toBe(range2) // Ends at 2 hours
+    })
+  })
+
+  describe('expanded', () => {
+    it('expands both boundaries by the given duration', () => {
+      const now = timestamp('2024-01-10T12:00:00.000Z')
+      const range = new DateTimeRange(now, now.add(1, 'hour'))
+      const expanded = range.expanded(new Duration(30, DurationUnit.MINUTES))
+
+      expect(expanded.from.isSame(now.subtract(30, 'minute'))).toBe(true)
+      expect(expanded.until.isSame(now.add(90, 'minute'))).toBe(true)
+    })
+
+    it('expanding by zero duration returns an equal range', () => {
+      const now = timestamp('2024-01-10T12:00:00.000Z')
+      const range = new DateTimeRange(now, now.add(1, 'hour'))
+      const expanded = range.expanded(new Duration(0, DurationUnit.MILLISECONDS))
+
+      expect(expanded.isSame(range)).toBe(true)
+    })
+
+    it('expanding by one hour moves each boundary by exactly one hour', () => {
+      const now = timestamp('2024-06-01T10:00:00.000Z')
+      const range = new DateTimeRange(now, now.add(2, 'hours'))
+      const expanded = range.expanded(new Duration(1, DurationUnit.HOURS))
+
+      expect(expanded.from.isSame(now.subtract(1, 'hour'))).toBe(true)
+      expect(expanded.until.isSame(now.add(3, 'hours'))).toBe(true)
+    })
+
+    it('expanding by milliseconds works at fine-grained precision', () => {
+      const now = timestamp('2024-01-01T00:00:00.000Z')
+      const range = new DateTimeRange(now, now.add(1, 'second'))
+      const expanded = range.expanded(new Duration(500, DurationUnit.MILLISECONDS))
+
+      expect(expanded.from.isSame(now.subtract(500, 'ms'))).toBe(true)
+      expect(expanded.until.isSame(now.add(1500, 'ms'))).toBe(true)
+    })
+
+    it('preserves the original range unchanged', () => {
+      const now = timestamp('2024-01-10T12:00:00.000Z')
+      const range = new DateTimeRange(now, now.add(1, 'hour'))
+      range.expanded(new Duration(30, DurationUnit.MINUTES))
+
+      expect(range.from.isSame(now)).toBe(true)
+      expect(range.until.isSame(now.add(1, 'hour'))).toBe(true)
+    })
+
+    it('expanding a range with a past-infinity lower bound keeps lower bound as past-infinity', () => {
+      const now = timestamp('2024-01-10T12:00:00.000Z')
+      const range = new DateTimeRange(new PastInfinity(), now)
+      const expanded = range.expanded(new Duration(1, DurationUnit.HOURS))
+
+      expect(expanded.from.isPastInfinity()).toBe(true)
+      expect(expanded.until.isSame(now.add(1, 'hour'))).toBe(true)
+    })
+
+    it('expanding a range with a future-infinity upper bound keeps upper bound as future-infinity', () => {
+      const now = timestamp('2024-01-10T12:00:00.000Z')
+      const range = new DateTimeRange(now, new FutureInfinity())
+      const expanded = range.expanded(new Duration(1, DurationUnit.HOURS))
+
+      expect(expanded.from.isSame(now.subtract(1, 'hour'))).toBe(true)
+      expect(expanded.until.isFutureInfinity()).toBe(true)
     })
   })
 })

--- a/packages/api/datewise/lib/plain-date/dayjs-plain-date.ts
+++ b/packages/api/datewise/lib/plain-date/dayjs-plain-date.ts
@@ -149,7 +149,7 @@ export class DayjsPlainDate implements PlainDate {
    * Similarly a duration of 1.4 days is applied as 1 day.
    */
   addDuration (duration: Duration): PlainDate {
-    return new DayjsPlainDate(this.date.add(Math.floor(duration.days), 'days'))
+    return new DayjsPlainDate(this.date.add(Math.trunc(duration.days), 'days'))
   }
 
   subtract (amount: number, unit: PlainDateUnit): DayjsPlainDate {
@@ -162,7 +162,7 @@ export class DayjsPlainDate implements PlainDate {
    * Similarly a duration of 1.4 days is applied as 1 day.
    */
   subtractDuration (duration: Duration): PlainDate {
-    return new DayjsPlainDate(this.date.subtract(Math.floor(duration.days), 'days')) 
+    return new DayjsPlainDate(this.date.subtract(Math.trunc(duration.days), 'days')) 
   }
 
   until (otherDate: PlainDateInput): Duration {

--- a/packages/api/datewise/lib/plain-date/dayjs-plain-date.ts
+++ b/packages/api/datewise/lib/plain-date/dayjs-plain-date.ts
@@ -143,8 +143,26 @@ export class DayjsPlainDate implements PlainDate {
     return new DayjsPlainDate(this.date.add(amount, unit))
   }
 
+  /**
+   * Returns a new `PlainDate` instance with the duration added. \
+   * Any duration less than a full day does not change the date, but still returns a new instance. \
+   * Similarly a duration of 1.4 days is applied as 1 day.
+   */
+  addDuration (duration: Duration): PlainDate {
+    return new DayjsPlainDate(this.date.add(Math.floor(duration.days), 'days'))
+  }
+
   subtract (amount: number, unit: PlainDateUnit): DayjsPlainDate {
     return new DayjsPlainDate(this.date.subtract(amount, unit))
+  }
+
+  /**
+   * Returns a new `PlainDate` instance with the duration subtracted. \
+   * Any duration less than a full day does not change the date, but still returns a new instance. \
+   * Similarly a duration of 1.4 days is applied as 1 day.
+   */
+  subtractDuration (duration: Duration): PlainDate {
+    return new DayjsPlainDate(this.date.subtract(Math.floor(duration.days), 'days')) 
   }
 
   until (otherDate: PlainDateInput): Duration {

--- a/packages/api/datewise/lib/plain-date/future-infinity-date.ts
+++ b/packages/api/datewise/lib/plain-date/future-infinity-date.ts
@@ -74,7 +74,15 @@ export class FutureInfinityDate implements PlainDate {
     return this
   }
 
+  addDuration (_duration: Duration): FutureInfinityDate {
+    return this 
+  }
+
   subtract (_amount: number, _unit: PlainDateUnit): FutureInfinityDate {
+    return this
+  }
+
+  subtractDuration (_duration: Duration): FutureInfinityDate {
     return this
   }
 

--- a/packages/api/datewise/lib/plain-date/past-infinity-date.ts
+++ b/packages/api/datewise/lib/plain-date/past-infinity-date.ts
@@ -75,7 +75,15 @@ export class PastInfinityDate implements PlainDate {
     return this
   }
 
+  addDuration (_duration: Duration): PastInfinityDate {
+    return this
+  }
+
   subtract (_amount: number, _unit: PlainDateUnit): PastInfinityDate {
+    return this
+  }
+
+  subtractDuration (_duration: Duration): PastInfinityDate {
     return this
   }
 

--- a/packages/api/datewise/lib/plain-date/plain-date.ts
+++ b/packages/api/datewise/lib/plain-date/plain-date.ts
@@ -35,7 +35,22 @@ export interface PlainDate {
   isTomorrow(): boolean
   isYesterday(): boolean
   add(amount: number, unit: PlainDateUnit): PlainDate
+
+  /**
+   * Returns a new `PlainDate` instance with the duration added. \
+   * Any duration less than a full day does not change the date, but still returns a new instance. \
+   * Similarly a duration of 1.4 days is applied as 1 day.
+   */
+  addDuration(duration: Duration): PlainDate
+
   subtract(amount: number, unit: PlainDateUnit): PlainDate
+
+  /**
+   * Returns a new `PlainDate` instance with the duration subtracted. \
+   * Any duration less than a full day does not change the date, but still returns a new instance. \
+   * Similarly a duration of 1.4 days is applied as 1 day.
+   */
+  subtractDuration(duration: Duration): PlainDate
 
   /**
    * Returns the duration until the given date.
@@ -50,7 +65,9 @@ export interface PlainDate {
    * If the date lies after this date, the duration is negative.
    */
   since(otherDate: PlainDateInput): Duration
+
   diff(withOther: PlainDateInput, unit: DiffPlainDateUnit): number
+
   /** 
    * Compares the order of the given date with this date. \
    * returns < 0 if this date is before the given date \

--- a/packages/api/datewise/lib/plain-date/plain-date.ts
+++ b/packages/api/datewise/lib/plain-date/plain-date.ts
@@ -38,7 +38,8 @@ export interface PlainDate {
 
   /**
    * Returns a new `PlainDate` instance with the duration added. \
-   * Any duration less than a full day does not change the date, but still returns a new instance. \
+   * Any duration less than a full day does not change the date, but still returns a 
+   * new instance (except for infinities which are singletons). \
    * Similarly a duration of 1.4 days is applied as 1 day.
    */
   addDuration(duration: Duration): PlainDate
@@ -47,7 +48,8 @@ export interface PlainDate {
 
   /**
    * Returns a new `PlainDate` instance with the duration subtracted. \
-   * Any duration less than a full day does not change the date, but still returns a new instance. \
+   * Any duration less than a full day does not change the date, but still returns a new instance
+   * (except for infinities which are singletons). \
    * Similarly a duration of 1.4 days is applied as 1 day.
    */
   subtractDuration(duration: Duration): PlainDate

--- a/packages/api/datewise/lib/plain-date/tests/plain-date.future-infinity.unit.test.ts
+++ b/packages/api/datewise/lib/plain-date/tests/plain-date.future-infinity.unit.test.ts
@@ -1,5 +1,6 @@
 import { before, describe, it } from 'node:test'
 import { expect } from 'expect'
+import { Duration, DurationUnit } from '@wisemen/quantity'
 import { FutureInfinityDate } from '../future-infinity-date.js'
 import { DayjsPlainDate } from '../dayjs-plain-date.js'
 import { PastInfinityDate } from '../past-infinity-date.js'
@@ -102,6 +103,28 @@ describe('FutureInfinityDate', () => {
       const duration = futureInfinity.since(pastDate)
 
       expect(duration.days).toBe(Infinity)
+    })
+  })
+
+  describe('addDuration', () => {
+    it('remains FutureInfinityDate when adding a duration', () => {
+      const date = new FutureInfinityDate()
+      const resultSmall = date.addDuration(new Duration(1, DurationUnit.DAYS))
+      const resultLarge = date.addDuration(new Duration(365, DurationUnit.DAYS))
+
+      expect(resultSmall.isFutureInfinity()).toBe(true)
+      expect(resultLarge.isFutureInfinity()).toBe(true)
+    })
+  })
+
+  describe('subtractDuration', () => {
+    it('remains FutureInfinityDate when subtracting a duration', () => {
+      const date = new FutureInfinityDate()
+      const resultSmall = date.subtractDuration(new Duration(1, DurationUnit.DAYS))
+      const resultLarge = date.subtractDuration(new Duration(365, DurationUnit.DAYS))
+
+      expect(resultSmall.isFutureInfinity()).toBe(true)
+      expect(resultLarge.isFutureInfinity()).toBe(true)
     })
   })
 })

--- a/packages/api/datewise/lib/plain-date/tests/plain-date.manipulation.unit.test.ts
+++ b/packages/api/datewise/lib/plain-date/tests/plain-date.manipulation.unit.test.ts
@@ -1,6 +1,7 @@
 import { before, describe, it } from 'node:test'
 import { expect } from 'expect'
 import dayjs from 'dayjs'
+import { Duration, DurationUnit } from '@wisemen/quantity'
 import { Month } from '../../common/month.js'
 import { FutureInfinityDate } from '../future-infinity-date.js'
 import { PastInfinityDate } from '../past-infinity-date.js'
@@ -25,6 +26,20 @@ describe('PlainDate manipulation', () => {
       expect(new FutureInfinityDate().subtract(1, 'year').isSame(new FutureInfinityDate())).toBe(true)
       expect(new FutureInfinityDate().subtract(1, 'month').isSame(new FutureInfinityDate())).toBe(true)
     })
+
+    it('Future infinity remains infinity when adding a duration', () => {
+      const date = new FutureInfinityDate()
+
+      expect(date.addDuration(new Duration(1, DurationUnit.DAYS)).isSame(date)).toBe(true)
+      expect(date.addDuration(new Duration(7, DurationUnit.DAYS)).isSame(date)).toBe(true)
+    })
+
+    it('Future infinity remains infinity when subtracting a duration', () => {
+      const date = new FutureInfinityDate()
+
+      expect(date.subtractDuration(new Duration(1, DurationUnit.DAYS)).isSame(date)).toBe(true)
+      expect(date.subtractDuration(new Duration(7, DurationUnit.DAYS)).isSame(date)).toBe(true)
+    })
   })
 
   describe('Past infinity', () => {
@@ -40,6 +55,20 @@ describe('PlainDate manipulation', () => {
       expect(new PastInfinityDate().subtract(1, 'week').isSame(new PastInfinityDate())).toBe(true)
       expect(new PastInfinityDate().subtract(1, 'year').isSame(new PastInfinityDate())).toBe(true)
       expect(new PastInfinityDate().subtract(1, 'month').isSame(new PastInfinityDate())).toBe(true)
+    })
+
+    it('Past infinity remains infinity when adding a duration', () => {
+      const date = new PastInfinityDate()
+
+      expect(date.addDuration(new Duration(1, DurationUnit.DAYS)).isSame(date)).toBe(true)
+      expect(date.addDuration(new Duration(7, DurationUnit.DAYS)).isSame(date)).toBe(true)
+    })
+
+    it('Past infinity remains infinity when subtracting a duration', () => {
+      const date = new PastInfinityDate()
+
+      expect(date.subtractDuration(new Duration(1, DurationUnit.DAYS)).isSame(date)).toBe(true)
+      expect(date.subtractDuration(new Duration(7, DurationUnit.DAYS)).isSame(date)).toBe(true)
     })
   })
 
@@ -106,6 +135,50 @@ describe('PlainDate manipulation', () => {
       expect(new DayjsPlainDate().add(1, 'year').isSame(new DayjsPlainDate(dayjs().add(1, 'year')))).toBe(true)
       expect(new DayjsPlainDate().add(1, 'year').year()).not.toBe(new DayjsPlainDate().year())
       expect(new DayjsPlainDate('2024-01-01').add(1, 'year').isSame(new DayjsPlainDate('2025-01-01'))).toBe(true)
+    })
+
+    it('addDuration adds whole days only', () => {
+      const oneDayLater = new DayjsPlainDate('2024-01-01').addDuration(new Duration(1, DurationUnit.DAYS))
+      const sevenDaysLater = new DayjsPlainDate('2024-01-01').addDuration(new Duration(7, DurationUnit.DAYS))
+      const overMonth = new DayjsPlainDate('2024-01-31').addDuration(new Duration(1, DurationUnit.DAYS))
+
+      expect(oneDayLater.isSame(new DayjsPlainDate('2024-01-02'))).toBe(true)
+      expect(sevenDaysLater.isSame(new DayjsPlainDate('2024-01-08'))).toBe(true)
+      expect(overMonth.isSame(new DayjsPlainDate('2024-02-01'))).toBe(true)
+    })
+
+    it('addDuration with sub-day duration does not change the date', () => {
+      const result = new DayjsPlainDate('2024-01-01').addDuration(new Duration(0.5, DurationUnit.DAYS))
+
+      expect(result.isSame(new DayjsPlainDate('2024-01-01'))).toBe(true)
+    })
+
+    it('addDuration with fractional days truncates to whole days', () => {
+      const result = new DayjsPlainDate('2024-01-01').addDuration(new Duration(1.4, DurationUnit.DAYS))
+
+      expect(result.isSame(new DayjsPlainDate('2024-01-02'))).toBe(true)
+    })
+
+    it('subtractDuration subtracts whole days only', () => {
+      const oneDayBefore = new DayjsPlainDate('2024-01-08').subtractDuration(new Duration(1, DurationUnit.DAYS))
+      const sevenDaysBefore = new DayjsPlainDate('2024-01-08').subtractDuration(new Duration(7, DurationUnit.DAYS))
+      const overMonth = new DayjsPlainDate('2024-02-01').subtractDuration(new Duration(1, DurationUnit.DAYS))
+
+      expect(oneDayBefore.isSame(new DayjsPlainDate('2024-01-07'))).toBe(true)
+      expect(sevenDaysBefore.isSame(new DayjsPlainDate('2024-01-01'))).toBe(true)
+      expect(overMonth.isSame(new DayjsPlainDate('2024-01-31'))).toBe(true)
+    })
+
+    it('subtractDuration with sub-day duration does not change the date', () => {
+      const result = new DayjsPlainDate('2024-01-01').subtractDuration(new Duration(0.5, DurationUnit.DAYS))
+
+      expect(result.isSame(new DayjsPlainDate('2024-01-01'))).toBe(true)
+    })
+
+    it('subtractDuration with fractional days truncates to whole days', () => {
+      const result = new DayjsPlainDate('2024-01-08').subtractDuration(new Duration(1.4, DurationUnit.DAYS))
+
+      expect(result.isSame(new DayjsPlainDate('2024-01-07'))).toBe(true)
     })
   })
 })

--- a/packages/api/datewise/lib/plain-date/tests/plain-date.past-infinity.unit.test.ts
+++ b/packages/api/datewise/lib/plain-date/tests/plain-date.past-infinity.unit.test.ts
@@ -1,5 +1,6 @@
 import { before, describe, it } from 'node:test'
 import { expect } from 'expect'
+import { Duration, DurationUnit } from '@wisemen/quantity'
 import { PastInfinityDate } from '../past-infinity-date.js'
 import { DayjsPlainDate } from '../dayjs-plain-date.js'
 import { FutureInfinityDate } from '../future-infinity-date.js'
@@ -102,6 +103,28 @@ describe('PastInfinityDate', () => {
       const duration = pastInfinity.since(futureDate)
 
       expect(duration.days).toBe(-Infinity)
+    })
+  })
+
+  describe('addDuration', () => {
+    it('remains PastInfinityDate when adding a duration', () => {
+      const date = new PastInfinityDate()
+      const resultSmall = date.addDuration(new Duration(1, DurationUnit.DAYS))
+      const resultLarge = date.addDuration(new Duration(365, DurationUnit.DAYS))
+
+      expect(resultSmall.isPastInfinity()).toBe(true)
+      expect(resultLarge.isPastInfinity()).toBe(true)
+    })
+  })
+
+  describe('subtractDuration', () => {
+    it('remains PastInfinityDate when subtracting a duration', () => {
+      const date = new PastInfinityDate()
+      const resultSmall = date.subtractDuration(new Duration(1, DurationUnit.DAYS))
+      const resultLarge = date.subtractDuration(new Duration(365, DurationUnit.DAYS))
+
+      expect(resultSmall.isPastInfinity()).toBe(true)
+      expect(resultLarge.isPastInfinity()).toBe(true)
     })
   })
 })

--- a/packages/api/datewise/lib/timestamp/dayjs-timestamp.ts
+++ b/packages/api/datewise/lib/timestamp/dayjs-timestamp.ts
@@ -150,7 +150,7 @@ export class DayjsTimestamp implements Timestamp {
   }
 
   addDuration (duration: Duration): Timestamp {
-    return new DayjsTimestamp(this.value.add(duration.milliseconds, 'ms'))
+    return new DayjsTimestamp(this.value.add(Math.floor(duration.milliseconds), 'ms'))
   }
 
   subtract (value: number, unit?: ManipulateType): DayjsTimestamp {
@@ -158,7 +158,7 @@ export class DayjsTimestamp implements Timestamp {
   }
 
   subtractDuration (duration: Duration): Timestamp {
-    return new DayjsTimestamp(this.value.subtract(duration.milliseconds, 'ms'))
+    return new DayjsTimestamp(this.value.subtract(Math.floor(duration.milliseconds), 'ms'))
   }
 
   startOf (unit: OpUnitType): DayjsTimestamp {

--- a/packages/api/datewise/lib/timestamp/dayjs-timestamp.ts
+++ b/packages/api/datewise/lib/timestamp/dayjs-timestamp.ts
@@ -150,7 +150,7 @@ export class DayjsTimestamp implements Timestamp {
   }
 
   addDuration (duration: Duration): Timestamp {
-    return new DayjsTimestamp(this.value.add(Math.floor(duration.milliseconds), 'ms'))
+    return new DayjsTimestamp(this.value.add(Math.trunc(duration.milliseconds), 'ms'))
   }
 
   subtract (value: number, unit?: ManipulateType): DayjsTimestamp {
@@ -158,7 +158,7 @@ export class DayjsTimestamp implements Timestamp {
   }
 
   subtractDuration (duration: Duration): Timestamp {
-    return new DayjsTimestamp(this.value.subtract(Math.floor(duration.milliseconds), 'ms'))
+    return new DayjsTimestamp(this.value.subtract(Math.trunc(duration.milliseconds), 'ms'))
   }
 
   startOf (unit: OpUnitType): DayjsTimestamp {


### PR DESCRIPTION

- feat: add `expand` on `DateRange` and `DateTimeRange` to symmetrically move both boundaries outwards by a specified duration
- feat: add `addDuration` and `subtractDuration` on `PlainDate`
- rework: rename `setFrom` and similar methods to `withFrom` to better indicate the immutability of the instances