### PR TITLE
feat(formango): bundle lean skill updates

### DIFF
--- a/packages/web/formango/skills/array-fields/SKILL.md
+++ b/packages/web/formango/skills/array-fields/SKILL.md
@@ -4,29 +4,21 @@ description: >
   Use form.registerArray() to manage dynamic field lists in formango.
   Covers FieldArray interface: iterate fields with v-for using unique ids
   as keys, register child fields by index, manipulate with append, remove,
-  insert, prepend, pop, shift, move, empty, setValue. Nested arrays via
-  fieldArray.registerArray(). Load when a form schema contains z.array()
-  or any repeatable field group.
+  insert, prepend, pop, shift, move, empty, setValue.
 type: core
 library: formango
-library_version: "3.2.1"
 requires:
   - form-setup
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/formango/src/lib/useForm.ts"
-  - "wisemen-digital/wisemen-core:packages/web/formango/src/types/form.type.ts"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/api/field-array.md"
 ---
-
-This skill builds on [form-setup](../form-setup/SKILL.md). Read it first for `useForm`, `register`, and `Field` concepts.
 
 # Formango — Array Fields
 
-## Setup
+## Quick Start
 
 ```vue
 <script setup lang="ts">
 import { useForm } from 'formango'
+import { UITextField } from '@wisemen/vue-core-design-system'
 import { z } from 'zod'
 
 const formSchema = z.object({
@@ -45,32 +37,14 @@ const emails = form.registerArray('emails')
 
 <template>
   <div v-for="(emailField, index) in emails.fields" :key="emailField">
-    <EmailInput :emails="emails" :index="index" />
+    <UITextField v-bind="toFormField(emails.register(`${index}`))" label="Email" />
     <button @click="emails.remove(index)">Remove</button>
   </div>
   <button @click="emails.append()">Add email</button>
 </template>
 ```
 
-```vue
-<!-- EmailInput.vue -->
-<script setup lang="ts">
-import type { FieldArray } from 'formango'
-
-const { emails, index } = defineProps<{
-  emails: FieldArray<string>
-  index: number
-}>()
-
-const email = emails.register(`${index}`)
-</script>
-
-<template>
-  <CustomInput v-bind="toFormField(email)" />
-</template>
-```
-
-## Core Patterns
+## Examples
 
 ### Array manipulation methods
 
@@ -95,6 +69,7 @@ Each array item is registered by its index as a string, relative to the `FieldAr
 ```vue
 <script setup lang="ts">
 import type { FieldArray } from 'formango'
