### PR TITLE
feat: rework StartsAfter and EndsBefore

### DIFF
--- a/.changeset/blue-months-prove.md
+++ b/.changeset/blue-months-prove.md
@@ -1,0 +1,6 @@
+---
+"@wisemen/datewise": major
+"@wisemen/date-time-range": patch
+---
+
+rework: `StartsAfter` and `EndsBefore` typeorm operators to work on timestamps / plaindates instead of ranges'

--- a/.changeset/blue-months-prove.md
+++ b/.changeset/blue-months-prove.md
@@ -3,4 +3,4 @@
 "@wisemen/date-time-range": patch
 ---
 
-rework: `StartsAfter` and `EndsBefore` typeorm operators to work on timestamps / plaindates instead of ranges'
+rework: `StartsAfter` and `EndsBefore` typeorm operators to work on timestamps / plaindates instead of ranges

--- a/packages/api/date-time-range/lib/date-time-range.ts
+++ b/packages/api/date-time-range/lib/date-time-range.ts
@@ -36,7 +36,7 @@ export class DateTimeRange {
   constructor (
     from: TimestampInput,
     until: TimestampInput,
-    inclusivitiy: InclusivityString
+    inclusivity: InclusivityString
   )
   constructor (
     from: TimestampInput,

--- a/packages/api/datewise/lib/common/typeorm/ends-before.ts
+++ b/packages/api/datewise/lib/common/typeorm/ends-before.ts
@@ -2,19 +2,39 @@ import { randomUUID } from 'crypto'
 import { FindOperator, Raw } from 'typeorm'
 import { DateTimeRange } from '../../date-time-range/date-time-range.js'
 import { DateRange } from '../../date-range/date-range.js'
+import { PlainDate } from '#src/plain-date/index.js'
+import { isPlainDate } from '#src/plain-date/is-plain-date.js'
+import { isTimestamp } from '#src/timestamp/is-timestamp.js'
+import { Timestamp } from '#src/timestamp/timestamp.js'
 
 /** 
  * Checks if a range ends before the given range with the `<<` operator. 
  */
-export function EndsBefore (range: DateRange): FindOperator<DateRange>
-export function EndsBefore (range: DateTimeRange): FindOperator<DateTimeRange>
+export function EndsBefore (date: PlainDate): FindOperator<DateRange>
+export function EndsBefore (ts: Timestamp | Date): FindOperator<DateTimeRange>
 export function EndsBefore (
-  range: DateRange | DateTimeRange
+  timestamp: PlainDate | Timestamp | Date
 ): FindOperator<DateRange> | FindOperator<DateTimeRange> {
+  let range: DateTimeRange | DateRange
+  if (isPlainDate(timestamp)) {
+    range = new DateRange(timestamp, timestamp)
+  } else if (isTimestamp(timestamp) || timestamp instanceof Date) {
+    range = new DateTimeRange(timestamp, timestamp, '[]')
+  } else {
+    throw new Error('invalid argument, expected plain date, timestamp or date')
+  }
+
   const paramName = randomUUID().replaceAll('-', '')
 
+  let cast: string
+  if (range instanceof DateRange) {
+    cast = 'daterange'
+  } else {
+    cast = 'tstzrange3'
+  }
+
   return Raw(
-    (alias: string) => `${alias} << :${paramName}::tstzrange3`,
+    (alias: string) => `${alias} << :${paramName}::${cast}`,
     { [paramName]: range.toString() }
   ) as FindOperator<DateRange> | FindOperator<DateTimeRange>
 }

--- a/packages/api/datewise/lib/common/typeorm/starts-after.ts
+++ b/packages/api/datewise/lib/common/typeorm/starts-after.ts
@@ -13,20 +13,20 @@ import { Timestamp } from '#src/timestamp/timestamp.js'
 export function StartsAfter (date: PlainDate): FindOperator<DateRange>
 export function StartsAfter (ts: Timestamp | Date): FindOperator<DateTimeRange>
 export function StartsAfter (
-  timestamp: PlainDate | Timestamp | Date
+  value: PlainDate | Timestamp | Date
 ): FindOperator<DateRange> | FindOperator<DateTimeRange> {
   let range: DateTimeRange | DateRange
-  if(isPlainDate(timestamp)) {
-    range = new DateRange(timestamp, timestamp)
-  } else if (isTimestamp(timestamp) || timestamp instanceof Date) {
-    range = new DateTimeRange(timestamp, timestamp, '[]')
+  if(isPlainDate(value)) {
+    range = new DateRange(value, value)
+  } else if (isTimestamp(value) || value instanceof Date) {
+    range = new DateTimeRange(value, value, '[]')
   } else {
     throw new Error('invalid argument, expected plain date, timestamp or date')
   }
 
 
   const paramName = randomUUID().replaceAll('-', '')
-  
+
   let cast: string 
   if(range instanceof DateRange) {
     cast = 'daterange'

--- a/packages/api/datewise/lib/common/typeorm/starts-after.ts
+++ b/packages/api/datewise/lib/common/typeorm/starts-after.ts
@@ -2,19 +2,40 @@ import { randomUUID } from 'crypto'
 import { FindOperator, Raw } from 'typeorm'
 import { DateTimeRange } from '../../date-time-range/date-time-range.js'
 import { DateRange } from '../../date-range/date-range.js'
+import { PlainDate } from '#src/plain-date/index.js'
+import { isPlainDate } from '#src/plain-date/is-plain-date.js'
+import { isTimestamp } from '#src/timestamp/is-timestamp.js'
+import { Timestamp } from '#src/timestamp/timestamp.js'
 
 /** 
  * Checks if a range starts after the given range with the `>>` operator. 
  */
-export function StartsAfter (range: DateRange): FindOperator<DateRange>
-export function StartsAfter (range: DateTimeRange): FindOperator<DateTimeRange>
+export function StartsAfter (date: PlainDate): FindOperator<DateRange>
+export function StartsAfter (ts: Timestamp | Date): FindOperator<DateTimeRange>
 export function StartsAfter (
-  range: DateRange | DateTimeRange
+  timestamp: PlainDate | Timestamp | Date
 ): FindOperator<DateRange> | FindOperator<DateTimeRange> {
+  let range: DateTimeRange | DateRange
+  if(isPlainDate(timestamp)) {
+    range = new DateRange(timestamp, timestamp)
+  } else if (isTimestamp(timestamp) || timestamp instanceof Date) {
+    range = new DateTimeRange(timestamp, timestamp, '[]')
+  } else {
+    throw new Error('invalid argument, expected plain date, timestamp or date')
+  }
+
+
   const paramName = randomUUID().replaceAll('-', '')
+  
+  let cast: string 
+  if(range instanceof DateRange) {
+    cast = 'daterange'
+  } else {
+    cast = 'tstzrange3'
+  }
 
   return Raw(
-    (alias: string) => `${alias} >> :${paramName}::tstzrange3`,
+    (alias: string) => `${alias} >> :${paramName}::${cast}`,
     { [paramName]: range.toString() }
   ) as FindOperator<DateRange> | FindOperator<DateTimeRange>
 }

--- a/packages/api/datewise/lib/date-range/tests/ends-before-plain-date.integration.test.ts
+++ b/packages/api/datewise/lib/date-range/tests/ends-before-plain-date.integration.test.ts
@@ -1,0 +1,63 @@
+import { after, before, describe, it } from 'node:test'
+import { expect } from 'expect'
+import { DataSource, In } from 'typeorm'
+import { DateRange } from '#src/date-range/date-range.js'
+import { plainDate } from '#src/plain-date/plain-date.fn.js'
+import { dataSource } from '#src/date-range/tests/sql/datasource.js'
+import { FiniteDateRangeTest } from '#src/date-range/tests/sql/finite-date-range-test.entity.js'
+import { IntegrationTestSetup } from '#src/date-range/tests/test-setup.js'
+import { EndsBefore } from '#src/common/typeorm/ends-before.js'
+
+describe('EndsBefore for PlainDate', () => {
+  const integrationTest = new IntegrationTestSetup()
+
+  before(async () => {
+    await integrationTest.setup()
+  })
+
+  after(async () => {
+    await integrationTest.teardown()
+  })
+
+  it('finds date ranges that end before the given date', async () => {
+    const range1 = new DateRange(plainDate('2025-01-01'), plainDate('2025-01-31'))
+    const range2 = new DateRange(plainDate('2025-01-15'), plainDate('2025-01-20'))
+    const range3 = new DateRange(plainDate('2025-03-01'), plainDate('2025-03-31'))
+
+    await seed(dataSource, { id: 1, range: range1 })
+    await seed(dataSource, { id: 2, range: range2 })
+    await seed(dataSource, { id: 3, range: range3 })
+
+    const results = await dataSource.manager.find(FiniteDateRangeTest, {
+      where: {
+        id: In([1, 2, 3]),
+        range: EndsBefore(plainDate('2025-02-15'))
+      }
+    })
+
+    expect(results.length).toBe(2)
+    expect(results.some(r => r.id === 1)).toBe(true)
+    expect(results.some(r => r.id === 2)).toBe(true)
+  })
+
+  it('excludes date ranges that end on or after the given date', async () => {
+    const range1 = new DateRange(plainDate('2025-03-01'), plainDate('2025-03-31'))
+    const range2 = new DateRange(plainDate('2025-02-15'), plainDate('2025-04-30'))
+
+    await seed(dataSource, { id: 4, range: range1 })
+    await seed(dataSource, { id: 5, range: range2 })
+
+    const results = await dataSource.manager.find(FiniteDateRangeTest, {
+      where: {
+        id: In([4, 5]),
+        range: EndsBefore(plainDate('2025-02-15'))
+      }
+    })
+
+    expect(results.length).toBe(0)
+  })
+
+  async function seed (dataSource: DataSource, row: FiniteDateRangeTest): Promise<void> {
+    await dataSource.manager.upsert(FiniteDateRangeTest, row, { conflictPaths: { id: true } })
+  }
+})

--- a/packages/api/datewise/lib/date-range/tests/sql/datasource.ts
+++ b/packages/api/datewise/lib/date-range/tests/sql/datasource.ts
@@ -11,6 +11,6 @@ export const dataSource = new DataSource({
   migrationsRun: true,
   entities: [
     'dist/**/finite-date-range-test.entity.js',
-    'dist/**/plain-date-test.entity.js'
+    'dist/**/plain-date-test.entity.js',
   ]
 })

--- a/packages/api/datewise/lib/date-range/tests/starts-after-plain-date.integration.test.ts
+++ b/packages/api/datewise/lib/date-range/tests/starts-after-plain-date.integration.test.ts
@@ -1,0 +1,63 @@
+import { after, before, describe, it } from 'node:test'
+import { expect } from 'expect'
+import { DataSource, In } from 'typeorm'
+import { StartsAfter } from '#src/common/index.js'
+import { DateRange } from '#src/date-range/date-range.js'
+import { dataSource } from '#src/date-range/tests/sql/datasource.js'
+import { FiniteDateRangeTest } from '#src/date-range/tests/sql/finite-date-range-test.entity.js'
+import { IntegrationTestSetup } from '#src/date-range/tests/test-setup.js'
+import { plainDate } from '#src/plain-date/plain-date.fn.js'
+
+describe('StartsAfter for PlainDate', () => {
+  const integrationTest = new IntegrationTestSetup()
+
+  before(async () => {
+    await integrationTest.setup()
+  })
+
+  after(async () => {
+    await integrationTest.teardown()
+  })
+
+  it('finds date ranges that start after the given date', async () => {
+    const range1 = new DateRange(plainDate('2025-03-01'), plainDate('2025-03-31'))
+    const range2 = new DateRange(plainDate('2025-04-01'), plainDate('2025-04-30'))
+    const range3 = new DateRange(plainDate('2025-01-01'), plainDate('2025-01-31'))
+
+    await seed(dataSource, { id: 1, range: range1 })
+    await seed(dataSource, { id: 2, range: range2 })
+    await seed(dataSource, { id: 3, range: range3 })
+
+    const results = await dataSource.manager.find(FiniteDateRangeTest, {
+      where: {
+        id: In([1, 2, 3]),
+        range: StartsAfter(plainDate('2025-02-01'))
+      }
+    })
+
+    expect(results.length).toBe(2)
+    expect(results.some(r => r.id === 1)).toBe(true)
+    expect(results.some(r => r.id === 2)).toBe(true)
+  })
+
+  it('excludes date ranges that start before or on the given date', async () => {
+    const range1 = new DateRange(plainDate('2025-01-01'), plainDate('2025-01-31'))
+    const range2 = new DateRange(plainDate('2025-02-01'), plainDate('2025-02-28'))
+
+    await seed(dataSource, { id: 4, range: range1 })
+    await seed(dataSource, { id: 5, range: range2 })
+
+    const results = await dataSource.manager.find(FiniteDateRangeTest, {
+      where: {
+        id: In([4, 5]),
+        range: StartsAfter(plainDate('2025-02-01'))
+      }
+    })
+
+    expect(results.length).toBe(0)
+  })
+
+  async function seed (dataSource: DataSource, row: FiniteDateRangeTest): Promise<void> {
+    await dataSource.manager.upsert(FiniteDateRangeTest, row, { conflictPaths: { id: true } })
+  }
+})

--- a/packages/api/datewise/lib/date-time-range/tests/date-time-range.column.integration.test.ts
+++ b/packages/api/datewise/lib/date-time-range/tests/date-time-range.column.integration.test.ts
@@ -450,7 +450,7 @@ describe('DateTimeRangeColumn', () => {
       expect(test).not.toBeNull()
     })
 
-    it('does not finds a range that starts on the date', async () => {
+    it('does not find a range that starts on the date', async () => {
       const date = period.range.inclLower.toDate()
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
@@ -461,7 +461,7 @@ describe('DateTimeRangeColumn', () => {
       expect(test).toBeNull()
     })
 
-    it('does not finds a range that contains the date', async () => {
+    it('does not find a range that contains the date', async () => {
       const date = period.range.inclLower.add(1, 'second').toDate()
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
@@ -472,7 +472,7 @@ describe('DateTimeRangeColumn', () => {
       expect(test).toBeNull()
     })
 
-    it('does not finds a range that ends on the date', async () => {
+    it('does not find a range that ends on the date', async () => {
       const date = period.range.exclUpper.toDate()
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
@@ -483,7 +483,7 @@ describe('DateTimeRangeColumn', () => {
       expect(test).toBeNull()
     })
 
-    it('does not finds a range that ended before the date', async () => {
+    it('does not find a range that ended before the date', async () => {
       const date = period.range.exclUpper.add(1, 'ms').toDate()
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
@@ -503,7 +503,7 @@ describe('DateTimeRangeColumn', () => {
       await dataSource.manager.upsert(DateTimeRangeTest, period, { conflictPaths: { id: true } })
     })
 
-    it('does not finds a range that immediately starts after a date', async () => {
+    it('does not find a range that immediately starts after a date', async () => {
       const date = period.range.exclLower.toDate()
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
@@ -514,7 +514,7 @@ describe('DateTimeRangeColumn', () => {
       expect(test).toBeNull()
     })
 
-    it('does not finds a range that starts after on the date', async () => {
+    it('does not find a range that starts on the date', async () => {
       const date = period.range.inclLower.toDate()
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
@@ -525,7 +525,7 @@ describe('DateTimeRangeColumn', () => {
       expect(test).toBeNull()
     })
 
-    it('does not finds a range that contains the date', async () => {
+    it('does not find a range that contains the date', async () => {
       const date = period.range.inclLower.add(1, 'second').toDate()
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
@@ -536,7 +536,7 @@ describe('DateTimeRangeColumn', () => {
       expect(test).toBeNull()
     })
 
-    it('does not finds a range that ends on the date', async () => {
+    it('does not find a range that ends on the date', async () => {
       const date = period.range.exclUpper.subtract(1, 'ms').toDate()
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {

--- a/packages/api/datewise/lib/date-time-range/tests/date-time-range.column.integration.test.ts
+++ b/packages/api/datewise/lib/date-time-range/tests/date-time-range.column.integration.test.ts
@@ -7,7 +7,6 @@ import { EndsBefore } from '../../common/typeorm/ends-before.js'
 import { FutureInfinity } from '../../timestamp/future-infinity.js'
 import { timestamp } from '../../timestamp/index.js'
 import { PastInfinity } from '../../timestamp/past-infinity.js'
-import { DateRange } from '../../date-range/date-range.js'
 import { OverlapsWith, Succeeds, Precedes, IsPrecededBy, IsSucceededBy } from '../../common/index.js'
 import { IntegrationTestSetup } from './test-setup.js'
 import { dataSource } from './sql/datasource.js'
@@ -441,22 +440,22 @@ describe('DateTimeRangeColumn', () => {
     })
 
     it('finds a range that immediately starts after a date', async () => {
-      const date = period.range.inclLower.clone()
+      const date = period.range.exclLower.clone()
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
         id: 34,
-        range: StartsAfter(new DateRange(date, date.add(1, 'ms')))
+        range: StartsAfter(date)
       })
 
       expect(test).not.toBeNull()
     })
 
-    it('does not finds a range that starts after on the date', async () => {
+    it('does not finds a range that starts on the date', async () => {
       const date = period.range.inclLower.toDate()
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
         id: 34,
-        range: StartsAfter(new DateTimeRange(date, date, '[]'))
+        range: StartsAfter(date)
       })
 
       expect(test).toBeNull()
@@ -467,7 +466,7 @@ describe('DateTimeRangeColumn', () => {
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
         id: 34,
-        range: StartsAfter(new DateTimeRange(date, date, '[]'))
+        range: StartsAfter(date)
       })
 
       expect(test).toBeNull()
@@ -478,7 +477,7 @@ describe('DateTimeRangeColumn', () => {
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
         id: 34,
-        range: StartsAfter(new DateTimeRange(date, date, '[]'))
+        range: StartsAfter(date)
       })
 
       expect(test).toBeNull()
@@ -489,7 +488,7 @@ describe('DateTimeRangeColumn', () => {
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
         id: 34,
-        range: StartsAfter(new DateTimeRange(date, date, '[]'))
+        range: StartsAfter(date)
       })
 
       expect(test).toBeNull()
@@ -509,7 +508,7 @@ describe('DateTimeRangeColumn', () => {
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
         id: 35,
-        range: EndsBefore(new DateTimeRange(date, date, '[]'))
+        range: EndsBefore(date)
       })
 
       expect(test).toBeNull()
@@ -520,7 +519,7 @@ describe('DateTimeRangeColumn', () => {
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
         id: 35,
-        range: EndsBefore(new DateTimeRange(date, date, '[]'))
+        range: EndsBefore(date)
       })
 
       expect(test).toBeNull()
@@ -531,7 +530,7 @@ describe('DateTimeRangeColumn', () => {
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
         id: 35,
-        range: EndsBefore(new DateTimeRange(date, date, '[]'))
+        range: EndsBefore(date)
       })
 
       expect(test).toBeNull()
@@ -542,7 +541,7 @@ describe('DateTimeRangeColumn', () => {
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
         id: 35,
-        range: EndsBefore(new DateTimeRange(date, date, '[]'))
+        range: EndsBefore(date)
       })
 
       expect(test).toBeNull()
@@ -553,7 +552,7 @@ describe('DateTimeRangeColumn', () => {
 
       const test = await dataSource.manager.findOneBy(DateTimeRangeTest, {
         id: 35,
-        range: EndsBefore(new DateTimeRange(date, date, '[]'))
+        range: EndsBefore(date)
       })
 
       expect(test).not.toBeNull()

--- a/packages/api/datewise/lib/date-time-range/tests/ends-before-timestamp.integration.test.ts
+++ b/packages/api/datewise/lib/date-time-range/tests/ends-before-timestamp.integration.test.ts
@@ -1,0 +1,63 @@
+import { after, before, describe, it } from 'node:test'
+import { expect } from 'expect'
+import { DataSource, In } from 'typeorm'
+import { EndsBefore } from '#src/common/index.js'
+import { DateTimeRange } from '#src/date-time-range/date-time-range.js'
+import { DateTimeRangeTest } from '#src/date-time-range/tests/sql/date-time-range-test.entity.js'
+import { timestamp } from '#src/timestamp/index.js'
+import { IntegrationTestSetup } from '#src/date-time-range/tests/test-setup.js'
+import { dataSource } from '#src/date-time-range/tests/sql/datasource.js'
+
+describe('EndsBefore for Timestamp', () => {
+  const integrationTest = new IntegrationTestSetup()
+
+  before(async () => {
+    await integrationTest.setup()
+  })
+
+  after(async () => {
+    await integrationTest.teardown()
+  })
+
+  it('finds date-time ranges that end before the given timestamp', async () => {
+    const range1 = new DateTimeRange(timestamp('2025-01-01T00:00:00Z'), timestamp('2025-01-31T23:59:59Z'))
+    const range2 = new DateTimeRange(timestamp('2025-01-15T00:00:00Z'), timestamp('2025-01-20T23:59:59Z'))
+    const range3 = new DateTimeRange(timestamp('2025-03-01T00:00:00Z'), timestamp('2025-03-31T23:59:59Z'))
+
+    await seed(dataSource, { id: 1, range: range1 })
+    await seed(dataSource, { id: 2, range: range2 })
+    await seed(dataSource, { id: 3, range: range3 })
+
+    const results = await dataSource.manager.find(DateTimeRangeTest, {
+      where: {
+        id: In([1, 2, 3]),
+        range: EndsBefore(timestamp('2025-02-15T00:00:00Z'))
+      }
+    })
+
+    expect(results.length).toBe(2)
+    expect(results.some(r => r.id === 1)).toBe(true)
+    expect(results.some(r => r.id === 2)).toBe(true)
+  })
+
+  it('excludes date-time ranges that end on or after the given timestamp', async () => {
+    const range1 = new DateTimeRange(timestamp('2025-03-01T00:00:00Z'), timestamp('2025-03-31T23:59:59Z'))
+    const range2 = new DateTimeRange(timestamp('2025-02-15T00:00:00Z'), timestamp('2025-04-30T23:59:59Z'))
+
+    await seed(dataSource, { id: 4, range: range1 })
+    await seed(dataSource, { id: 5, range: range2 })
+
+    const results = await dataSource.manager.find(DateTimeRangeTest, {
+      where: {
+        id: In([4, 5]),
+        range: EndsBefore(timestamp('2025-02-15T00:00:00Z'))
+      }
+    })
+
+    expect(results.length).toBe(0)
+  })
+
+  async function seed (dataSource: DataSource, row: DateTimeRangeTest): Promise<void> {
+    await dataSource.manager.upsert(DateTimeRangeTest, row, { conflictPaths: { id: true } })
+  }
+})

--- a/packages/api/datewise/lib/date-time-range/tests/starts-after-timestamp.integration.test.ts
+++ b/packages/api/datewise/lib/date-time-range/tests/starts-after-timestamp.integration.test.ts
@@ -1,0 +1,63 @@
+import { after, before, describe, it } from 'node:test'
+import { expect } from 'expect'
+import { DataSource, In } from 'typeorm'
+import { IntegrationTestSetup } from './test-setup.js'
+import { StartsAfter } from '#src/common/index.js'
+import { dataSource } from './sql/datasource.js'
+import { DateTimeRange } from '#src/date-time-range/date-time-range.js'
+import { DateTimeRangeTest } from './sql/date-time-range-test.entity.js'
+import { timestamp } from '#src/timestamp/index.js'
+
+describe('StartsAfter for Timestamp', () => {
+  const integrationTest = new IntegrationTestSetup()
+
+  before(async () => {
+    await integrationTest.setup()
+  })
+
+  after(async () => {
+    await integrationTest.teardown()
+  })
+
+  it('finds date-time ranges that start after the given timestamp', async () => {
+    const range1 = new DateTimeRange(timestamp('2025-03-01T00:00:00Z'), timestamp('2025-03-31T23:59:59Z'))
+    const range2 = new DateTimeRange(timestamp('2025-04-01T00:00:00Z'), timestamp('2025-04-30T23:59:59Z'))
+    const range3 = new DateTimeRange(timestamp('2025-01-01T00:00:00Z'), timestamp('2025-01-31T23:59:59Z'))
+
+    await seed(dataSource, { id: 1, range: range1 })
+    await seed(dataSource, { id: 2, range: range2 })
+    await seed(dataSource, { id: 3, range: range3 })
+
+    const results = await dataSource.manager.find(DateTimeRangeTest, {
+      where: {
+        id: In([1, 2, 3]),
+        range: StartsAfter(timestamp('2025-02-01T00:00:00Z'))
+      }
+    })
+
+    expect(results.length).toBe(2)
+    expect(results.some(r => r.id === 1)).toBe(true)
+    expect(results.some(r => r.id === 2)).toBe(true)
+  })
+
+  it('excludes date-time ranges that start before or on the given timestamp', async () => {
+    const range1 = new DateTimeRange(timestamp('2025-01-01T00:00:00Z'), timestamp('2025-01-31T23:59:59Z'))
+    const range2 = new DateTimeRange(timestamp('2025-02-01T00:00:00Z'), timestamp('2025-02-28T23:59:59Z'))
+
+    await seed(dataSource, { id: 4, range: range1 })
+    await seed(dataSource, { id: 5, range: range2 })
+
+    const results = await dataSource.manager.find(DateTimeRangeTest, {
+      where: {
+        id: In([4, 5]),
+        range: StartsAfter(timestamp('2025-02-01T00:00:00Z'))
+      }
+    })
+
+    expect(results.length).toBe(0)
+  })
+
+  async function seed (dataSource: DataSource, row: DateTimeRangeTest): Promise<void> {
+    await dataSource.manager.upsert(DateTimeRangeTest, row, { conflictPaths: { id: true } })
+  }
+})

--- a/packages/api/datewise/lib/plain-date/is-plain-date.ts
+++ b/packages/api/datewise/lib/plain-date/is-plain-date.ts
@@ -1,10 +1,10 @@
-import { DayjsPlainDate } from "#src/plain-date/dayjs-plain-date.js";
-import { FutureInfinityDate } from "#src/plain-date/future-infinity-date.js";
-import { PlainDate } from "#src/plain-date/index.js";
-import { PastInfinityDate } from "#src/plain-date/past-infinity-date.js";
+import { DayjsPlainDate } from '#src/plain-date/dayjs-plain-date.js';
+import { FutureInfinityDate } from '#src/plain-date/future-infinity-date.js';
+import { PlainDate } from '#src/plain-date/index.js';
+import { PastInfinityDate } from '#src/plain-date/past-infinity-date.js';
 
-export function isPlainDate(x: unknown): x is PlainDate {
+export function isPlainDate (x: unknown): x is PlainDate {
     return x instanceof DayjsPlainDate ||
-        x instanceof FutureInfinityDate || 
+        x instanceof FutureInfinityDate ||
         x instanceof PastInfinityDate
 }

--- a/packages/api/datewise/lib/plain-date/is-plain-date.ts
+++ b/packages/api/datewise/lib/plain-date/is-plain-date.ts
@@ -1,0 +1,10 @@
+import { DayjsPlainDate } from "#src/plain-date/dayjs-plain-date.js";
+import { FutureInfinityDate } from "#src/plain-date/future-infinity-date.js";
+import { PlainDate } from "#src/plain-date/index.js";
+import { PastInfinityDate } from "#src/plain-date/past-infinity-date.js";
+
+export function isPlainDate(x: unknown): x is PlainDate {
+    return x instanceof DayjsPlainDate ||
+        x instanceof FutureInfinityDate || 
+        x instanceof PastInfinityDate
+}

--- a/packages/api/datewise/lib/timestamp/is-timestamp.ts
+++ b/packages/api/datewise/lib/timestamp/is-timestamp.ts
@@ -1,10 +1,10 @@
-import { DayjsTimestamp } from "#src/timestamp/dayjs-timestamp.js";
-import { FutureInfinity } from "#src/timestamp/future-infinity.js";
-import { PastInfinity } from "#src/timestamp/past-infinity.js";
-import { Timestamp } from "#src/timestamp/timestamp.js";
+import { DayjsTimestamp } from '#src/timestamp/dayjs-timestamp.js';
+import { FutureInfinity } from '#src/timestamp/future-infinity.js';
+import { PastInfinity } from '#src/timestamp/past-infinity.js';
+import { Timestamp } from '#src/timestamp/timestamp.js';
 
-export function isTimestamp(x: unknown): x is Timestamp {
+export function isTimestamp (x: unknown): x is Timestamp {
     return x instanceof DayjsTimestamp
-        || x instanceof FutureInfinity 
+        || x instanceof FutureInfinity
         || x instanceof PastInfinity
 }

--- a/packages/api/datewise/lib/timestamp/is-timestamp.ts
+++ b/packages/api/datewise/lib/timestamp/is-timestamp.ts
@@ -1,0 +1,10 @@
+import { DayjsTimestamp } from "#src/timestamp/dayjs-timestamp.js";
+import { FutureInfinity } from "#src/timestamp/future-infinity.js";
+import { PastInfinity } from "#src/timestamp/past-infinity.js";
+import { Timestamp } from "#src/timestamp/timestamp.js";
+
+export function isTimestamp(x: unknown): x is Timestamp {
+    return x instanceof DayjsTimestamp
+        || x instanceof FutureInfinity 
+        || x instanceof PastInfinity
+}

--- a/packages/api/datewise/package.json
+++ b/packages/api/datewise/package.json
@@ -7,6 +7,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",
+  "imports": {
+    "#src/*.js": "./dist/*.js"
+  },
   "files": [
     "dist/"
   ],

--- a/packages/api/datewise/package.json
+++ b/packages/api/datewise/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "imports": {
-    "#src/*.js": "./dist/*.js"
+    "#src/*": "./dist/*"
   },
   "files": [
     "dist/"

--- a/packages/api/datewise/tsconfig.json
+++ b/packages/api/datewise/tsconfig.json
@@ -9,8 +9,7 @@
     "types": [
       "node",
     ],
-    "moduleResolution": "nodenext",
-    
+    "moduleResolution": "nodenext", 
     "paths": {
       "#src/*": ["./lib/*"]
     },

--- a/packages/api/datewise/tsconfig.json
+++ b/packages/api/datewise/tsconfig.json
@@ -9,7 +9,7 @@
     "types": [
       "node",
     ],
-    "moduleResolution": "nodenext", 
+    "moduleResolution": "nodenext",
     "paths": {
       "#src/*": ["./lib/*"]
     },


### PR DESCRIPTION
### Description
Reworked the operators to work on `Date`, `Timestamp` and `PlainDate` instead of ranges.
The naming was confusing and this was an oversight when moving these operators to datewise.

If you want to work on ranges it still exists as `IsStrictlyLeftOf` and `IsStrictlyRightOf`.