### PR TITLE
fix(design-system): dialog z-index, destructive footer, and style improvements

### DIFF
--- a/.bumpy/dialog-improvements.md
+++ b/.bumpy/dialog-improvements.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/vue-core-design-system": minor
+---
+
+Improve dialog z-index handling (overlay now tracks z-index dynamically), add destructive mode and isDisabled prop to DialogFooterSubmit, fix FormDialog close button prop name, reduce ConfirmDialog size to xxs, and adjust DialogHeader gap

--- a/packages/web/design-system/src/ui/dialog/ConfirmDialog.vue
+++ b/packages/web/design-system/src/ui/dialog/ConfirmDialog.vue
@@ -51,7 +51,7 @@ function onClose(): void {
     :has-close-button="false"
     :prevent-click-outside="props.preventClickOutside"
     :prevent-esc="props.preventEsc"
-    size="xs"
+    size="xxs"
     @close="onClose"
   >
     <DialogHeader

--- a/packages/web/design-system/src/ui/dialog/Dialog.vue
+++ b/packages/web/design-system/src/ui/dialog/Dialog.vue
@@ -80,7 +80,7 @@ function onInteractOutside(event: CustomEvent): void {
 
 const overlay = useOverlay()
 
-const dialogContentZIndex = `${40 + overlay.overlays.filter((d) => d.isMounted).length}`
+const dialogZIndex = `${40 + overlay.overlays.filter((d) => d.isMounted).length}`
 </script>
 
 <template>
@@ -91,6 +91,9 @@ const dialogContentZIndex = `${40 + overlay.overlays.filter((d) => d.isMounted).
   >
     <RekaDialogOverlay
       :class="style.overlay()"
+      :style="{
+        zIndex: dialogZIndex,
+      }"
       data-animation="dialog"
       data-dialog-overlay
     />
@@ -98,7 +101,7 @@ const dialogContentZIndex = `${40 + overlay.overlays.filter((d) => d.isMounted).
     <RekaDialogContent
       :class="style.contentWrapper()"
       :style="{
-        zIndex: dialogContentZIndex,
+        zIndex: dialogZIndex,
       }"
       data-animation="dialog"
       @escape-key-down="onEscapeKeyDown"

--- a/packages/web/design-system/src/ui/dialog/DialogFooterSubmit.vue
+++ b/packages/web/design-system/src/ui/dialog/DialogFooterSubmit.vue
@@ -4,9 +4,14 @@ import { useHotkey } from '@tanstack/vue-hotkeys'
 import { UIButton } from '@/ui/button'
 import { useInjectFormContext } from '@/ui/form'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
+  isDestructive?: boolean
+  isDisabled?: boolean
   label: string
-}>()
+}>(), {
+  isDestructive: false,
+  isDisabled: false,
+})
 
 const {
   form,
@@ -21,11 +26,12 @@ useHotkey('Meta+Enter', () => {
   <UIButton
     :label="props.label"
     :is-loading="form.isSubmitting.value"
+    :is-disabled="props.isDestructive"
     :keyboard-shortcut="{
       key: 'Enter',
       meta: true,
     }"
-    variant="primary"
+    :variant="props.isDestructive ? 'destructive-primary' : 'primary'"
     @click="form.submit"
   />
 </template>

--- a/packages/web/design-system/src/ui/dialog/DialogHeader.vue
+++ b/packages/web/design-system/src/ui/dialog/DialogHeader.vue
@@ -78,7 +78,7 @@ const dialogContext = useInjectDialogContext(null)
         />
       </div>
 
-      <div class="flex min-w-0 flex-1 flex-col gap-sm">
+      <div class="flex min-w-0 flex-1 flex-col gap-md">
         <RekaDialogTitle
           as="h2"
           class="text-sm font-semibold text-primary"

--- a/packages/web/design-system/src/ui/dialog/FormDialog.vue
+++ b/packages/web/design-system/src/ui/dialog/FormDialog.vue
@@ -36,7 +36,7 @@ function onClose(): void {
 
 <template>
   <Dialog
-    :has-close-button="props.showCloseButton"
+    :show-close-button="props.showCloseButton"
     :size="props.size"
     :prevent-click-outside="props.preventClickOutside"
     :prevent-esc="props.preventEsc"

--- a/packages/web/design-system/src/ui/dialog/dialog.style.ts
+++ b/packages/web/design-system/src/ui/dialog/dialog.style.ts
@@ -28,7 +28,7 @@ export const createDialogStyle = tv({
     header: 'sticky top-0 z-10 bg-primary',
     innerContent: '',
     overlay: `
-      fixed inset-0 z-40 bg-linear-to-t from-black/50 to-black/25
+      fixed inset-0 bg-linear-to-t from-black/50 to-black/25
       will-change-[opacity]
       dark:from-black/80 dark:to-black/50
     `,


### PR DESCRIPTION
## Summary
- **Dialog**: Overlay now also receives the dynamic z-index (was only applied to content), removes hardcoded `z-40` from overlay style
- **ConfirmDialog**: Change size from `xs` to `xxs`
- **DialogFooterSubmit**: Add `isDestructive` and `isDisabled` props — switches to `destructive-primary` variant when destructive
- **DialogHeader**: Increase gap from `gap-sm` to `gap-md`
- **FormDialog**: Fix incorrect prop name `has-close-button` → `show-close-button`

## Test plan
- [ ] Open multiple stacked dialogs and verify overlays stack at correct z-indices
- [ ] Verify ConfirmDialog renders at `xxs` size
- [ ] Verify DialogFooterSubmit shows red destructive button when `isDestructive` is true
- [ ] Verify FormDialog close button still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)