+import { UITextField, UICheckbox } from '@wisemen/vue-core-design-system'
 
 interface TodoItem {
   title: string
@@ -112,8 +87,8 @@ const completed = item.register('completed')
 </script>
 
 <template>
-  <CustomInput v-bind="toFormField(title)" />
-  <CustomCheckbox v-bind="toFormField(completed)" />
+  <UITextField v-bind="toFormField(title)" label="Title" />
+  <UICheckbox v-bind="toFormField(completed)" label="Completed" />
 </template>
 ```
 
@@ -124,104 +99,13 @@ const emails = form.registerArray('emails')
 
 emails.fields.value        // string[] — unique ids for v-for :key
 emails.modelValue.value    // current array value
-emails.value.value         // alias for modelValue
 emails.isDirty.value       // true if array differs from initial state
 emails.isTouched.value     // true if any child field was blurred
 emails.isValid.value       // true if no validation errors on array or children
 emails.errors.value        // FormattedError[] — errors for this array and children
-emails.rawErrors.value     // StandardSchemaV1.Issue[] — raw validation issues
 ```
 
-## Common Mistakes
+## See Also
 
-### CRITICAL Using register instead of registerArray for arrays
-
-Wrong:
-
-```ts
-const emails = form.register('emails')
-// emails is Field<string[]>, not FieldArray<string>
-// emails.append is undefined — no array methods available
-```
-
-Correct:
-
-```ts
-const emails = form.registerArray('emails')
-// emails is FieldArray<string> — has append, remove, insert, etc.
-emails.append('new@email.com')
-```
-
-Schema fields defined with `z.array()` must use `registerArray`, not `register`. Using `register` creates a single `Field` without array manipulation methods.
-
-Source: docs/packages/formango/api/field-array.md
-
-### HIGH Using array index as v-for key instead of field id
-
-Wrong:
-
-```vue
-<div v-for="(_, index) in emails.fields" :key="index">
-  <EmailInput :emails="emails" :index="index" />
-</div>
-```
-
-Correct:
-
-```vue
-<div v-for="(emailField, index) in emails.fields" :key="emailField">
-  <EmailInput :emails="emails" :index="index" />
-</div>
-```
-
-`FieldArray.fields` provides unique string ids for each item. Using the numeric index as `:key` causes Vue to reuse wrong DOM elements when items are removed or reordered, leading to stale field state.
-
-Source: docs/packages/formango/api/field-array.md
-
-### HIGH Registering array children with wrong path syntax
-
-Wrong:
-
-```ts
-// Inside a child component receiving the FieldArray
-const email = emails.register(`emails.${index}`)
-// path is relative to FieldArray, not the form root
-```
-
-Correct:
-
-```ts
-const email = emails.register(`${index}`)
-// just the index — FieldArray already knows its own root path
-```
-
-When calling `register` on a `FieldArray`, the path is relative to the array. Passing the full path from the form root doubles the prefix and creates a disconnected field.
-
-Source: docs/packages/formango/api/field-array.md — ExampleArrayField.vue
-
-### HIGH Mutating array directly instead of using FieldArray methods
-
-Wrong:
-
-```ts
-emails.modelValue.value.push('new@email.com')
-// bypasses internal path tracking — form state becomes inconsistent
-```
-
-Correct:
-
-```ts
-emails.append('new@email.com')
-```
-
-Direct mutation bypasses formango's internal path management, field id tracking, and reactivity system. Always use `append`, `remove`, `insert`, and other `FieldArray` methods to modify array contents.
-
-Source: src/lib/useForm.ts — createFieldArray
-
-See also: [form-setup](../form-setup/SKILL.md) — base form creation and field registration
-
-See also: [validation-errors](../validation-errors/SKILL.md) — array field errors are scoped per-item
-
-## Version
-
-Targets formango v3.2.1.
+- [form-setup](../form-setup/SKILL.md) — base form creation and field registration
+- [validation-errors](../validation-errors/SKILL.md) — array field errors are scoped per-item

--- a/packages/web/formango/skills/form-setup/SKILL.md
+++ b/packages/web/formango/skills/form-setup/SKILL.md
@@ -5,32 +5,21 @@ description: >
   schema/initialState/onSubmit/onSubmitError, register fields with
   form.register(), build a toFormField mapper for v-bind, compose subforms
   by passing Field<T> to child components where they call field.register()
-  for nested paths. Covers Form, Field, UseFormOptions types, submit,
-  reset, setValues, blurAll, unregister. Load when building any Vue 3 form
-  with formango.
+  for nested paths.
 type: core
 library: formango
-library_version: "3.2.3"
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/formango/src/lib/useForm.ts"
-  - "wisemen-digital/wisemen-core:packages/web/formango/src/types/form.type.ts"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/guide/getting-started.md"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/api/useForm.md"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/api/field.md"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/best-practices/custom-input.md"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/examples/subforms.md"
 ---
 
 # Formango — Form Setup & Field Binding
 
-## Setup
+## Quick Start
 
 ```vue
 <script setup lang="ts">
 import { useForm } from 'formango'
 import type { Field } from 'formango'
 import { formatErrorsToZodFormattedError } from 'formango'
-import type { ZodFormattedError } from 'zod'
+import { UITextField } from '@wisemen/vue-core-design-system'
 import { z } from 'zod'
 
 const loginSchema = z.object({
@@ -45,11 +34,9 @@ const form = useForm({
     password: '',
   },
   onSubmit: async (data) => {
-    // data is typed as { email: string; password: string }
     await api.login(data)
   },
   onSubmitError: ({ data, errors }) => {
-    // Called when submit is attempted but validation fails
     console.error('Validation failed:', errors)
   },
 })
@@ -70,8 +57,8 @@ function toFormField<TValue, TDefaultValue>(field: Field<TValue, TDefaultValue>)
 
 <template>
   <form @submit.prevent="form.submit">
-    <CustomInput v-bind="toFormField(email)" />
-    <CustomInput v-bind="toFormField(password)" />
+    <UITextField v-bind="toFormField(email)" label="Email" placeholder="Enter your email..." />
+    <UITextField v-bind="toFormField(password)" label="Password" type="password" placeholder="Enter your password..." />
     <button type="submit" :disabled="form.isSubmitting.value">
       Submit
     </button>
@@ -79,21 +66,20 @@ function toFormField<TValue, TDefaultValue>(field: Field<TValue, TDefaultValue>)
 </template>
 ```
 
-## Core Patterns
+## Examples
 
 ### Register fields with default values
 
 ```ts
 const name = form.register('name', 'Default Name')
-// name.modelValue.value is 'Default Name' initially
 // Field type: Field<string, string> — no null union because default was provided
 ```
 
 When a default value is passed, the field's `modelValue` type excludes `null`. Without a default, the type is `TValue | null`.
 
-### Compose subforms with child components
+### Compose with child components
 
-Pass a registered `Field` as a prop to a child component. The child calls `field.register()` for nested paths — this keeps all state in the parent form.
+For splitting top-level fields across components, pass the `Form` itself typed as `Form<typeof schema>`. For nested object fields, pass a registered `Field<T>` — the child calls `field.register()` for nested paths.
 
 ```vue
 <!-- UserForm.vue -->
@@ -121,7 +107,7 @@ const shippingAddress = form.register('shippingAddress')
 </script>
 
 <template>
-  <CustomInput v-bind="toFormField(email)" />
+  <UITextField v-bind="toFormField(email)" label="Email" />
   <AddressForm :address="shippingAddress" />
 </template>
 ```
@@ -145,30 +131,10 @@ const postalCode = address.register('postalCode')
 </script>
 
 <template>
-  <CustomInput v-bind="toFormField(street)" />
-  <CustomInput v-bind="toFormField(city)" />
-  <CustomInput v-bind="toFormField(postalCode)" />
+  <UITextField v-bind="toFormField(street)" label="Street" />
+  <UITextField v-bind="toFormField(city)" label="City" />
+  <UITextField v-bind="toFormField(postalCode)" label="Postal Code" />
 </template>
-```
-
-### Conditional validation with Zod refine
-
-```ts
-const deleteSchema = z.object({
-  confirmName: z.string().refine(
-    (val) => val === expectedName.toUpperCase(),
-    { message: i18n.t('validation.name_mismatch') },
-  ),
-})
-
-const form = useForm({
-  schema: deleteSchema,
-  onSubmit: async () => {
-    await deleteMutation.execute()
-  },
-})
-
-const confirmName = form.register('confirmName')
 ```
 
 ### Form state and lifecycle
@@ -186,138 +152,7 @@ form.reset()                               // reset to initialState
 form.unregister('email')                   // unregister a field
 ```
 
-## Common Mistakes
+## See Also
 
-### CRITICAL Destructuring form from useForm (v2 pattern)
-
-Wrong:
-
-```ts
-const { form } = useForm({ schema, onSubmit })
-```
-
-Correct:
-
-```ts
-const form = useForm({ schema, onSubmit })
-```
-
-In v3, `useForm` returns the `Form` object directly. Destructuring `{ form }` produces `undefined` because there is no `form` property on the return value. This was changed in the v2 → v3 migration.
-
-Source: CHANGELOG.md v3.0.0
-
-### CRITICAL Using onSubmitForm instead of onSubmit
-
-Wrong:
-
-```ts
-const form = useForm({
-  schema,
-  onSubmitForm: (data) => { /* never called */ },
-})
-```
-
-Correct:
-
-```ts
-const form = useForm({
-  schema,
-  onSubmit: (data) => { /* called on valid submit */ },
-})
-```
-
-v3 renamed `onSubmitForm` to `onSubmit` and `onSubmitFormError` to `onSubmitError`. The old callback names are silently ignored — the form submits but the handler never fires.
-
-Source: CHANGELOG.md v3.0.0
-
-### CRITICAL Not passing Field to subform component
-
-Wrong:
-
-```vue
-<!-- AddressForm.vue — creates a separate form, breaks parent state -->
-<script setup lang="ts">
-import { useForm } from 'formango'
-import { addressSchema } from './address.model'
-
-const form = useForm({
-  schema: addressSchema,
-  onSubmit: (data) => { /* disconnected from parent */ },
-})
-const street = form.register('street')
-</script>
-```
-
-Correct:
-
-```vue
-<!-- AddressForm.vue — registers on parent form via Field prop -->
-<script setup lang="ts">
-import type { Field } from 'formango'
-import type { Address } from './address.model'
-
-const { address } = defineProps<{ address: Field<Address> }>()
-const street = address.register('street')
-</script>
-```
-
-Subform components must accept a `Field<T>` prop and call `field.register()` for nested paths. Creating a separate `useForm` in the child disconnects it from the parent form's validation, dirty tracking, and submission.
-
-Source: docs/packages/formango/examples/subforms.md
-
-### HIGH Accessing field values without .value
-
-Wrong:
-
-```ts
-if (name.isDirty) {
-  // always truthy — isDirty is a ComputedRef object, not a boolean
-}
-```
-
-Correct:
-
-```ts
-if (name.isDirty.value) {
-  // correct boolean check
-}
-```
-
-Field properties (`modelValue`, `errors`, `isDirty`, `isTouched`, `isValid`, `isChanged`) are `ComputedRef` or `Ref` — they require `.value` in `<script>`. Vue auto-unwraps refs in `<template>`, so this only matters in script code.
-
-Source: src/types/form.type.ts — Field interface
-
-### HIGH Using initialData instead of initialState
-
-Wrong:
-
-```ts
-const form = useForm({
-  schema,
-  initialData: { name: 'test' },
-  onSubmit,
-})
-// form starts empty — initialData is silently ignored
-```
-
-Correct:
-
-```ts
-const form = useForm({
-  schema,
-  initialState: { name: 'test' },
-  onSubmit,
-})
-```
-
-The option is named `initialState`, not `initialData`. Passing `initialData` is silently ignored because TypeScript's excess property check may not catch it depending on the call site.
-
-Source: src/lib/useForm.ts — UseFormOptions interface
-
-See also: [array-fields](../array-fields/SKILL.md) — for dynamic lists, use `registerArray` instead of `register`
-
-See also: [validation-errors](../validation-errors/SKILL.md) — error display, i18n, server-side errors
-
-## Version
-
-Targets formango v3.2.1.
+- [array-fields](../array-fields/SKILL.md) — for dynamic lists, use `registerArray` instead of `register`
+- [validation-errors](../validation-errors/SKILL.md) — error display, i18n, server-side errors


### PR DESCRIPTION
## Summary

Bundles the 2 formango lean skill PRs into a single PR. Slims down existing skill files by removing `library_version`, `sources`, verbose sections (~300 lines removed).

Updated skills: form-setup, array-fields

Replaces: #970, #972

Part of #918

## Test plan
- [ ] Verify both SKILL.md files are correctly trimmed
- [ ] Spot-check that essential content is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)