### PR TITLE
feat(tbn-1187): replace http status code specific response decoratros

### DIFF
--- a/.changeset/dark-taxis-attend.md
+++ b/.changeset/dark-taxis-attend.md
@@ -1,0 +1,13 @@
+---
+"@wisemen/api-error": major
+---
+
+feat(TBN-1187):
+replace http status specific error response decorators with `@ApiErrorResponse` which catches all status types automatically.
+
+migration guide:
+replace the following with `ApiErrorResponse`:
+
+- ApiNotFoundErrorResponse
+- ApiBadRequestErrorResponse
+- ApiConflictErrorResponse

--- a/packages/api/api-error/lib/decorators/api-error-response.decorator.ts
+++ b/packages/api/api-error/lib/decorators/api-error-response.decorator.ts
@@ -17,7 +17,7 @@ export function ApiErrorResponse (
   const statusMap = new Map<HttpStatus, ClassConstructor<ApiError>[]>()
   
   for (const err of errors) {
-    const status = getApiErrorStatusMetadata(err.prototype)
+    const status = getApiErrorStatusMetadata(err.prototype as object)
     const statusErrors = statusMap.get(status) ?? []
     statusErrors.push(err)
     statusMap.set(status, statusErrors)

--- a/packages/api/api-error/lib/decorators/api-error-response.decorator.ts
+++ b/packages/api/api-error/lib/decorators/api-error-response.decorator.ts
@@ -2,35 +2,35 @@ import { ApiExtraModels, ApiResponse, getSchemaPath } from '@nestjs/swagger'
 import { applyDecorators, HttpStatus } from '@nestjs/common'
 import type { ClassConstructor } from 'class-transformer'
 import { ApiError } from '../api-errors/api-error.js'
-import { BadRequestApiError } from '../api-errors/bad-request.api-error.js'
-import { ConflictApiError } from '../api-errors/conflict.api-error.js'
-import { NotFoundApiError } from '../api-errors/not-found.api-error.js'
+import { getApiErrorStatusMetadata } from './api-error-status.decorator.js'
 
-export function ApiNotFoundErrorResponse (
-  ...errors: Array<ClassConstructor<NotFoundApiError>>
-): MethodDecorator {
-  return ApiErrorResponse(HttpStatus.NOT_FOUND, errors)
-}
-
-export function ApiBadRequestErrorResponse (
-  ...errors: Array<ClassConstructor<BadRequestApiError>>
-): MethodDecorator {
-  return ApiErrorResponse(HttpStatus.BAD_REQUEST, errors)
-}
-
-export function ApiConflictErrorResponse (
-  ...errors: Array<ClassConstructor<ConflictApiError>>
-): MethodDecorator {
-  return ApiErrorResponse(HttpStatus.CONFLICT, errors)
-}
-
+/**
+ * This decorator defines error response docs for `@nestjs/swagger`.
+ * It adds the errors to `@ApiExtraModels()` and creates a `@ApiResponse()` for each http status code.
+ * 
+ * @param errors must be an array of classes that have the `@ApiStatusCode()` decorator applied x
+ * to any class member.
+ */
 export function ApiErrorResponse (
-  status: HttpStatus,
-  errors: Array<ClassConstructor<ApiError>>
+  ...errors: Array<ClassConstructor<ApiError>>
 ): MethodDecorator {
+  const statusMap = new Map<HttpStatus, ClassConstructor<ApiError>[]>()
+  
+  for (const err of errors) {
+    const status = getApiErrorStatusMetadata(err.prototype)
+    const statusErrors = statusMap.get(status) ?? []
+    statusErrors.push(err)
+    statusMap.set(status, statusErrors)
+  }
+
+  const apiResponseDecorators: MethodDecorator[] = []
+  for (const [status, errors] of statusMap.entries()) {
+    apiResponseDecorators.push(createApiResponseDecorator(status, errors))
+  }
+
   return applyDecorators(
     ApiExtraModels(...errors),
-    createApiResponseDecorator(status, errors)
+    ...apiResponseDecorators
   )
 }
 

--- a/packages/api/api-error/lib/decorators/api-error-status.decorator.ts
+++ b/packages/api/api-error/lib/decorators/api-error-status.decorator.ts
@@ -15,7 +15,7 @@ export function ApiErrorStatus (status: HttpStatus): PropertyDecorator {
 export function getApiErrorStatusMetadata(target: object): HttpStatus {
   const status = Reflect.getMetadata(API_ERROR_STATUS_KEY, target) as HttpStatus | undefined
   if(status === undefined) {
-    throw new Error(`missing ${API_ERROR_STATUS_KEY} metadata on ${target}`)
+    throw new Error(`missing ${API_ERROR_STATUS_KEY} metadata`)
   }
   return status
 }

--- a/packages/api/api-error/lib/decorators/api-error-status.decorator.ts
+++ b/packages/api/api-error/lib/decorators/api-error-status.decorator.ts
@@ -1,10 +1,21 @@
-import { HttpStatus } from '@nestjs/common'
+import { applyDecorators, HttpStatus } from '@nestjs/common'
 import { ApiProperty } from '@nestjs/swagger'
 
+const API_ERROR_STATUS_KEY = 'wisemen.api-error-status'
+
 export function ApiErrorStatus (status: HttpStatus): PropertyDecorator {
-  return ApiProperty({
-    required: true,
-    enum: [String(status)],
-    example: status.toString()
-  })
+    return applyDecorators(
+      ApiProperty({ required: true, enum: [String(status)], example: status.toString() }),
+      (target: object, _propertyKey: string | symbol): void =>  {
+        Reflect.defineMetadata(API_ERROR_STATUS_KEY, status, target)
+      }
+  )
+}
+
+export function getApiErrorStatusMetadata(target: object): HttpStatus {
+  const status = Reflect.getMetadata(API_ERROR_STATUS_KEY, target) as HttpStatus | undefined
+  if(status === undefined) {
+    throw new Error(`missing ${API_ERROR_STATUS_KEY} metadata on ${target}`)
+  }
+  return status
 }

--- a/packages/api/api-error/lib/decorators/index.ts
+++ b/packages/api/api-error/lib/decorators/index.ts
@@ -1,4 +1,4 @@
 export * from './api-error-code.decorator.js'
 export * from './api-error-meta.decorator.js'
 export * from './api-error-response.decorator.js'
-export * from './api-error-status.decorator.js'
+export { ApiErrorStatus } from './api-error-status.decorator.js'

--- a/packages/api/api-error/lib/decorators/tests/api-error-status.decorator.unit.test.ts
+++ b/packages/api/api-error/lib/decorators/tests/api-error-status.decorator.unit.test.ts
@@ -1,0 +1,16 @@
+import { HttpStatus } from "@nestjs/common";
+import { describe, it } from "node:test";
+import { ApiErrorStatus, getApiErrorStatusMetadata } from "../api-error-status.decorator.js";
+import { expect } from "expect";
+
+describe('@ApiErrorStatus unit test', () => {
+  it('adds retrievable metadata on the class in which the status is defined', () => {
+    class TestClass {
+      @ApiErrorStatus(HttpStatus.OK)
+      status: HttpStatus
+    }
+
+    const status = getApiErrorStatusMetadata(TestClass.prototype)
+    expect(status).toBe(HttpStatus.OK)
+  })
+})  

--- a/packages/api/api-error/package.json
+++ b/packages/api/api-error/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf ./dist",
     "build": "tsc",
     "pretest": "npm run clean && npm run build",
-    "test": "node --test",
+    "test": "node --experimental-test-isolation=none --test ./**/*.test.js",
     "prerelease": "npm run build",
     "release": "pnpx release-it"
   },


### PR DESCRIPTION
feat(TBN-1187):
replace http status specific error response decorators with `@ApiErrorResponse` which catches all status types automatically.

migration guide:
replace the following with `ApiErrorResponse`: