### PR TITLE
feat(design-system): add moss color variant to badge and dot

### DIFF
--- a/.bumpy/badge-dot-moss-color.md
+++ b/.bumpy/badge-dot-moss-color.md
@@ -1,0 +1,6 @@
+---
+"@wisemen/vue-core-design-system": minor
+"@wisemen/vue-core-tailwind-config": patch
+---
+
+Add moss color variant to badge and dot components

--- a/packages/web/design-system/src/ui/badge/badge.props.ts
+++ b/packages/web/design-system/src/ui/badge/badge.props.ts
@@ -1,6 +1,6 @@
 import type { Component } from 'vue'
 
-export type BadgeColor = 'blue' | 'brand' | 'error' | 'gray' | 'pink' | 'purple' | 'success' | 'warning'
+export type BadgeColor = 'blue' | 'brand' | 'error' | 'gray' | 'moss' | 'pink' | 'purple' | 'success' | 'warning'
 
 export interface BadgeAvatarConfig {
   /**

--- a/packages/web/design-system/src/ui/badge/badge.style.ts
+++ b/packages/web/design-system/src/ui/badge/badge.style.ts
@@ -417,6 +417,66 @@ export const badgeVariants = tv({
       variant: 'translucent',
     },
 
+    // moss
+    {
+      class: {
+        base: `
+          border-moss-400
+          dark:border-moss-600
+        `,
+        dot: 'bg-moss-500',
+        icon: `
+          text-moss-700
+          dark:text-moss-300
+        `,
+        label: `
+          text-moss-700
+          dark:text-moss-300
+        `,
+        separator: `
+          bg-moss-400
+          dark:bg-moss-600
+        `,
+      },
+      color: 'moss',
+      variant: 'outline',
+    },
+    {
+      class: {
+        base: 'border-moss-500 bg-moss-500',
+        dot: 'bg-white',
+        icon: 'text-white',
+        label: 'text-white',
+        separator: 'bg-moss-500',
+      },
+      color: 'moss',
+      variant: 'solid',
+    },
+    {
+      class: {
+        base: `
+          bg-moss-25
+          dark:border-moss-800 dark:bg-moss-950
+          border-moss-200
+        `,
+        dot: 'bg-moss-500',
+        icon: `
+          text-moss-700
+          dark:text-moss-200
+        `,
+        label: `
+          text-moss-700
+          dark:text-moss-200
+        `,
+        separator: `
+          dark:bg-moss-800
+          bg-moss-200
+        `,
+      },
+      color: 'moss',
+      variant: 'translucent',
+    },
+
     // warning
     {
       class: {
@@ -510,6 +570,7 @@ export const badgeVariants = tv({
       brand: {},
       error: {},
       gray: {},
+      moss: {},
       pink: {},
       purple: {},
       success: {},

--- a/packages/web/design-system/src/ui/dot/dot.props.ts
+++ b/packages/web/design-system/src/ui/dot/dot.props.ts
@@ -1,4 +1,4 @@
-export type DotColor = 'blue' | 'brand' | 'error' | 'gray' | 'pink' | 'purple' | 'success' | 'warning'
+export type DotColor = 'blue' | 'brand' | 'error' | 'gray' | 'moss' | 'pink' | 'purple' | 'success' | 'warning'
 
 export type DotSize = 'lg' | 'md' | 'sm'
 

--- a/packages/web/design-system/src/ui/dot/dot.style.ts
+++ b/packages/web/design-system/src/ui/dot/dot.style.ts
@@ -8,6 +8,7 @@ export const dotVariants = tv({
       brand: 'bg-brand-500',
       error: 'bg-error-500',
       gray: 'bg-gray-400',
+      moss: 'bg-moss-500',
       pink: 'bg-pink-500',
       purple: 'bg-purple-500',
       success: 'bg-success-500',

--- a/packages/web/tailwind-config/src/styles/tailwind-design-tokens.css
+++ b/packages/web/tailwind-config/src/styles/tailwind-design-tokens.css
@@ -158,6 +158,7 @@
   --color-purple-900: var(--purple-900);
   --color-purple-950: var(--purple-950);
 
+  --color-moss-25: var(--moss-25);
   --color-moss-50: var(--moss-50);
   --color-moss-100: var(--moss-100);
   --color-moss-200: var(--moss-200);
@@ -166,6 +167,9 @@
   --color-moss-500: var(--moss-500);
   --color-moss-600: var(--moss-600);
   --color-moss-700: var(--moss-700);
+  --color-moss-800: var(--moss-800);
+  --color-moss-900: var(--moss-900);
+  --color-moss-950: var(--moss-950);
 
   --color-fg-primary: var(--fg-primary);
   --color-fg-secondary: var(--fg-secondary);


### PR DESCRIPTION
## Summary
- Adds `moss` as a new color option to `BadgeColor` and `DotColor` types
- Implements all three badge variants (outline, solid, translucent) for the moss color
- Adds missing moss color tokens (`moss-25`, `moss-800`, `moss-900`, `moss-950`) to the tailwind design tokens

## Test plan
- [ ] Verify badge renders correctly in all 3 variants with `color="moss"` (light & dark mode)
- [ ] Verify dot renders correctly with `color="moss"`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)