### PR TITLE
feat: add vue pdf package

### DIFF
--- a/.changeset/tidy-pandas-burn.md
+++ b/.changeset/tidy-pandas-burn.md
@@ -1,0 +1,6 @@
+---
+"@wisemen/vue-core-pdf": minor
+"@wisemen/vue-core-utils": minor
+---
+
+Add a reusable Vue PDF package with document/page primitives, preview helpers, PDF filename and page-size utilities, and an optional html2pdf adapter. Also expose a shared browser download utility for URL and Blob downloads.

--- a/packages/web/pdf/README.md
+++ b/packages/web/pdf/README.md
@@ -104,11 +104,29 @@ Example:
 <script setup lang="ts">
 import {
   Html2PdfGenerator,
+  type Html2PdfCanvasOptions,
   type Html2PdfGeneratorExpose,
+  type Html2PdfOptions,
+  type Html2PdfPagebreakOptions,
 } from '@wisemen/vue-core-pdf/html2pdf'
 import { ref } from 'vue'
 
 const generator = ref<Html2PdfGeneratorExpose | null>(null)
+
+const pagebreak: Html2PdfPagebreakOptions = {
+  avoid: ['.keep-together', '.line-item'],
+  before: ['.new-page'],
+  mode: ['css', 'legacy'],
+}
+
+const html2canvas: Html2PdfCanvasOptions = {
+  scale: 3,
+  useCORS: true,
+}
+
+const options: Html2PdfOptions = {
+  margin: 0,
+}
 
 async function download(): Promise<void> {
   await generator.value?.download()
@@ -124,6 +142,9 @@ async function download(): Promise<void> {
     ref="generator"
     filename="order.pdf"
     format="a5"
+    :html2canvas="html2canvas"
+    :options="options"
+    :pagebreak="pagebreak"
   >
     <div class="h-[var(--html2pdf-page-height)] w-[var(--html2pdf-page-width)] bg-white">
       PDF content
@@ -139,7 +160,12 @@ interface Html2PdfGeneratorExpose {
   closePreview: () => void
   download: () => Promise<Blob>
   generate: () => Promise<Blob>
+  generatedBlob: Blob | null
+  generationState: Html2PdfGenerationState
+  isGenerating: boolean
   preview: () => Promise<string>
+  previewUrl: string | null
+  progress: number
   revokePreviewUrl: () => void
 }
 ```
@@ -151,3 +177,6 @@ Notes:
 - `html2pdf.js` rasterizes DOM through canvas. Prefer server-generated PDFs for official/legal/email documents.
 - The adapter provides `--html2pdf-page-width` and `--html2pdf-page-height` CSS variables to slotted content.
 - Pagebreak selectors default to `.custom-page-break-before`, `.custom-page-break-after`, and `.custom-page-break-avoid`.
+- Pass `pagebreak` explicitly for business-critical templates; prefer semantic classes such as `.keep-together`, `.new-page`, or `.line-item` over layout-dependent selectors.
+- `html2canvas`, `jsPdf`, `image`, and `options` props let consuming apps tune rendering while preserving package defaults.
+- Dedicated props are merged after nested `options` values, so `:html2canvas="{ scale: 3 }"` overrides `:options="{ html2canvas: { scale: 2 } }"`.

--- a/packages/web/pdf/README.md
+++ b/packages/web/pdf/README.md
@@ -1,0 +1,152 @@
+# @wisemen/vue-core-pdf
+
+Shared Vue PDF primitives and utilities.
+
+## Install styles
+
+Import the package stylesheet once in the consuming app:
+
+```ts
+import '@wisemen/vue-core-pdf/style.css'
+```
+
+## Layout primitives
+
+```vue
+<script setup lang="ts">
+import {
+  PdfDocument,
+  PdfPage,
+} from '@wisemen/vue-core-pdf'
+</script>
+
+<template>
+  <PdfDocument format="a4">
+    <PdfPage padding="20mm" shadow>
+      Content
+    </PdfPage>
+  </PdfDocument>
+</template>
+```
+
+Custom page sizes are supported:
+
+```vue
+<PdfPage :format="{ width: 240, height: 297, unit: 'mm' }" />
+```
+
+## Headless HTML preview viewer
+
+`PdfHtmlPreviewViewer` provides scroll-container pagination and zoom state while leaving the toolbar UI to the consuming app.
+
+```vue
+<PdfHtmlPreviewViewer>
+  <template #toolbar="{ currentPage, totalPages, nextPage, previousPage, zoom, zoomIn, zoomOut }">
+    <button @click="previousPage">
+      Previous
+    </button>
+    <span>{{ currentPage }} / {{ totalPages }}</span>
+    <button @click="nextPage">
+      Next
+    </button>
+    <button @click="zoomOut">
+      -
+    </button>
+    <span>{{ zoom }}%</span>
+    <button @click="zoomIn">
+      +
+    </button>
+  </template>
+
+  <PdfDocument format="a4">
+    <PdfPage padding="20mm">
+      Page 1
+    </PdfPage>
+  </PdfDocument>
+</PdfHtmlPreviewViewer>
+```
+
+## Utilities
+
+```ts
+PdfPageSizeUtil.getSize('a4', 'mm')
+PdfFilenameUtil.ensureExtension('invoice')
+PdfDownloadUtil.downloadBlob(blob, { filename: 'invoice.pdf' })
+```
+
+## Composables
+
+- `usePdfObjectUrl()` creates and revokes object URLs safely.
+- `usePdfViewerPagination()` observes rendered pages in a scroll container.
+- `usePdfLocale()` temporarily applies a locale while a PDF route is mounted.
+
+## Optional html2pdf adapter
+
+Client-side PDF generation is available from a separate subpath export:
+
+```ts
+import {
+  Html2PdfGenerator,
+  type Html2PdfGeneratorExpose,
+} from '@wisemen/vue-core-pdf/html2pdf'
+```
+
+The consuming application must install `html2pdf.js`:
+
+```sh
+pnpm add html2pdf.js
+```
+
+Example:
+
+```vue
+<script setup lang="ts">
+import {
+  Html2PdfGenerator,
+  type Html2PdfGeneratorExpose,
+} from '@wisemen/vue-core-pdf/html2pdf'
+import { ref } from 'vue'
+
+const generator = ref<Html2PdfGeneratorExpose | null>(null)
+
+async function download(): Promise<void> {
+  await generator.value?.download()
+}
+</script>
+
+<template>
+  <button @click="download">
+    Download PDF
+  </button>
+
+  <Html2PdfGenerator
+    ref="generator"
+    filename="order.pdf"
+    format="a5"
+  >
+    <div class="h-[var(--html2pdf-page-height)] w-[var(--html2pdf-page-width)] bg-white">
+      PDF content
+    </div>
+  </Html2PdfGenerator>
+</template>
+```
+
+The adapter exposes:
+
+```ts
+interface Html2PdfGeneratorExpose {
+  closePreview: () => void
+  download: () => Promise<Blob>
+  generate: () => Promise<Blob>
+  preview: () => Promise<string>
+  revokePreviewUrl: () => void
+}
+```
+
+Notes:
+
+- Importing from `@wisemen/vue-core-pdf/html2pdf` keeps `html2pdf.js` out of the root package entry.
+- `html2pdf.js` is browser-only and relatively heavy; lazy-load routes/components that use it where possible.
+- `html2pdf.js` rasterizes DOM through canvas. Prefer server-generated PDFs for official/legal/email documents.
+- The adapter provides `--html2pdf-page-width` and `--html2pdf-page-height` CSS variables to slotted content.
+- Pagebreak selectors default to `.custom-page-break-before`, `.custom-page-break-after`, and `.custom-page-break-avoid`.

--- a/packages/web/pdf/README.md
+++ b/packages/web/pdf/README.md
@@ -71,8 +71,9 @@ Custom page sizes are supported:
 ```ts
 PdfPageSizeUtil.getSize('a4', 'mm')
 PdfFilenameUtil.ensureExtension('invoice')
-PdfDownloadUtil.downloadBlob(blob, { filename: 'invoice.pdf' })
 ```
+
+Use `BrowserDownloadUtil` from `@wisemen/vue-core-utils` for generic browser-only URL and Blob downloads.
 
 ## Composables
 

--- a/packages/web/pdf/README.md
+++ b/packages/web/pdf/README.md
@@ -75,6 +75,38 @@ PdfFilenameUtil.ensureExtension('invoice')
 
 Use `BrowserDownloadUtil` from `@wisemen/vue-core-utils` for generic browser-only URL and Blob downloads.
 
+## Choosing a renderer
+
+Use the `html2pdf` adapter for browser-only convenience downloads, drafts, previews, and local exports. For official, legal, financial, emailed, archived, or highly pagination-sensitive documents, prefer a server-side renderer with controlled fonts, assets, runtime, and pagination behavior.
+
+Keep business templates in consuming apps. Use this package for shared page primitives, renderer-agnostic pagebreak conventions, preview helpers, and optional client-side generation.
+
+## Pagebreak conventions
+
+Use semantic pagebreak classes in templates so browser preview, client-side `html2pdf`, browser print, and future server-side renderers can share the same layout intent:
+
+```html
+<section class="pdf-page-break-before">
+  Starts on a new page
+</section>
+
+<section class="pdf-keep-together">
+  Avoid splitting this block across pages
+</section>
+
+<section class="pdf-page-break-after">
+  Force the following content to a new page
+</section>
+```
+
+Available classes:
+
+- `.pdf-page-break-before` applies `break-before: page` and `page-break-before: always`.
+- `.pdf-page-break-after` applies `break-after: page` and `page-break-after: always`.
+- `.pdf-page-break-avoid` and `.pdf-keep-together` apply `break-inside: avoid` and `page-break-inside: avoid`.
+
+The `html2pdf` adapter defaults to these classes and also supports the legacy `.custom-page-break-before`, `.custom-page-break-after`, and `.custom-page-break-avoid` selectors.
+
 ## Composables
 
 - `usePdfObjectUrl()` creates and revokes object URLs safely.
@@ -114,8 +146,8 @@ import { ref } from 'vue'
 const generator = ref<Html2PdfGeneratorExpose | null>(null)
 
 const pagebreak: Html2PdfPagebreakOptions = {
-  avoid: ['.keep-together', '.line-item'],
-  before: ['.new-page'],
+  avoid: ['.pdf-keep-together', '.line-item'],
+  before: ['.pdf-page-break-before'],
   mode: ['css', 'legacy'],
 }
 
@@ -176,7 +208,7 @@ Notes:
 - `html2pdf.js` is browser-only and relatively heavy; lazy-load routes/components that use it where possible.
 - `html2pdf.js` rasterizes DOM through canvas. Prefer server-generated PDFs for official/legal/email documents.
 - The adapter provides `--html2pdf-page-width` and `--html2pdf-page-height` CSS variables to slotted content.
-- Pagebreak selectors default to `.custom-page-break-before`, `.custom-page-break-after`, and `.custom-page-break-avoid`.
-- Pass `pagebreak` explicitly for business-critical templates; prefer semantic classes such as `.keep-together`, `.new-page`, or `.line-item` over layout-dependent selectors.
+- Pagebreak selectors default to `.pdf-page-break-before`, `.pdf-page-break-after`, `.pdf-page-break-avoid`, `.pdf-keep-together`, and legacy `.custom-page-break-*` selectors.
+- Pass `pagebreak` explicitly for business-critical templates; prefer semantic classes such as `.pdf-keep-together`, `.pdf-page-break-before`, or `.pdf-page-break-after` over layout-dependent selectors.
 - `html2canvas`, `jsPdf`, `image`, and `options` props let consuming apps tune rendering while preserving package defaults.
 - Dedicated props are merged after nested `options` values, so `:html2canvas="{ scale: 3 }"` overrides `:options="{ html2canvas: { scale: 2 } }"`.

--- a/packages/web/pdf/env.d.ts
+++ b/packages/web/pdf/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+
+  const component: DefineComponent<Record<string, never>, Record<string, never>, unknown>
+
+  export default component
+}

--- a/packages/web/pdf/eslint.config.ts
+++ b/packages/web/pdf/eslint.config.ts
@@ -1,0 +1,10 @@
+import { packageConfig } from '@wisemen/eslint-config-vue'
+
+export default [
+  ...(await packageConfig()),
+  {
+    rules: {
+      '@intlify/vue-i18n/no-raw-text': 'off',
+    },
+  },
+]

--- a/packages/web/pdf/package.json
+++ b/packages/web/pdf/package.json
@@ -42,6 +42,9 @@
     "test": "vitest --run",
     "type-check": "vue-tsc --noEmit"
   },
+  "dependencies": {
+    "@wisemen/vue-core-utils": "workspace:*"
+  },
   "peerDependencies": {
     "html2pdf.js": "^0.14.0",
     "vue": "catalog:peer"
@@ -56,6 +59,7 @@
     "@vue/test-utils": "catalog:test",
     "@vue/tsconfig": "catalog:vue",
     "@wisemen/eslint-config-vue": "workspace:*",
+    "@wisemen/vue-core-utils": "workspace:*",
     "eslint": "catalog:lint-web",
     "html2pdf.js": "^0.14.0",
     "jsdom": "catalog:test",

--- a/packages/web/pdf/package.json
+++ b/packages/web/pdf/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@wisemen/vue-core-pdf",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "version": "0.0.0",
+  "private": false,
+  "license": "SEE LICENSE IN LICENSE.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wisemen-digital/wisemen-core",
+    "directory": "packages/web/pdf"
+  },
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./html2pdf": {
+      "types": "./dist/html2pdf/index.d.ts",
+      "import": "./dist/html2pdf.js"
+    },
+    "./style.css": "./dist/style.css",
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.umd.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "typings": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "build-only": "vite build",
+    "cleanup": "rimraf dist/ node_modules/ .turbo/",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest --run",
+    "type-check": "vue-tsc --noEmit"
+  },
+  "peerDependencies": {
+    "html2pdf.js": "^0.14.0",
+    "vue": "catalog:peer"
+  },
+  "peerDependenciesMeta": {
+    "html2pdf.js": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "catalog:vite",
+    "@vue/test-utils": "catalog:test",
+    "@vue/tsconfig": "catalog:vue",
+    "@wisemen/eslint-config-vue": "workspace:*",
+    "eslint": "catalog:lint-web",
+    "html2pdf.js": "^0.14.0",
+    "jsdom": "catalog:test",
+    "rimraf": "catalog:build",
+    "typescript": "catalog:build",
+    "vite": "catalog:vite",
+    "vite-plugin-dts": "catalog:vite",
+    "vitest": "catalog:test",
+    "vue": "catalog:vue",
+    "vue-tsc": "catalog:vue"
+  }
+}

--- a/packages/web/pdf/src/components/pdf-document/PdfDocument.spec.ts
+++ b/packages/web/pdf/src/components/pdf-document/PdfDocument.spec.ts
@@ -1,0 +1,39 @@
+import { mount } from '@vue/test-utils'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+import PdfDocument from './PdfDocument.vue'
+
+describe('PdfDocument', () => {
+  it('renders the default slot and page CSS variables', () => {
+    const wrapper = mount(PdfDocument, {
+      props: {
+        format: 'a4',
+        pageGap: '12mm',
+      },
+      slots: {
+        default: 'PDF content',
+      },
+    })
+
+    expect(wrapper.text()).toContain('PDF content')
+    expect(wrapper.attributes('style')).toContain('--pdf-page-height: 297mm')
+    expect(wrapper.attributes('style')).toContain('--pdf-page-width: 210mm')
+    expect(wrapper.attributes('style')).toContain('--pdf-page-gap: 12mm')
+  })
+
+  it('supports landscape orientation', () => {
+    const wrapper = mount(PdfDocument, {
+      props: {
+        format: 'a4',
+        orientation: 'landscape',
+      },
+    })
+
+    expect(wrapper.attributes('style')).toContain('--pdf-page-height: 210mm')
+    expect(wrapper.attributes('style')).toContain('--pdf-page-width: 297mm')
+  })
+})

--- a/packages/web/pdf/src/components/pdf-document/PdfDocument.vue
+++ b/packages/web/pdf/src/components/pdf-document/PdfDocument.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type {
+  PdfOrientation,
+  PdfPageFormat,
+} from '@/types/pdfPageFormat.type'
+import { PdfPageSizeUtil } from '@/utils/pdfPageSize.util'
+
+const props = withDefaults(defineProps<{
+  format?: PdfPageFormat
+  orientation?: PdfOrientation
+  pageGap?: string
+  isPrintColorExact?: boolean
+}>(), {
+  format: 'a4',
+  orientation: 'portrait',
+  pageGap: '16mm',
+  isPrintColorExact: true,
+})
+
+const cssVariables = computed<Record<string, string>>(() => ({
+  ...PdfPageSizeUtil.toCssVariables(props.format, {
+    orientation: props.orientation,
+  }),
+  '--pdf-page-gap': props.pageGap,
+}))
+</script>
+
+<template>
+  <div
+    :class="{
+      'pdf-document--print-color-exact': props.isPrintColorExact,
+    }"
+    :style="cssVariables"
+    class="pdf-document"
+  >
+    <slot />
+  </div>
+</template>
+
+<style>
+.pdf-document {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pdf-page-gap);
+}
+
+.pdf-document--print-color-exact {
+  print-color-adjust: exact;
+  -webkit-print-color-adjust: exact;
+}
+
+@media print {
+  .pdf-document {
+    gap: 0;
+  }
+}
+</style>

--- a/packages/web/pdf/src/components/pdf-document/index.ts
+++ b/packages/web/pdf/src/components/pdf-document/index.ts
@@ -1,0 +1,1 @@
+export { default as PdfDocument } from './PdfDocument.vue'

--- a/packages/web/pdf/src/components/pdf-html-preview-viewer/PdfHtmlPreviewViewer.vue
+++ b/packages/web/pdf/src/components/pdf-html-preview-viewer/PdfHtmlPreviewViewer.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import {
+  computed,
+  nextTick,
+  onMounted,
+  ref,
+} from 'vue'
+
+import { usePdfViewerPagination } from '@/composables/pdf-viewer-pagination'
+
+const props = withDefaults(defineProps<{
+  initialZoom?: number
+  maxZoom?: number
+  minZoom?: number
+  pageSelector?: string
+  threshold?: number
+  totalPages?: number | null
+  zoomStep?: number
+}>(), {
+  initialZoom: 100,
+  maxZoom: 200,
+  minZoom: 25,
+  pageSelector: '.pdf-page',
+  threshold: 0.5,
+  totalPages: null,
+  zoomStep: 10,
+})
+
+const emit = defineEmits<{
+  open: []
+}>()
+
+const scrollContainer = ref<HTMLElement | null>(null)
+const zoom = ref<number>(props.initialZoom)
+
+const pagination = usePdfViewerPagination({
+  container: scrollContainer,
+  pageSelector: computed<string>(() => props.pageSelector),
+  threshold: computed<number>(() => props.threshold),
+  totalPages: computed<number | null>(() => props.totalPages),
+})
+
+const zoomScale = computed<number>(() => zoom.value / 100)
+const canZoomIn = computed<boolean>(() => zoom.value < props.maxZoom)
+const canZoomOut = computed<boolean>(() => zoom.value > props.minZoom)
+
+function zoomIn(): void {
+  zoom.value = Math.min(zoom.value + props.zoomStep, props.maxZoom)
+}
+
+function zoomOut(): void {
+  zoom.value = Math.max(zoom.value - props.zoomStep, props.minZoom)
+}
+
+function resetZoom(): void {
+  zoom.value = props.initialZoom
+}
+
+function observePages(): void {
+  pagination.observePages()
+}
+
+function onOpen(): void {
+  emit('open')
+}
+
+onMounted(async () => {
+  await nextTick()
+
+  observePages()
+})
+
+defineExpose({
+  observePages,
+})
+</script>
+
+<template>
+  <section class="pdf-html-preview-viewer">
+    <slot
+      name="toolbar"
+      :can-go-to-next-page="pagination.canGoToNextPage.value"
+      :can-go-to-previous-page="pagination.canGoToPreviousPage.value"
+      :can-zoom-in="canZoomIn"
+      :can-zoom-out="canZoomOut"
+      :current-page="pagination.currentPage.value"
+      :go-to-page="pagination.goToPage"
+      :next-page="pagination.nextPage"
+      :open="onOpen"
+      :previous-page="pagination.previousPage"
+      :reset-zoom="resetZoom"
+      :total-pages="pagination.totalPages.value"
+      :zoom="zoom"
+      :zoom-in="zoomIn"
+      :zoom-out="zoomOut"
+    />
+
+    <div
+      ref="scrollContainer"
+      class="pdf-html-preview-viewer__scroll-container"
+    >
+      <div
+        :style="{
+          transform: `scale(${zoomScale})`,
+        }"
+        class="pdf-html-preview-viewer__content"
+      >
+        <slot />
+      </div>
+    </div>
+  </section>
+</template>
+
+<style>
+.pdf-html-preview-viewer {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.pdf-html-preview-viewer__scroll-container {
+  min-height: 0;
+  overflow: auto;
+}
+
+.pdf-html-preview-viewer__content {
+  width: max-content;
+  min-width: 100%;
+  transform-origin: top center;
+}
+</style>

--- a/packages/web/pdf/src/components/pdf-html-preview-viewer/index.ts
+++ b/packages/web/pdf/src/components/pdf-html-preview-viewer/index.ts
@@ -1,0 +1,1 @@
+export { default as PdfHtmlPreviewViewer } from './PdfHtmlPreviewViewer.vue'

--- a/packages/web/pdf/src/components/pdf-page/PdfPage.spec.ts
+++ b/packages/web/pdf/src/components/pdf-page/PdfPage.spec.ts
@@ -1,0 +1,38 @@
+import { mount } from '@vue/test-utils'
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+import PdfPage from './PdfPage.vue'
+
+describe('PdfPage', () => {
+  it('renders page content with format and padding CSS variables', () => {
+    const wrapper = mount(PdfPage, {
+      props: {
+        format: 'a5',
+        padding: '10mm',
+      },
+      slots: {
+        default: 'Page content',
+      },
+    })
+
+    expect(wrapper.text()).toContain('Page content')
+    expect(wrapper.attributes('style')).toContain('--pdf-page-height: 210mm')
+    expect(wrapper.attributes('style')).toContain('--pdf-page-width: 148mm')
+    expect(wrapper.attributes('style')).toContain('--pdf-page-padding: 10mm')
+  })
+
+  it('can render without fixed page dimensions', () => {
+    const wrapper = mount(PdfPage, {
+      props: {
+        format: null,
+        padding: '8mm',
+      },
+    })
+
+    expect(wrapper.attributes('style')).toBe('--pdf-page-padding: 8mm;')
+  })
+})

--- a/packages/web/pdf/src/components/pdf-page/PdfPage.vue
+++ b/packages/web/pdf/src/components/pdf-page/PdfPage.vue
@@ -75,6 +75,22 @@ const cssVariables = computed<Record<string, string>>(() => {
   page-break-after: auto;
 }
 
+.pdf-page-break-before {
+  break-before: page;
+  page-break-before: always;
+}
+
+.pdf-page-break-after {
+  break-after: page;
+  page-break-after: always;
+}
+
+.pdf-page-break-avoid,
+.pdf-keep-together {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
 .pdf-page--print-color-exact {
   print-color-adjust: exact;
   -webkit-print-color-adjust: exact;

--- a/packages/web/pdf/src/components/pdf-page/PdfPage.vue
+++ b/packages/web/pdf/src/components/pdf-page/PdfPage.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type {
+  PdfOrientation,
+  PdfPageFormat,
+} from '@/types/pdfPageFormat.type'
+import { PdfPageSizeUtil } from '@/utils/pdfPageSize.util'
+
+const props = withDefaults(defineProps<{
+  format?: PdfPageFormat | null
+  orientation?: PdfOrientation
+  padding?: string
+  shadow?: boolean
+  breakAfter?: boolean
+  isPrintColorExact?: boolean
+}>(), {
+  format: null,
+  orientation: 'portrait',
+  padding: '0',
+  shadow: false,
+  breakAfter: true,
+  isPrintColorExact: true,
+})
+
+const cssVariables = computed<Record<string, string>>(() => {
+  if (props.format === null) {
+    return {
+      '--pdf-page-padding': props.padding,
+    }
+  }
+
+  return {
+    ...PdfPageSizeUtil.toCssVariables(props.format, {
+      orientation: props.orientation,
+    }),
+    '--pdf-page-padding': props.padding,
+  }
+})
+</script>
+
+<template>
+  <article
+    :class="{
+      'pdf-page--break-after': props.breakAfter,
+      'pdf-page--print-color-exact': props.isPrintColorExact,
+      'pdf-page--shadow': props.shadow,
+    }"
+    :style="cssVariables"
+    class="pdf-page"
+  >
+    <slot />
+  </article>
+</template>
+
+<style>
+.pdf-page {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: var(--pdf-page-width);
+  min-height: var(--pdf-page-height);
+  padding: var(--pdf-page-padding);
+  background: white;
+  overflow: hidden;
+}
+
+.pdf-page--break-after {
+  break-after: page;
+  page-break-after: always;
+}
+
+.pdf-page--break-after:last-child {
+  break-after: auto;
+  page-break-after: auto;
+}
+
+.pdf-page--print-color-exact {
+  print-color-adjust: exact;
+  -webkit-print-color-adjust: exact;
+}
+
+.pdf-page--shadow {
+  box-shadow: 0 16px 40px rgb(15 23 42 / 12%);
+}
+
+@media print {
+  .pdf-page {
+    width: var(--pdf-page-width);
+    min-height: var(--pdf-page-height);
+    box-shadow: none;
+  }
+}
+</style>

--- a/packages/web/pdf/src/components/pdf-page/index.ts
+++ b/packages/web/pdf/src/components/pdf-page/index.ts
@@ -1,0 +1,1 @@
+export { default as PdfPage } from './PdfPage.vue'

--- a/packages/web/pdf/src/composables/pdf-locale/index.ts
+++ b/packages/web/pdf/src/composables/pdf-locale/index.ts
@@ -1,0 +1,2 @@
+export { usePdfLocale } from './pdfLocale.composable'
+export type { PdfLocaleReturn } from './pdfLocale.composable'

--- a/packages/web/pdf/src/composables/pdf-locale/pdfLocale.composable.spec.ts
+++ b/packages/web/pdf/src/composables/pdf-locale/pdfLocale.composable.spec.ts
@@ -1,0 +1,62 @@
+import { mount } from '@vue/test-utils'
+import {
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { defineComponent } from 'vue'
+
+import { usePdfLocale } from './pdfLocale.composable'
+
+describe('usePdfLocale', () => {
+  it('applies the configured locale on mount and restores the previous locale on unmount', () => {
+    let currentLocale = 'nl'
+    const setLocale = vi.fn((locale: string) => {
+      currentLocale = locale
+    })
+    const component = defineComponent({
+      setup() {
+        return usePdfLocale({
+          getCurrentLocale: () => currentLocale,
+          locale: 'fr',
+          setLocale,
+        })
+      },
+      template: '<div />',
+    })
+
+    const wrapper = mount(component)
+
+    expect(setLocale).toHaveBeenCalledWith('fr')
+    expect(currentLocale).toBe('fr')
+
+    wrapper.unmount()
+
+    expect(setLocale).toHaveBeenLastCalledWith('nl')
+    expect(currentLocale).toBe('nl')
+  })
+
+  it('uses the fallback locale when no PDF locale is configured', () => {
+    const setLocale = vi.fn()
+    const component = defineComponent({
+      setup() {
+        return usePdfLocale({
+          fallbackLocale: 'en',
+          getCurrentLocale: () => 'nl',
+          locale: null,
+          setLocale,
+        })
+      },
+      template: '<div />',
+    })
+
+    const wrapper = mount(component)
+
+    expect(setLocale).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+
+    expect(setLocale).toHaveBeenCalledWith('en')
+  })
+})

--- a/packages/web/pdf/src/composables/pdf-locale/pdfLocale.composable.ts
+++ b/packages/web/pdf/src/composables/pdf-locale/pdfLocale.composable.ts
@@ -1,0 +1,58 @@
+import {
+  onBeforeUnmount,
+  onMounted,
+  toValue,
+} from 'vue'
+
+import type { MaybeRefOrGetter } from 'vue'
+
+interface UsePdfLocaleOptions {
+  getCurrentLocale: () => string
+  locale: MaybeRefOrGetter<string | null>
+  setLocale: (locale: string) => void
+  fallbackLocale?: MaybeRefOrGetter<string> | null
+}
+
+export type PdfLocaleReturn = ReturnType<typeof usePdfLocale>
+
+export function usePdfLocale(options: UsePdfLocaleOptions) {
+  let previousLocale: string | null = null
+
+  function applyLocale(): void {
+    const locale = toValue(options.locale)
+
+    if (locale === null) {
+      return
+    }
+
+    previousLocale = options.getCurrentLocale()
+    options.setLocale(locale)
+  }
+
+  function restoreLocale(): void {
+    const fallbackLocale = options.fallbackLocale === undefined || options.fallbackLocale === null
+      ? null
+      : toValue(options.fallbackLocale)
+
+    const locale = previousLocale ?? fallbackLocale
+
+    if (locale === null) {
+      return
+    }
+
+    options.setLocale(locale)
+  }
+
+  onMounted(() => {
+    applyLocale()
+  })
+
+  onBeforeUnmount(() => {
+    restoreLocale()
+  })
+
+  return {
+    applyLocale,
+    restoreLocale,
+  }
+}

--- a/packages/web/pdf/src/composables/pdf-object-url/index.ts
+++ b/packages/web/pdf/src/composables/pdf-object-url/index.ts
@@ -1,0 +1,2 @@
+export { usePdfObjectUrl } from './pdfObjectUrl.composable'
+export type { PdfObjectUrlReturn } from './pdfObjectUrl.composable'

--- a/packages/web/pdf/src/composables/pdf-object-url/pdfObjectUrl.composable.spec.ts
+++ b/packages/web/pdf/src/composables/pdf-object-url/pdfObjectUrl.composable.spec.ts
@@ -1,0 +1,47 @@
+import { mount } from '@vue/test-utils'
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { defineComponent } from 'vue'
+
+import { usePdfObjectUrl } from './pdfObjectUrl.composable'
+
+describe('usePdfObjectUrl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('creates and revokes object URLs', () => {
+    const firstBlob = new Blob(['first'], { type: 'application/pdf' })
+    const secondBlob = new Blob(['second'], { type: 'application/pdf' })
+    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL')
+      .mockReturnValueOnce('blob:first')
+      .mockReturnValueOnce('blob:second')
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    const component = defineComponent({
+      setup() {
+        return usePdfObjectUrl()
+      },
+      template: '<div />',
+    })
+
+    const wrapper = mount(component)
+
+    expect(wrapper.vm.setBlob(firstBlob)).toBe('blob:first')
+    expect(wrapper.vm.url).toBe('blob:first')
+
+    expect(wrapper.vm.setBlob(secondBlob)).toBe('blob:second')
+    expect(wrapper.vm.url).toBe('blob:second')
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:first')
+
+    wrapper.unmount()
+
+    expect(createObjectUrlSpy).toHaveBeenCalledTimes(2)
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:second')
+  })
+})

--- a/packages/web/pdf/src/composables/pdf-object-url/pdfObjectUrl.composable.ts
+++ b/packages/web/pdf/src/composables/pdf-object-url/pdfObjectUrl.composable.ts
@@ -1,0 +1,39 @@
+import {
+  onBeforeUnmount,
+  ref,
+} from 'vue'
+
+import type { Ref } from 'vue'
+
+export type PdfObjectUrlReturn = ReturnType<typeof usePdfObjectUrl>
+
+export function usePdfObjectUrl() {
+  const url = ref<string | null>(null) as Ref<string | null>
+
+  function revoke(): void {
+    if (url.value === null) {
+      return
+    }
+
+    URL.revokeObjectURL(url.value)
+    url.value = null
+  }
+
+  function setBlob(blob: Blob): string {
+    revoke()
+
+    url.value = URL.createObjectURL(blob)
+
+    return url.value
+  }
+
+  onBeforeUnmount(() => {
+    revoke()
+  })
+
+  return {
+    revoke,
+    setBlob,
+    url,
+  }
+}

--- a/packages/web/pdf/src/composables/pdf-viewer-pagination/index.ts
+++ b/packages/web/pdf/src/composables/pdf-viewer-pagination/index.ts
@@ -1,0 +1,2 @@
+export { usePdfViewerPagination } from './pdfViewerPagination.composable'
+export type { PdfViewerPaginationReturn } from './pdfViewerPagination.composable'

--- a/packages/web/pdf/src/composables/pdf-viewer-pagination/pdfViewerPagination.composable.ts
+++ b/packages/web/pdf/src/composables/pdf-viewer-pagination/pdfViewerPagination.composable.ts
@@ -1,0 +1,134 @@
+import {
+  computed,
+  onBeforeUnmount,
+  ref,
+  toValue,
+} from 'vue'
+
+import type {
+  ComputedRef,
+  MaybeRefOrGetter,
+  Ref,
+} from 'vue'
+
+interface UsePdfViewerPaginationOptions {
+  container: MaybeRefOrGetter<HTMLElement | null>
+  pageSelector?: MaybeRefOrGetter<string>
+  threshold?: MaybeRefOrGetter<number>
+  totalPages?: MaybeRefOrGetter<number | null>
+}
+
+export type PdfViewerPaginationReturn = ReturnType<typeof usePdfViewerPagination>
+
+export function usePdfViewerPagination(options: UsePdfViewerPaginationOptions) {
+  const currentPage = ref<number>(1) as Ref<number>
+  const observedPages = ref<HTMLElement[]>([]) as Ref<HTMLElement[]>
+  const intersectionObserver = ref<IntersectionObserver | null>(null) as Ref<IntersectionObserver | null>
+
+  const totalPages = computed<number>(() => {
+    if (options.totalPages === undefined) {
+      return observedPages.value.length
+    }
+
+    return toValue(options.totalPages) ?? observedPages.value.length
+  })
+
+  const canGoToPreviousPage = computed<boolean>(() => currentPage.value > 1)
+  const canGoToNextPage = computed<boolean>(() => currentPage.value < totalPages.value)
+
+  function observePages(): void {
+    disconnect()
+
+    const container = toValue(options.container)
+
+    if (container === null) {
+      return
+    }
+
+    const pageSelector = options.pageSelector === undefined
+      ? 'article'
+      : toValue(options.pageSelector)
+
+    observedPages.value = Array.from(container.querySelectorAll<HTMLElement>(pageSelector))
+
+    intersectionObserver.value = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) {
+            continue
+          }
+
+          const index = observedPages.value.indexOf(entry.target as HTMLElement)
+
+          if (index === -1) {
+            continue
+          }
+
+          currentPage.value = index + 1
+        }
+      },
+      {
+        root: container,
+        threshold: options.threshold === undefined ? 0.5 : toValue(options.threshold),
+      },
+    )
+
+    for (const page of observedPages.value) {
+      intersectionObserver.value.observe(page)
+    }
+  }
+
+  function disconnect(): void {
+    intersectionObserver.value?.disconnect()
+    intersectionObserver.value = null
+    observedPages.value = []
+  }
+
+  function goToPage(page: number): void {
+    const pageIndex = Math.min(Math.max(page, 1), totalPages.value) - 1
+    const targetPage = observedPages.value[pageIndex]
+
+    if (targetPage === undefined) {
+      return
+    }
+
+    targetPage.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    })
+    currentPage.value = pageIndex + 1
+  }
+
+  function nextPage(): void {
+    if (!canGoToNextPage.value) {
+      return
+    }
+
+    goToPage(currentPage.value + 1)
+  }
+
+  function previousPage(): void {
+    if (!canGoToPreviousPage.value) {
+      return
+    }
+
+    goToPage(currentPage.value - 1)
+  }
+
+  onBeforeUnmount(() => {
+    disconnect()
+  })
+
+  return {
+    canGoToNextPage: canGoToNextPage as ComputedRef<boolean>,
+    canGoToPreviousPage: canGoToPreviousPage as ComputedRef<boolean>,
+    currentPage,
+    disconnect,
+    goToPage,
+    nextPage,
+    observePages,
+    observedPages,
+    previousPage,
+    totalPages,
+  }
+}

--- a/packages/web/pdf/src/html2pdf/Html2PdfGenerator.spec.ts
+++ b/packages/web/pdf/src/html2pdf/Html2PdfGenerator.spec.ts
@@ -45,10 +45,11 @@ function createHtml2PdfWorkerMock() {
   return worker
 }
 
-function mountComponent(): ReturnType<typeof mount> {
+function mountComponent(props: Record<string, unknown> = {}): ReturnType<typeof mount> {
   return mount(Html2PdfGenerator, {
     props: {
       filename: 'invoice.pdf',
+      ...props,
     },
     slots: {
       default: '<div>PDF content</div>',
@@ -80,6 +81,16 @@ describe('Html2PdfGenerator', () => {
     expect(mocks.html2pdf).toHaveBeenCalledOnce()
     expect(mocks.set).toHaveBeenCalledOnce()
     expect(mocks.from).toHaveBeenCalledWith(expect.any(HTMLElement))
+    expect(generator.isGenerating).toBe(false)
+    expect(generator.progress).toBe(100)
+    expect(generator.generatedBlob).toBe(blob)
+    expect(generator.previewUrl).toBe('blob:pdf')
+    expect(generator.generationState).toEqual({
+      blob,
+      isGenerating: false,
+      previewUrl: 'blob:pdf',
+      progress: 100,
+    })
     expect(URL.createObjectURL).toHaveBeenCalledOnce()
     expect(wrapper.emitted('generated')).toEqual([[
       {
@@ -114,6 +125,68 @@ describe('Html2PdfGenerator', () => {
     expect(wrapper.emitted('downloaded')).toEqual([[blob]])
   })
 
+  it('merges custom pagebreak and rendering options', async () => {
+    const wrapper = mountComponent({
+      html2canvas: {
+        scale: 3,
+      },
+      image: {
+        quality: 0.8,
+        type: 'png',
+      },
+      jsPdf: {
+        precision: 4,
+      },
+      options: {
+        enableLinks: false,
+        html2canvas: {
+          logging: true,
+          scale: 1,
+        },
+        image: {
+          quality: 0.5,
+        },
+        jsPDF: {
+          compress: true,
+        },
+        margin: 8,
+      },
+      pagebreak: {
+        avoid: ['.keep-together'],
+        before: ['.page-start'],
+        mode: ['css', 'legacy'],
+      },
+    })
+
+    const generator = wrapper.vm as unknown as Html2PdfGeneratorExpose
+
+    await generator.generate()
+
+    expect(mocks.set).toHaveBeenCalledWith(expect.objectContaining({
+      enableLinks: false,
+      html2canvas: expect.objectContaining({
+        logging: true,
+        scale: 3,
+        useCORS: true,
+      }),
+      image: {
+        quality: 0.8,
+        type: 'png',
+      },
+      jsPDF: expect.objectContaining({
+        compress: true,
+        precision: 4,
+        unit: 'px',
+      }),
+      margin: 8,
+      pagebreak: {
+        avoid: ['.keep-together'],
+        before: ['.page-start'],
+        mode: ['css', 'legacy'],
+      },
+    }))
+  })
+
   it('revokes the generated object URL when closing the preview', async () => {
     const wrapper = mountComponent()
 
@@ -123,5 +196,6 @@ describe('Html2PdfGenerator', () => {
     generator.closePreview()
 
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:pdf')
+    expect(generator.previewUrl).toBeNull()
   })
 })

--- a/packages/web/pdf/src/html2pdf/Html2PdfGenerator.spec.ts
+++ b/packages/web/pdf/src/html2pdf/Html2PdfGenerator.spec.ts
@@ -1,0 +1,127 @@
+import { BrowserDownloadUtil } from '@wisemen/vue-core-utils'
+import { mount } from '@vue/test-utils'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import Html2PdfGenerator from './Html2PdfGenerator.vue'
+import type { Html2PdfGeneratorExpose } from './html2Pdf.types'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  get: vi.fn<() => Promise<{ output: () => Promise<Blob> }>>(),
+  html2pdf: vi.fn(),
+  output: vi.fn<() => Promise<Blob>>(),
+  set: vi.fn(),
+  toContainer: vi.fn(),
+  toPdf: vi.fn(),
+}))
+
+vi.mock('html2pdf.js', () => ({
+  default: mocks.html2pdf,
+}))
+
+function createHtml2PdfWorkerMock() {
+  const worker = {
+    from: mocks.from,
+    get: mocks.get,
+    set: mocks.set,
+    toContainer: mocks.toContainer,
+    toPdf: mocks.toPdf,
+  }
+
+  mocks.set.mockReturnValue(worker)
+  mocks.from.mockReturnValue(worker)
+  mocks.toContainer.mockReturnValue(worker)
+  mocks.toPdf.mockReturnValue(worker)
+  mocks.get.mockResolvedValue({ output: mocks.output })
+  mocks.html2pdf.mockReturnValue(worker)
+
+  return worker
+}
+
+function mountComponent(): ReturnType<typeof mount> {
+  return mount(Html2PdfGenerator, {
+    props: {
+      filename: 'invoice.pdf',
+    },
+    slots: {
+      default: '<div>PDF content</div>',
+    },
+  })
+}
+
+describe('Html2PdfGenerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createHtml2PdfWorkerMock()
+    mocks.output.mockResolvedValue(new Blob(['pdf'], { type: 'application/pdf' }))
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:pdf')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('generates a PDF blob and emits the generated object URL', async () => {
+    const wrapper = mountComponent()
+
+    const generator = wrapper.vm as unknown as Html2PdfGeneratorExpose
+
+    const blob = await generator.generate()
+
+    expect(blob.type).toBe('application/pdf')
+    expect(mocks.html2pdf).toHaveBeenCalledOnce()
+    expect(mocks.set).toHaveBeenCalledOnce()
+    expect(mocks.from).toHaveBeenCalledWith(expect.any(HTMLElement))
+    expect(URL.createObjectURL).toHaveBeenCalledOnce()
+    expect(wrapper.emitted('generated')).toEqual([[
+      {
+        blob,
+        objectUrl: 'blob:pdf',
+      },
+    ]])
+  })
+
+  it('reuses the generated object URL for preview without creating a second URL', async () => {
+    const wrapper = mountComponent()
+
+    const generator = wrapper.vm as unknown as Html2PdfGeneratorExpose
+
+    const objectUrl = await generator.preview()
+
+    expect(objectUrl).toBe('blob:pdf')
+    expect(URL.createObjectURL).toHaveBeenCalledOnce()
+  })
+
+  it('downloads the generated blob when downloads are enabled', async () => {
+    const downloadBlobSpy = vi.spyOn(BrowserDownloadUtil, 'downloadBlob').mockImplementation(() => {})
+    const wrapper = mountComponent()
+
+    const generator = wrapper.vm as unknown as Html2PdfGeneratorExpose
+
+    const blob = await generator.download()
+
+    expect(downloadBlobSpy).toHaveBeenCalledWith(blob, {
+      filename: 'invoice.pdf',
+    })
+    expect(wrapper.emitted('downloaded')).toEqual([[blob]])
+  })
+
+  it('revokes the generated object URL when closing the preview', async () => {
+    const wrapper = mountComponent()
+
+    const generator = wrapper.vm as unknown as Html2PdfGeneratorExpose
+
+    await generator.preview()
+    generator.closePreview()
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:pdf')
+  })
+})

--- a/packages/web/pdf/src/html2pdf/Html2PdfGenerator.spec.ts
+++ b/packages/web/pdf/src/html2pdf/Html2PdfGenerator.spec.ts
@@ -152,7 +152,7 @@ describe('Html2PdfGenerator', () => {
         margin: 8,
       },
       pagebreak: {
-        avoid: ['.keep-together'],
+        avoid: ['.pdf-keep-together'],
         before: ['.page-start'],
         mode: ['css', 'legacy'],
       },
@@ -180,8 +180,35 @@ describe('Html2PdfGenerator', () => {
       }),
       margin: 8,
       pagebreak: {
-        avoid: ['.keep-together'],
+        avoid: ['.pdf-keep-together'],
         before: ['.page-start'],
+        mode: ['css', 'legacy'],
+      },
+    }))
+  })
+
+  it('uses renderer-agnostic pagebreak selectors by default', async () => {
+    const wrapper = mountComponent()
+
+    const generator = wrapper.vm as unknown as Html2PdfGeneratorExpose
+
+    await generator.generate()
+
+    expect(mocks.set).toHaveBeenCalledWith(expect.objectContaining({
+      pagebreak: {
+        after: [
+          '.pdf-page-break-after',
+          '.custom-page-break-after',
+        ],
+        avoid: [
+          '.pdf-page-break-avoid',
+          '.pdf-keep-together',
+          '.custom-page-break-avoid',
+        ],
+        before: [
+          '.pdf-page-break-before',
+          '.custom-page-break-before',
+        ],
         mode: ['css', 'legacy'],
       },
     }))

--- a/packages/web/pdf/src/html2pdf/Html2PdfGenerator.vue
+++ b/packages/web/pdf/src/html2pdf/Html2PdfGenerator.vue
@@ -1,0 +1,313 @@
+<script setup lang="ts">
+import html2pdf from 'html2pdf.js'
+import {
+  computed,
+  ref,
+} from 'vue'
+
+import { usePdfObjectUrl } from '@/composables/pdf-object-url'
+import type { PdfNamedPageFormat } from '@/types/pdfPageFormat.type'
+import { PdfDownloadUtil } from '@/utils/pdfDownload.util'
+import { PdfPageSizeUtil } from '@/utils/pdfPageSize.util'
+import type {
+  Html2PdfBeforeGeneratePayload,
+  Html2PdfGenerateResult,
+  Html2PdfImageType,
+  Html2PdfPagebreakOptions,
+} from './html2Pdf.types'
+
+const props = withDefaults(defineProps<{
+  filename: string
+  format?: PdfNamedPageFormat
+  imageQuality?: number
+  imageType?: Html2PdfImageType
+  isDownloadEnabled?: boolean
+  isImageFixEnabled?: boolean
+  isPreviewEnabled?: boolean
+  pagebreak?: Html2PdfPagebreakOptions
+  previewTitle?: string
+  quality?: number
+}>(), {
+  format: 'a4',
+  imageQuality: 1,
+  imageType: 'jpeg',
+  isDownloadEnabled: true,
+  isImageFixEnabled: true,
+  isPreviewEnabled: false,
+  pagebreak: () => ({
+    after: '.custom-page-break-after',
+    avoid: '.custom-page-break-avoid',
+    before: '.custom-page-break-before',
+    mode: ['css'],
+  }),
+  previewTitle: 'PDF preview',
+  quality: 2,
+})
+
+const emit = defineEmits<{
+  beforeGenerate: [payload: Html2PdfBeforeGeneratePayload]
+  downloaded: [blob: Blob]
+  error: [error: unknown]
+  generated: [payload: Html2PdfGenerateResult]
+  paginated: []
+  progress: [progress: number]
+  startPagination: []
+}>()
+
+const pdfContentRef = ref<HTMLElement | null>(null)
+const progress = ref<number>(0)
+const previewUrl = ref<string | null>(null)
+
+const {
+  revoke: revokePreviewUrl,
+  setBlob: setPreviewBlob,
+} = usePdfObjectUrl()
+
+const pdfFormatPixels = computed(() => PdfPageSizeUtil.getSize(props.format, 'px'))
+
+const pdfContentStyle = computed<Record<string, string>>(() => ({
+  '--html2pdf-page-height': `${pdfFormatPixels.value.height}px`,
+  '--html2pdf-page-width': `${pdfFormatPixels.value.width}px`,
+  'minHeight': `${pdfFormatPixels.value.height}px`,
+  'width': `${pdfFormatPixels.value.width}px`,
+}))
+
+function setProgress(value: number): void {
+  progress.value = value
+  emit('progress', value)
+}
+
+function createOptions(): Record<string, unknown> {
+  return {
+    enableLinks: true,
+    filename: props.filename,
+    hotfix: [
+      'px_scaling',
+    ],
+    html2canvas: {
+      letterRendering: false,
+      scale: props.quality,
+      useCORS: true,
+    },
+    image: {
+      quality: props.imageQuality,
+      type: props.imageType,
+    },
+    jsPDF: {
+      format: [
+        pdfFormatPixels.value.width,
+        pdfFormatPixels.value.height,
+      ],
+      orientation: '',
+      precision: 1,
+      unit: 'px',
+    },
+    margin: [
+      0,
+      0,
+      0,
+      0,
+    ],
+    pagebreak: props.pagebreak,
+  }
+}
+
+async function withImageFix<T>(callback: () => Promise<T>): Promise<T> {
+  if (!props.isImageFixEnabled) {
+    return await callback()
+  }
+
+  const style = document.createElement('style')
+
+  document.head.appendChild(style)
+  style.sheet?.insertRule('body > div:last-child img { display: inline-block; width: auto; height: auto; }')
+
+  try {
+    return await callback()
+  } finally {
+    style.remove()
+  }
+}
+
+async function generate(): Promise<Blob> {
+  const element = pdfContentRef.value
+
+  if (element === null) {
+    throw new Error('PDF content element is not mounted')
+  }
+
+  emit('startPagination')
+  setProgress(0)
+  setProgress(25)
+  emit('paginated')
+
+  const options = createOptions()
+
+  emit('beforeGenerate', {
+    element,
+    options,
+  })
+
+  try {
+    const blob = await withImageFix(async () => {
+      const pdf = await html2pdf()
+        .set(options)
+        .from(element)
+        .toContainer()
+        .toPdf()
+        .get('pdf')
+
+      return await pdf.output('blob') as Blob
+    })
+
+    const objectUrl = setPreviewBlob(blob)
+
+    previewUrl.value = objectUrl
+    setProgress(100)
+
+    emit('generated', {
+      blob,
+      objectUrl,
+    })
+
+    return blob
+  } catch (error) {
+    emit('error', error)
+
+    throw error
+  }
+}
+
+async function download(): Promise<Blob> {
+  const blob = await generate()
+
+  if (!props.isDownloadEnabled) {
+    return blob
+  }
+
+  PdfDownloadUtil.downloadBlob(blob, {
+    filename: props.filename,
+  })
+
+  emit('downloaded', blob)
+
+  return blob
+}
+
+async function preview(): Promise<string> {
+  const blob = await generate()
+  const objectUrl = setPreviewBlob(blob)
+
+  previewUrl.value = objectUrl
+
+  return objectUrl
+}
+
+function closePreview(): void {
+  previewUrl.value = null
+}
+
+defineExpose({
+  closePreview,
+  download,
+  generate,
+  preview,
+  revokePreviewUrl,
+})
+</script>
+
+<template>
+  <div class="html2pdf-generator">
+    <section class="html2pdf-generator__layout-container">
+      <section
+        ref="pdfContentRef"
+        :style="pdfContentStyle"
+        class="html2pdf-generator__content-wrapper"
+      >
+        <slot />
+      </section>
+    </section>
+
+    <teleport to="body">
+      <section
+        v-if="props.isPreviewEnabled && previewUrl !== null"
+        class="html2pdf-generator__preview"
+      >
+        <button
+          class="html2pdf-generator__preview-close"
+          type="button"
+          @click="closePreview"
+        >
+          &times;
+        </button>
+
+        <iframe
+          :src="previewUrl"
+          :title="props.previewTitle"
+          height="100%"
+          width="100%"
+        />
+      </section>
+    </teleport>
+  </div>
+</template>
+
+<style>
+.html2pdf-generator {
+  position: absolute;
+  z-index: -999;
+}
+
+.html2pdf-generator__layout-container {
+  position: fixed;
+  top: 0;
+  left: -100vw;
+  z-index: -9999;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100vw;
+  height: 100vh;
+  overflow: auto;
+}
+
+.html2pdf-generator__content-wrapper {
+  min-height: var(--html2pdf-page-height);
+  width: var(--html2pdf-page-width);
+}
+
+.html2pdf-generator__preview {
+  position: fixed;
+  top: 100px;
+  left: 50%;
+  z-index: 9999999;
+  width: 65%;
+  min-width: 600px;
+  height: 80vh;
+  border-radius: 5px;
+  box-shadow: 0 0 10px #00000048;
+  transform: translateX(-50%);
+}
+
+.html2pdf-generator__preview iframe {
+  border: 0;
+}
+
+.html2pdf-generator__preview-close {
+  position: absolute;
+  top: -20px;
+  left: -15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 35px;
+  height: 35px;
+  border: 0;
+  border-radius: 50%;
+  color: #fff;
+  background: #555;
+  box-shadow: 0 0 10px #00000048;
+  cursor: pointer;
+  font-size: 20px;
+}
+</style>

--- a/packages/web/pdf/src/html2pdf/Html2PdfGenerator.vue
+++ b/packages/web/pdf/src/html2pdf/Html2PdfGenerator.vue
@@ -43,10 +43,20 @@ const props = withDefaults(defineProps<{
   isImageFixEnabled: true,
   isPreviewEnabled: false,
   pagebreak: () => ({
-    after: '.custom-page-break-after',
-    avoid: '.custom-page-break-avoid',
-    before: '.custom-page-break-before',
-    mode: ['css'],
+    after: [
+      '.pdf-page-break-after',
+      '.custom-page-break-after',
+    ],
+    avoid: [
+      '.pdf-page-break-avoid',
+      '.pdf-keep-together',
+      '.custom-page-break-avoid',
+    ],
+    before: [
+      '.pdf-page-break-before',
+      '.custom-page-break-before',
+    ],
+    mode: ['css', 'legacy'],
   }),
   previewTitle: 'PDF preview',
   quality: 2,

--- a/packages/web/pdf/src/html2pdf/Html2PdfGenerator.vue
+++ b/packages/web/pdf/src/html2pdf/Html2PdfGenerator.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { BrowserDownloadUtil } from '@wisemen/vue-core-utils'
 import html2pdf from 'html2pdf.js'
 import {
   computed,
@@ -7,7 +8,6 @@ import {
 
 import { usePdfObjectUrl } from '@/composables/pdf-object-url'
 import type { PdfNamedPageFormat } from '@/types/pdfPageFormat.type'
-import { PdfDownloadUtil } from '@/utils/pdfDownload.util'
 import { PdfPageSizeUtil } from '@/utils/pdfPageSize.util'
 import type {
   Html2PdfBeforeGeneratePayload,
@@ -185,7 +185,7 @@ async function download(): Promise<Blob> {
     return blob
   }
 
-  PdfDownloadUtil.downloadBlob(blob, {
+  BrowserDownloadUtil.downloadBlob(blob, {
     filename: props.filename,
   })
 
@@ -195,16 +195,22 @@ async function download(): Promise<Blob> {
 }
 
 async function preview(): Promise<string> {
-  const blob = await generate()
-  const objectUrl = setPreviewBlob(blob)
+  await generate()
 
-  previewUrl.value = objectUrl
+  if (previewUrl.value === null) {
+    throw new Error('PDF preview URL was not created')
+  }
 
-  return objectUrl
+  return previewUrl.value
+}
+
+function revokeGeneratedObjectUrl(): void {
+  revokePreviewUrl()
+  previewUrl.value = null
 }
 
 function closePreview(): void {
-  previewUrl.value = null
+  revokeGeneratedObjectUrl()
 }
 
 defineExpose({
@@ -212,7 +218,7 @@ defineExpose({
   download,
   generate,
   preview,
-  revokePreviewUrl,
+  revokePreviewUrl: revokeGeneratedObjectUrl,
 })
 </script>
 

--- a/packages/web/pdf/src/html2pdf/Html2PdfGenerator.vue
+++ b/packages/web/pdf/src/html2pdf/Html2PdfGenerator.vue
@@ -11,19 +11,27 @@ import type { PdfNamedPageFormat } from '@/types/pdfPageFormat.type'
 import { PdfPageSizeUtil } from '@/utils/pdfPageSize.util'
 import type {
   Html2PdfBeforeGeneratePayload,
+  Html2PdfCanvasOptions,
   Html2PdfGenerateResult,
+  Html2PdfImageOptions,
   Html2PdfImageType,
+  Html2PdfJsPdfOptions,
+  Html2PdfOptions,
   Html2PdfPagebreakOptions,
 } from './html2Pdf.types'
 
 const props = withDefaults(defineProps<{
   filename: string
   format?: PdfNamedPageFormat
+  html2canvas?: Html2PdfCanvasOptions
   imageQuality?: number
+  image?: Html2PdfImageOptions
   imageType?: Html2PdfImageType
   isDownloadEnabled?: boolean
   isImageFixEnabled?: boolean
   isPreviewEnabled?: boolean
+  jsPdf?: Html2PdfJsPdfOptions
+  options?: Html2PdfOptions
   pagebreak?: Html2PdfPagebreakOptions
   previewTitle?: string
   quality?: number
@@ -55,6 +63,8 @@ const emit = defineEmits<{
 }>()
 
 const pdfContentRef = ref<HTMLElement | null>(null)
+const generatedBlob = ref<Blob | null>(null)
+const isGenerating = ref<boolean>(false)
 const progress = ref<number>(0)
 const previewUrl = ref<string | null>(null)
 
@@ -77,38 +87,52 @@ function setProgress(value: number): void {
   emit('progress', value)
 }
 
-function createOptions(): Record<string, unknown> {
+const generationState = computed(() => ({
+  blob: generatedBlob.value,
+  isGenerating: isGenerating.value,
+  previewUrl: previewUrl.value,
+  progress: progress.value,
+}))
+
+function createOptions(): Html2PdfOptions {
   return {
-    enableLinks: true,
-    filename: props.filename,
+    ...props.options,
+    enableLinks: props.options?.enableLinks ?? true,
+    filename: props.options?.filename ?? props.filename,
     hotfix: [
       'px_scaling',
+      ...(props.options?.hotfix ?? []),
     ],
     html2canvas: {
       letterRendering: false,
       scale: props.quality,
       useCORS: true,
+      ...props.options?.html2canvas,
+      ...props.html2canvas,
     },
     image: {
       quality: props.imageQuality,
       type: props.imageType,
+      ...props.options?.image,
+      ...props.image,
     },
     jsPDF: {
       format: [
         pdfFormatPixels.value.width,
         pdfFormatPixels.value.height,
       ],
-      orientation: '',
       precision: 1,
       unit: 'px',
+      ...props.options?.jsPDF,
+      ...props.jsPdf,
     },
-    margin: [
+    margin: props.options?.margin ?? [
       0,
       0,
       0,
       0,
     ],
-    pagebreak: props.pagebreak,
+    pagebreak: props.pagebreak ?? props.options?.pagebreak,
   }
 }
 
@@ -137,6 +161,7 @@ async function generate(): Promise<Blob> {
   }
 
   emit('startPagination')
+  isGenerating.value = true
   setProgress(0)
   setProgress(25)
   emit('paginated')
@@ -146,12 +171,12 @@ async function generate(): Promise<Blob> {
   emit('beforeGenerate', {
     element,
     options,
-  })
+  } as Html2PdfBeforeGeneratePayload)
 
   try {
     const blob = await withImageFix(async () => {
       const pdf = await html2pdf()
-        .set(options)
+        .set(options as Record<string, unknown>)
         .from(element)
         .toContainer()
         .toPdf()
@@ -162,6 +187,7 @@ async function generate(): Promise<Blob> {
 
     const objectUrl = setPreviewBlob(blob)
 
+    generatedBlob.value = blob
     previewUrl.value = objectUrl
     setProgress(100)
 
@@ -175,6 +201,8 @@ async function generate(): Promise<Blob> {
     emit('error', error)
 
     throw error
+  } finally {
+    isGenerating.value = false
   }
 }
 
@@ -217,7 +245,12 @@ defineExpose({
   closePreview,
   download,
   generate,
+  generatedBlob,
+  generationState,
+  isGenerating,
   preview,
+  previewUrl,
+  progress,
   revokePreviewUrl: revokeGeneratedObjectUrl,
 })
 </script>

--- a/packages/web/pdf/src/html2pdf/html2Pdf.types.ts
+++ b/packages/web/pdf/src/html2pdf/html2Pdf.types.ts
@@ -1,0 +1,30 @@
+import type { PdfNamedPageFormat } from '@/types/pdfPageFormat.type'
+
+export type Html2PdfImageType = 'jpeg' | 'png' | 'webp'
+
+export interface Html2PdfPagebreakOptions {
+  after?: string | string[]
+  avoid?: string | string[]
+  before?: string | string[]
+  mode?: string | string[]
+}
+
+export interface Html2PdfGenerateResult {
+  blob: Blob
+  objectUrl: string
+}
+
+export interface Html2PdfBeforeGeneratePayload {
+  element: HTMLElement
+  options: Record<string, unknown>
+}
+
+export interface Html2PdfGeneratorExpose {
+  closePreview: () => void
+  download: () => Promise<Blob>
+  generate: () => Promise<Blob>
+  preview: () => Promise<string>
+  revokePreviewUrl: () => void
+}
+
+export type Html2PdfFormat = PdfNamedPageFormat

--- a/packages/web/pdf/src/html2pdf/html2Pdf.types.ts
+++ b/packages/web/pdf/src/html2pdf/html2Pdf.types.ts
@@ -2,6 +2,8 @@ import type { PdfNamedPageFormat } from '@/types/pdfPageFormat.type'
 
 export type Html2PdfImageType = 'jpeg' | 'png' | 'webp'
 
+export type Html2PdfMargin = number | [number, number] | [number, number, number, number]
+
 export interface Html2PdfPagebreakOptions {
   after?: string | string[]
   avoid?: string | string[]
@@ -9,9 +11,56 @@ export interface Html2PdfPagebreakOptions {
   mode?: string | string[]
 }
 
+export interface Html2PdfCanvasOptions {
+  allowTaint?: boolean
+  backgroundColor?: string | null
+  foreignObjectRendering?: boolean
+  imageTimeout?: number
+  letterRendering?: boolean
+  logging?: boolean
+  scale?: number
+  useCORS?: boolean
+  windowHeight?: number
+  windowWidth?: number
+  x?: number
+  y?: number
+}
+
+export interface Html2PdfJsPdfOptions {
+  compress?: boolean
+  format?: string | [number, number]
+  hotfixes?: string[]
+  orientation?: 'landscape' | 'portrait'
+  precision?: number
+  unit?: 'cm' | 'in' | 'mm' | 'px' | 'pt'
+}
+
+export interface Html2PdfImageOptions {
+  quality?: number
+  type?: Html2PdfImageType
+}
+
+export interface Html2PdfOptions {
+  enableLinks?: boolean
+  filename?: string
+  hotfix?: string[]
+  html2canvas?: Html2PdfCanvasOptions
+  image?: Html2PdfImageOptions
+  jsPDF?: Html2PdfJsPdfOptions
+  margin?: Html2PdfMargin
+  pagebreak?: Html2PdfPagebreakOptions
+}
+
 export interface Html2PdfGenerateResult {
   blob: Blob
   objectUrl: string
+}
+
+export interface Html2PdfGenerationState {
+  blob: Blob | null
+  isGenerating: boolean
+  previewUrl: string | null
+  progress: number
 }
 
 export interface Html2PdfBeforeGeneratePayload {
@@ -23,7 +72,12 @@ export interface Html2PdfGeneratorExpose {
   closePreview: () => void
   download: () => Promise<Blob>
   generate: () => Promise<Blob>
+  generatedBlob: Blob | null
+  generationState: Html2PdfGenerationState
+  isGenerating: boolean
   preview: () => Promise<string>
+  previewUrl: string | null
+  progress: number
   revokePreviewUrl: () => void
 }
 

--- a/packages/web/pdf/src/html2pdf/html2pdf-js.d.ts
+++ b/packages/web/pdf/src/html2pdf/html2pdf-js.d.ts
@@ -1,0 +1,16 @@
+declare module 'html2pdf.js' {
+  interface Html2PdfWorker {
+    from: (element: HTMLElement | null) => Html2PdfWorker
+    get: (key: string) => Promise<{
+      output: (type: 'blob') => Promise<Blob>
+    }>
+    save: (filename?: string) => Promise<void>
+    set: (options: Record<string, unknown>) => Html2PdfWorker
+    toContainer: () => Html2PdfWorker
+    toPdf: () => Html2PdfWorker
+  }
+
+  const html2pdf: () => Html2PdfWorker
+
+  export default html2pdf
+}

--- a/packages/web/pdf/src/html2pdf/index.ts
+++ b/packages/web/pdf/src/html2pdf/index.ts
@@ -1,9 +1,15 @@
 export { default as Html2PdfGenerator } from './Html2PdfGenerator.vue'
 export type {
   Html2PdfBeforeGeneratePayload,
+  Html2PdfCanvasOptions,
   Html2PdfFormat,
   Html2PdfGenerateResult,
+  Html2PdfGenerationState,
   Html2PdfGeneratorExpose,
+  Html2PdfImageOptions,
   Html2PdfImageType,
+  Html2PdfJsPdfOptions,
+  Html2PdfMargin,
+  Html2PdfOptions,
   Html2PdfPagebreakOptions,
 } from './html2Pdf.types'

--- a/packages/web/pdf/src/html2pdf/index.ts
+++ b/packages/web/pdf/src/html2pdf/index.ts
@@ -1,0 +1,9 @@
+export { default as Html2PdfGenerator } from './Html2PdfGenerator.vue'
+export type {
+  Html2PdfBeforeGeneratePayload,
+  Html2PdfFormat,
+  Html2PdfGenerateResult,
+  Html2PdfGeneratorExpose,
+  Html2PdfImageType,
+  Html2PdfPagebreakOptions,
+} from './html2Pdf.types'

--- a/packages/web/pdf/src/index.ts
+++ b/packages/web/pdf/src/index.ts
@@ -1,0 +1,21 @@
+export { PdfDocument } from '@/components/pdf-document'
+export { PdfHtmlPreviewViewer } from '@/components/pdf-html-preview-viewer'
+export { PdfPage } from '@/components/pdf-page'
+export { usePdfLocale } from '@/composables/pdf-locale'
+export type { PdfLocaleReturn } from '@/composables/pdf-locale'
+export { usePdfObjectUrl } from '@/composables/pdf-object-url'
+export type { PdfObjectUrlReturn } from '@/composables/pdf-object-url'
+export { usePdfViewerPagination } from '@/composables/pdf-viewer-pagination'
+export type { PdfViewerPaginationReturn } from '@/composables/pdf-viewer-pagination'
+export { PdfDownloadUtil } from '@/utils/pdfDownload.util'
+export { PdfFilenameUtil } from '@/utils/pdfFilename.util'
+export { PdfPageSizeUtil } from '@/utils/pdfPageSize.util'
+export type {
+  PdfCustomPageSize,
+  PdfNamedPageFormat,
+  PdfOrientation,
+  PdfPageFormat,
+  PdfPageSize,
+  PdfPageSizeUnit,
+} from '@/types/pdfPageFormat.type'
+export type { PdfDownloadOptions } from '@/types/pdfDownloadOptions.type'

--- a/packages/web/pdf/src/index.ts
+++ b/packages/web/pdf/src/index.ts
@@ -7,7 +7,6 @@ export { usePdfObjectUrl } from '@/composables/pdf-object-url'
 export type { PdfObjectUrlReturn } from '@/composables/pdf-object-url'
 export { usePdfViewerPagination } from '@/composables/pdf-viewer-pagination'
 export type { PdfViewerPaginationReturn } from '@/composables/pdf-viewer-pagination'
-export { PdfDownloadUtil } from '@/utils/pdfDownload.util'
 export { PdfFilenameUtil } from '@/utils/pdfFilename.util'
 export { PdfPageSizeUtil } from '@/utils/pdfPageSize.util'
 export type {
@@ -18,4 +17,3 @@ export type {
   PdfPageSize,
   PdfPageSizeUnit,
 } from '@/types/pdfPageFormat.type'
-export type { PdfDownloadOptions } from '@/types/pdfDownloadOptions.type'

--- a/packages/web/pdf/src/types/pdfDownloadOptions.type.ts
+++ b/packages/web/pdf/src/types/pdfDownloadOptions.type.ts
@@ -1,0 +1,5 @@
+export interface PdfDownloadOptions {
+  filename?: string | null
+  rel?: string | null
+  target?: HTMLAnchorElement['target'] | null
+}

--- a/packages/web/pdf/src/types/pdfPageFormat.type.ts
+++ b/packages/web/pdf/src/types/pdfPageFormat.type.ts
@@ -1,0 +1,24 @@
+export type PdfNamedPageFormat = 'a0'
+  | 'a1'
+  | 'a2'
+  | 'a3'
+  | 'a4'
+  | 'a5'
+  | 'a6'
+  | 'legal'
+  | 'letter'
+
+export type PdfPageSizeUnit = 'in' | 'mm' | 'px'
+
+export type PdfOrientation = 'landscape' | 'portrait'
+
+export interface PdfPageSize {
+  height: number
+  width: number
+}
+
+export interface PdfCustomPageSize extends PdfPageSize {
+  unit: PdfPageSizeUnit
+}
+
+export type PdfPageFormat = PdfCustomPageSize | PdfNamedPageFormat

--- a/packages/web/pdf/src/utils/pdfDownload.util.ts
+++ b/packages/web/pdf/src/utils/pdfDownload.util.ts
@@ -1,0 +1,43 @@
+import type { PdfDownloadOptions } from '@/types/pdfDownloadOptions.type'
+
+export class PdfDownloadUtil {
+  static downloadUrl(url: string, options: PdfDownloadOptions = {}): void {
+    const link = document.createElement('a')
+
+    link.href = url
+
+    if (options.filename !== undefined && options.filename !== null) {
+      link.download = options.filename
+    }
+
+    if (options.target !== undefined && options.target !== null) {
+      link.target = options.target
+    }
+
+    if (options.rel !== undefined && options.rel !== null) {
+      link.rel = options.rel
+    }
+
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
+
+  static downloadBlob(blob: Blob, options: PdfDownloadOptions = {}): void {
+    const url = URL.createObjectURL(blob)
+
+    try {
+      this.downloadUrl(url, options)
+    } finally {
+      URL.revokeObjectURL(url)
+    }
+  }
+
+  static openInNewTab(url: string): void {
+    const openedWindow = window.open(url, '_blank', 'noopener,noreferrer')
+
+    if (openedWindow !== null) {
+      openedWindow.opener = null
+    }
+  }
+}

--- a/packages/web/pdf/src/utils/pdfFilename.util.spec.ts
+++ b/packages/web/pdf/src/utils/pdfFilename.util.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { PdfFilenameUtil } from '@/utils/pdfFilename.util'
+
+describe('PdfFilenameUtil', () => {
+  it('adds missing extension', () => {
+    expect(PdfFilenameUtil.ensureExtension('invoice')).toBe('invoice.pdf')
+  })
+
+  it('does not duplicate existing extension', () => {
+    expect(PdfFilenameUtil.ensureExtension('invoice.pdf')).toBe('invoice.pdf')
+  })
+
+  it('slugifies filenames', () => {
+    expect(PdfFilenameUtil.slugify('Project Café Order.pdf')).toBe('project-cafe-order.pdf')
+  })
+})

--- a/packages/web/pdf/src/utils/pdfFilename.util.ts
+++ b/packages/web/pdf/src/utils/pdfFilename.util.ts
@@ -1,0 +1,22 @@
+export class PdfFilenameUtil {
+  static ensureExtension(filename: string, extension = 'pdf'): string {
+    const normalizedExtension = extension.replace(/^\./u, '')
+
+    if (filename.toLowerCase().endsWith(`.${normalizedExtension.toLowerCase()}`)) {
+      return filename
+    }
+
+    return `${filename}.${normalizedExtension}`
+  }
+
+  static slugify(filename: string): string {
+    return filename
+      .normalize('NFKD')
+      .replace(/[\u0300-\u036F]/gu, '')
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9.]+/gu, '-')
+      .replace(/-{2,}/gu, '-')
+      .replace(/^-|-$/gu, '')
+  }
+}

--- a/packages/web/pdf/src/utils/pdfPageSize.util.spec.ts
+++ b/packages/web/pdf/src/utils/pdfPageSize.util.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { PdfPageSizeUtil } from '@/utils/pdfPageSize.util'
+
+describe('PdfPageSizeUtil', () => {
+  it('returns standard A4 size in millimeters', () => {
+    expect(PdfPageSizeUtil.getSize('a4', 'mm')).toEqual({
+      height: 297,
+      width: 210,
+    })
+  })
+
+  it('applies landscape orientation', () => {
+    expect(PdfPageSizeUtil.getSize('a4', 'mm', { orientation: 'landscape' })).toEqual({
+      height: 210,
+      width: 297,
+    })
+  })
+
+  it('converts A4 to pixels', () => {
+    expect(PdfPageSizeUtil.getSize('a4', 'px', { dpi: 96 })).toEqual({
+      height: 1122.5197,
+      width: 793.7008,
+    })
+  })
+
+  it('supports custom sizes', () => {
+    expect(PdfPageSizeUtil.getSize({ height: 297, unit: 'mm', width: 240 }, 'mm')).toEqual({
+      height: 297,
+      width: 240,
+    })
+  })
+})

--- a/packages/web/pdf/src/utils/pdfPageSize.util.ts
+++ b/packages/web/pdf/src/utils/pdfPageSize.util.ts
@@ -1,0 +1,142 @@
+import type {
+  PdfCustomPageSize,
+  PdfNamedPageFormat,
+  PdfOrientation,
+  PdfPageFormat,
+  PdfPageSize,
+  PdfPageSizeUnit,
+} from '@/types/pdfPageFormat.type'
+
+interface GetSizeOptions {
+  dpi?: number
+  orientation?: PdfOrientation
+}
+
+const DEFAULT_DPI = 96
+const MM_PER_INCH = 25.4
+
+const NAMED_PAGE_SIZES_IN_MM: Record<PdfNamedPageFormat, PdfPageSize> = {
+  a0: { height: 1189, width: 841 },
+  a1: { height: 841, width: 594 },
+  a2: { height: 594, width: 420 },
+  a3: { height: 420, width: 297 },
+  a4: { height: 297, width: 210 },
+  a5: { height: 210, width: 148 },
+  a6: { height: 148, width: 105 },
+  legal: { height: 356, width: 216 },
+  letter: { height: 279, width: 216 },
+}
+
+export class PdfPageSizeUtil {
+  static getSize(format: PdfPageFormat, unit: PdfPageSizeUnit = 'mm', options: GetSizeOptions = {}): PdfPageSize {
+    const sizeInMm = this.getSizeInMm(format)
+    const orientedSize = this.applyOrientation(sizeInMm, options.orientation ?? 'portrait')
+
+    return this.convertSize(orientedSize, 'mm', unit, options.dpi ?? DEFAULT_DPI)
+  }
+
+  static toCssSize(format: PdfPageFormat, options: GetSizeOptions = {}): Record<'height' | 'width', string> {
+    const size = this.getSize(format, this.getFormatUnit(format), options)
+
+    return {
+      height: `${size.height}${this.getFormatUnit(format)}`,
+      width: `${size.width}${this.getFormatUnit(format)}`,
+    }
+  }
+
+  static toCssVariables(format: PdfPageFormat, options: GetSizeOptions = {}): Record<string, string> {
+    const size = this.toCssSize(format, options)
+
+    return {
+      '--pdf-page-height': size.height,
+      '--pdf-page-width': size.width,
+    }
+  }
+
+  static convertSize(size: PdfPageSize, fromUnit: PdfPageSizeUnit, toUnit: PdfPageSizeUnit, dpi = DEFAULT_DPI): PdfPageSize {
+    if (fromUnit === toUnit) {
+      return {
+        height: size.height,
+        width: size.width,
+      }
+    }
+
+    const sizeInInches = {
+      height: this.convertUnit(size.height, fromUnit, 'in', dpi),
+      width: this.convertUnit(size.width, fromUnit, 'in', dpi),
+    }
+
+    return {
+      height: this.round(this.convertUnit(sizeInInches.height, 'in', toUnit, dpi)),
+      width: this.round(this.convertUnit(sizeInInches.width, 'in', toUnit, dpi)),
+    }
+  }
+
+  private static getSizeInMm(format: PdfPageFormat): PdfPageSize {
+    if (this.isCustomPageSize(format)) {
+      return this.convertSize(format, format.unit, 'mm')
+    }
+
+    return NAMED_PAGE_SIZES_IN_MM[format]
+  }
+
+  private static getFormatUnit(format: PdfPageFormat): PdfPageSizeUnit {
+    if (this.isCustomPageSize(format)) {
+      return format.unit
+    }
+
+    return 'mm'
+  }
+
+  private static applyOrientation(size: PdfPageSize, orientation: PdfOrientation): PdfPageSize {
+    const isLandscapeSize = size.width > size.height
+
+    if (orientation === 'landscape' && !isLandscapeSize) {
+      return {
+        height: size.width,
+        width: size.height,
+      }
+    }
+
+    if (orientation === 'portrait' && isLandscapeSize) {
+      return {
+        height: size.width,
+        width: size.height,
+      }
+    }
+
+    return size
+  }
+
+  private static convertUnit(value: number, fromUnit: PdfPageSizeUnit, toUnit: PdfPageSizeUnit, dpi: number): number {
+    if (fromUnit === toUnit) {
+      return value
+    }
+
+    if (fromUnit === 'mm' && toUnit === 'in') {
+      return value / MM_PER_INCH
+    }
+
+    if (fromUnit === 'in' && toUnit === 'mm') {
+      return value * MM_PER_INCH
+    }
+
+    if (fromUnit === 'px' && toUnit === 'in') {
+      return value / dpi
+    }
+
+    if (fromUnit === 'in' && toUnit === 'px') {
+      return value * dpi
+    }
+
+    return this.convertUnit(this.convertUnit(value, fromUnit, 'in', dpi), 'in', toUnit, dpi)
+  }
+
+  private static isCustomPageSize(format: PdfPageFormat): format is PdfCustomPageSize {
+    return typeof format !== 'string'
+  }
+
+  private static round(value: number): number {
+    return Number(value.toFixed(4))
+  }
+}

--- a/packages/web/pdf/tsconfig.build.json
+++ b/packages/web/pdf/tsconfig.build.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declaration": false,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "lib": ["esnext", "dom"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "esnext"
+  },
+  "exclude": [
+    "src/**/*.test.ts"
+  ],
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "include": [
+    "env.d.ts",
+    "src/**/*",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue"
+  ]
+}

--- a/packages/web/pdf/tsconfig.json
+++ b/packages/web/pdf/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["./tsconfig.build.json"],
+  "files": []
+}

--- a/packages/web/pdf/vite.config.ts
+++ b/packages/web/pdf/vite.config.ts
@@ -25,11 +25,13 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@wisemen/vue-core-utils',
         'html2pdf.js',
         'vue',
       ],
       output: {
         globals: {
+          '@wisemen/vue-core-utils': 'WisemenVueCoreUtils',
           'html2pdf.js': 'html2pdf',
           vue: 'Vue',
         },

--- a/packages/web/pdf/vite.config.ts
+++ b/packages/web/pdf/vite.config.ts
@@ -1,0 +1,54 @@
+import { resolve } from 'node:path'
+
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+
+const projectRootDir = resolve(__dirname)
+
+export default defineConfig({
+  build: {
+    lib: {
+      name: 'vue-core-pdf',
+      cssFileName: 'style',
+      entry: {
+        html2pdf: resolve(__dirname, 'src/html2pdf/index.ts'),
+        index: resolve(__dirname, 'src/index.ts'),
+      },
+      fileName: (format, name) => {
+        if (format === 'es') {
+          return `${name}.js`
+        }
+
+        return `${name}.${format}`
+      },
+    },
+    rollupOptions: {
+      external: [
+        'html2pdf.js',
+        'vue',
+      ],
+      output: {
+        globals: {
+          'html2pdf.js': 'html2pdf',
+          vue: 'Vue',
+        },
+      },
+    },
+  },
+  plugins: [
+    vue(),
+    dts({
+      cleanVueFileName: true,
+      exclude: [
+        'src/**/*.spec.ts',
+      ],
+      tsconfigPath: 'tsconfig.build.json',
+    }),
+  ],
+  resolve: {
+    alias: {
+      '@': resolve(projectRootDir, 'src'),
+    },
+  },
+})

--- a/packages/web/pdf/vitest.config.ts
+++ b/packages/web/pdf/vitest.config.ts
@@ -1,0 +1,29 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import vuePlugin from '@vitejs/plugin-vue'
+import {
+  configDefaults,
+  defineConfig,
+} from 'vitest/config'
+
+const META_URL = import.meta.url
+const projectRootDir = resolve(__dirname)
+
+export default defineConfig({
+  plugins: [
+    vuePlugin(),
+  ],
+  resolve: {
+    alias: {
+      '@': resolve(projectRootDir, 'src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    exclude: [
+      ...configDefaults.exclude,
+    ],
+    root: fileURLToPath(new URL('./', META_URL)),
+  },
+})

--- a/packages/web/utils/src/browser-download/browserDownload.type.ts
+++ b/packages/web/utils/src/browser-download/browserDownload.type.ts
@@ -1,4 +1,4 @@
-export interface PdfDownloadOptions {
+export interface BrowserDownloadOptions {
   filename?: string | null
   rel?: string | null
   target?: HTMLAnchorElement['target'] | null

--- a/packages/web/utils/src/browser-download/browserDownload.util.test.ts
+++ b/packages/web/utils/src/browser-download/browserDownload.util.test.ts
@@ -1,0 +1,46 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import { BrowserDownloadUtil } from './browserDownload.util'
+
+describe('BrowserDownloadUtil', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('downloads a URL through an anchor element', () => {
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+    BrowserDownloadUtil.downloadUrl('https://example.com/file.pdf', {
+      filename: 'file.pdf',
+      rel: 'noopener',
+      target: '_blank',
+    })
+
+    expect(clickSpy).toHaveBeenCalledOnce()
+    expect(document.body.children).toHaveLength(0)
+  })
+
+  it('downloads a blob through an object URL', () => {
+    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url')
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    const downloadUrlSpy = vi.spyOn(BrowserDownloadUtil, 'downloadUrl').mockImplementation(() => {})
+    const blob = new Blob(['content'], { type: 'application/pdf' })
+
+    BrowserDownloadUtil.downloadBlob(blob, { filename: 'file.pdf' })
+
+    expect(createObjectUrlSpy).toHaveBeenCalledWith(blob)
+    expect(downloadUrlSpy).toHaveBeenCalledWith('blob:mock-url', { filename: 'file.pdf' })
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:mock-url')
+  })
+})

--- a/packages/web/utils/src/browser-download/browserDownload.util.ts
+++ b/packages/web/utils/src/browser-download/browserDownload.util.ts
@@ -1,7 +1,10 @@
-import type { PdfDownloadOptions } from '@/types/pdfDownloadOptions.type'
+import type { BrowserDownloadOptions } from './browserDownload.type'
 
-export class PdfDownloadUtil {
-  static downloadUrl(url: string, options: PdfDownloadOptions = {}): void {
+export class BrowserDownloadUtil {
+  /**
+   * Browser-only utility for triggering a download from an existing URL.
+   */
+  static downloadUrl(url: string, options: BrowserDownloadOptions = {}): void {
     const link = document.createElement('a')
 
     link.href = url
@@ -23,7 +26,10 @@ export class PdfDownloadUtil {
     document.body.removeChild(link)
   }
 
-  static downloadBlob(blob: Blob, options: PdfDownloadOptions = {}): void {
+  /**
+   * Browser-only utility for triggering a download from a Blob.
+   */
+  static downloadBlob(blob: Blob, options: BrowserDownloadOptions = {}): void {
     const url = URL.createObjectURL(blob)
 
     try {
@@ -33,6 +39,9 @@ export class PdfDownloadUtil {
     }
   }
 
+  /**
+   * Browser-only utility for opening a URL in a new tab without exposing window.opener.
+   */
   static openInNewTab(url: string): void {
     const openedWindow = window.open(url, '_blank', 'noopener,noreferrer')
 

--- a/packages/web/utils/src/index.ts
+++ b/packages/web/utils/src/index.ts
@@ -2,6 +2,8 @@ export { ArrayUtil } from '@/array/array.util'
 export {
   assert, assertDefined, assertNever,
 } from '@/assert/assert'
+export { BrowserDownloadUtil } from '@/browser-download/browserDownload.util'
+export type { BrowserDownloadOptions } from '@/browser-download/browserDownload.type'
 export { isDevelopment } from '@/is-development/isDevelopment.util'
 export {
   Logger, logger,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2798,6 +2798,51 @@ importers:
         specifier: catalog:build
         version: 5.9.3
 
+  packages/web/pdf:
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: catalog:vite
+        version: 6.0.3(rolldown-vite@7.3.1(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.2)(tsx@4.20.3)(yaml@2.8.3))(vue@3.5.27(typescript@5.9.3))
+      '@vue/test-utils':
+        specifier: catalog:test
+        version: 2.4.6
+      '@vue/tsconfig':
+        specifier: catalog:vue
+        version: 0.8.1(typescript@5.9.3)(vue@3.5.27(typescript@5.9.3))
+      '@wisemen/eslint-config-vue':
+        specifier: workspace:*
+        version: link:../eslint-config
+      eslint:
+        specifier: catalog:lint-web
+        version: 9.39.4(jiti@2.6.1)
+      html2pdf.js:
+        specifier: ^0.14.0
+        version: 0.14.0
+      jsdom:
+        specifier: catalog:test
+        version: 27.4.0
+      rimraf:
+        specifier: catalog:build
+        version: 6.1.3
+      typescript:
+        specifier: catalog:build
+        version: 5.9.3
+      vite:
+        specifier: npm:rolldown-vite@7.3.1
+        version: rolldown-vite@7.3.1(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.2)(tsx@4.20.3)(yaml@2.8.3)
+      vite-plugin-dts:
+        specifier: catalog:vite
+        version: 4.5.4(@types/node@25.3.0)(rolldown-vite@7.3.1(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.2)(tsx@4.20.3)(yaml@2.8.3))(rollup@4.60.3)(typescript@5.9.3)
+      vitest:
+        specifier: catalog:test
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(rolldown-vite@7.3.1(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.98.0)(terser@5.46.2)(tsx@4.20.3)(yaml@2.8.3))
+      vue:
+        specifier: catalog:vue
+        version: 3.5.27(typescript@5.9.3)
+      vue-tsc:
+        specifier: catalog:vue
+        version: 3.2.2(typescript@5.9.3)
+
   packages/web/telemetry:
     dependencies:
       '@opentelemetry/api':
@@ -7389,6 +7434,9 @@ packages:
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
 
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
   '@types/pg-pool@2.0.7':
     resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
 
@@ -7397,6 +7445,9 @@ packages:
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
@@ -8338,6 +8389,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -8461,6 +8516,10 @@ packages:
 
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -8684,6 +8743,9 @@ packages:
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -8728,6 +8790,9 @@ packages:
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
@@ -8894,6 +8959,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.3:
+    resolution: {integrity: sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -9522,6 +9590,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
@@ -9577,6 +9648,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -9921,6 +9995,13 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+
+  html2pdf.js@0.14.0:
+    resolution: {integrity: sha512-yvNJgE/8yru2UeGflkPdjW8YEY+nDH5X7/2WG4uiuSCwYiCp8PZ8EKNiTAa6HxJ1NjC51fZSIEq6xld5CADKBQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -10014,6 +10095,9 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -10388,6 +10472,9 @@ packages:
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
+
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
 
   jstransformer@1.0.0:
     resolution: {integrity: sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==}
@@ -11103,6 +11190,9 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -11186,6 +11276,9 @@ packages:
 
   perfect-debounce@2.0.0:
     resolution: {integrity: sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   pg-boss@12.15.0:
     resolution: {integrity: sha512-xw0n3M6PtAOEtPYAF/PULFqba1a27BTJOJ+tVfbd/kG++GjF5RM1xj24n5xQyek3VwDR9LObftc+ygAJ0V2kVw==}
@@ -11457,6 +11550,9 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -11532,6 +11628,9 @@ packages:
 
   regenerate@1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
+
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -11615,6 +11714,10 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
@@ -11964,6 +12067,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -12091,6 +12198,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   swagger-ui-dist@5.32.4:
     resolution: {integrity: sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==}
 
@@ -12158,6 +12269,9 @@ packages:
     resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -12616,6 +12730,9 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -18168,6 +18285,8 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/pako@2.0.4': {}
+
   '@types/pg-pool@2.0.7':
     dependencies:
       '@types/pg': 8.15.6
@@ -18179,6 +18298,9 @@ snapshots:
       pg-types: 2.2.0
 
   '@types/qs@6.14.0': {}
+
+  '@types/raf@3.4.3':
+    optional: true
 
   '@types/range-parser@1.2.7': {}
 
@@ -19574,6 +19696,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-arraybuffer@1.0.2: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.27: {}
@@ -19716,6 +19840,18 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001791: {}
+
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/raf': 3.4.3
+      core-js: 3.49.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
 
   ccount@2.0.1: {}
 
@@ -19906,6 +20042,9 @@ snapshots:
     dependencies:
       browserslist: 4.28.2
 
+  core-js@3.49.0:
+    optional: true
+
   core-util-is@1.0.3: {}
 
   cors@2.8.6:
@@ -19947,6 +20086,10 @@ snapshots:
       which: 2.0.2
 
   crypto-random-string@2.0.0: {}
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   css-tree@3.1.0:
     dependencies:
@@ -20076,6 +20219,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dot-prop@5.3.0:
     dependencies:
@@ -21015,6 +21162,12 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-png@6.4.0:
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.1.0
+
   fast-querystring@1.1.2:
     dependencies:
       fast-decode-uri-component: 1.0.1
@@ -21100,6 +21253,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -21568,6 +21723,17 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+
+  html2pdf.js@0.14.0:
+    dependencies:
+      dompurify: 3.4.3
+      html2canvas: 1.4.1
+      jspdf: 4.2.1
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -21657,6 +21823,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  iobuffer@5.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -22042,6 +22210,17 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.7.4
+
+  jspdf@4.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      fast-png: 6.4.0
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.49.0
+      dompurify: 3.4.3
+      html2canvas: 1.4.1
 
   jstransformer@1.0.0:
     dependencies:
@@ -22960,6 +23139,8 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pako@2.1.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -23026,6 +23207,9 @@ snapshots:
   perfect-debounce@1.0.0: {}
 
   perfect-debounce@2.0.0: {}
+
+  performance-now@2.1.0:
+    optional: true
 
   pg-boss@12.15.0:
     dependencies:
@@ -23328,6 +23512,11 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   range-parser@1.2.1: {}
 
   raw-body@3.0.2:
@@ -23417,6 +23606,9 @@ snapshots:
       regenerate: 1.4.2
 
   regenerate@1.4.2: {}
+
+  regenerator-runtime@0.13.11:
+    optional: true
 
   regex-recursion@6.0.2:
     dependencies:
@@ -23508,6 +23700,9 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   rimraf@6.1.3:
     dependencies:
@@ -23965,6 +24160,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
@@ -24118,6 +24316,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-pathdata@6.0.3:
+    optional: true
+
   swagger-ui-dist@5.32.4:
     dependencies:
       '@scarf/scarf': 1.4.0
@@ -24174,6 +24375,10 @@ snapshots:
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
 
   thread-stream@4.0.0:
     dependencies:
@@ -24619,6 +24824,10 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@11.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2799,6 +2799,10 @@ importers:
         version: 5.9.3
 
   packages/web/pdf:
+    dependencies:
+      '@wisemen/vue-core-utils':
+        specifier: workspace:*
+        version: link:../utils
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: catalog:vite


### PR DESCRIPTION
### Description

Introduce @wisemen/vue-core-pdf as a reusable Vue package for PDF document layouts, HTML previewing, object URL handling, filename/page-size helpers, and downloads.

Add an optional html2pdf adapter behind the @wisemen/vue-core-pdf/html2pdf subpath so downstream apps can opt into browser PDF generation without coupling the root package export to html2pdf.js.

Includes README usage docs and unit coverage for filename and page-size utilities. Verified with pnpm --filter @wisemen/vue-core-pdf type-check, pnpm --filter @wisemen/vue-core-pdf test, and pnpm --filter @wisemen/vue-core-pdf build; also validated in atelier-couture-web against the existing order PDF flow.

### Checklist
- [x] Have you added tests for new features?
- [x] Have you updated the documentation?
- [x] Have you linked an issue or discussion (if applicable)?