### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/young-planes-smoke.md
+++ b/.bumpy/young-planes-smoke.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Emit `@open` for UIContextMenu and UIActionContextMenu components

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## 1.3.2
+<sub>2026-06-08</sub>
+
+- [#1196](https://github.com/wisemen-digital/wisemen-core/pull/1196)  *(patch)* Thanks [@wouterlms](https://github.com/wouterlms)! - Emit `@open` for UIContextMenu and UIActionContextMenu components
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/vue-core-design-system` 1.3.1 → **1.3.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1212/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Emit `@open` for UIContextMenu and UIActionContextMenu components ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1212/changes#diff-cb6f1de3b789dde908eec1d88587fb446fbf36bb528c38abe7ef11fb408fd8d6))
