### PR TITLE
feat(design-system): table scroll improvements and resize debounce

### DIFF
--- a/.bumpy/table-scroll-improvements.md
+++ b/.bumpy/table-scroll-improvements.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/vue-core-design-system": minor
+---
+
+Track vertical scroll state in table, hide last row border when table is scrollable or contained, debounce column width resize capture to reduce jank

--- a/packages/web/design-system/src/ui/table/components/TableBody.vue
+++ b/packages/web/design-system/src/ui/table/components/TableBody.vue
@@ -1,9 +1,25 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import TableSubgrid from '@/ui/table/components/TableSubgrid.vue'
+import { useInjectTableContext } from '@/ui/table/context/table.context'
+
+const {
+  isScrollableVertically, variant,
+} = useInjectTableContext()
+
+const shouldHideLastRowBorder = computed<boolean>(
+  () => isScrollableVertically.value || variant.value === 'contained',
+)
 </script>
 
 <template>
-  <TableSubgrid class="group/body">
+  <TableSubgrid
+    :class="{
+      '[&>*:last-child]:border-b-0': shouldHideLastRowBorder }
+    "
+    class="group/body"
+  >
     <slot />
   </TableSubgrid>
 </template>

--- a/packages/web/design-system/src/ui/table/components/TableRoot.vue
+++ b/packages/web/design-system/src/ui/table/components/TableRoot.vue
@@ -27,6 +27,7 @@ const emit = defineEmits<{
 const scrollContainerEl = ref<HTMLElement | null>(null)
 
 const {
+  isScrollableVertically,
   isScrolledFromLeft,
   isScrolledToEnd,
   setScrollContainer: setScrollContainerScrollState,
@@ -81,6 +82,7 @@ useProvideTableContext({
   isColumnResizeDisabled: computed(() => props.disableColumnResize),
   isGroupingEnabled: computed(() => isGroupingEnabled.value),
   isResizingColumn: isResizing,
+  isScrollableVertically: computed(() => isScrollableVertically.value),
   isScrolledFromLeft: computed(() => isScrolledFromLeft.value),
   isScrolledToEnd: computed(() => isScrolledToEnd.value),
   actions: computed(() => props.actions),

--- a/packages/web/design-system/src/ui/table/composables/tableColumnWidths.composable.ts
+++ b/packages/web/design-system/src/ui/table/composables/tableColumnWidths.composable.ts
@@ -1,4 +1,7 @@
-import { useResizeObserver } from '@vueuse/core'
+import {
+  useDebounceFn,
+  useResizeObserver,
+} from '@vueuse/core'
 import type {
   Action,
   ActionGroup,
@@ -74,6 +77,10 @@ export function useTableColumnWidths(
 
   let lastContainerWidth = 0
 
+  const debouncedCaptureTemplate = useDebounceFn((el: HTMLElement) => {
+    captureComputedTemplate(el)
+  }, 25)
+
   useResizeObserver(gridEl, (entries) => {
     const width = entries[0]?.borderBoxSize[0]?.inlineSize
 
@@ -84,7 +91,7 @@ export function useTableColumnWidths(
     lastContainerWidth = width
 
     if (manualWidths.value === null && gridEl.value !== null) {
-      captureComputedTemplate(gridEl.value)
+      debouncedCaptureTemplate(gridEl.value)
     }
   }, {
     box: 'border-box',

--- a/packages/web/design-system/src/ui/table/composables/tableScrollState.composable.ts
+++ b/packages/web/design-system/src/ui/table/composables/tableScrollState.composable.ts
@@ -3,10 +3,12 @@ import { ref } from 'vue'
 export function useTableScrollState() {
   const isScrolledFromLeft = ref<boolean>(false)
   const isScrolledToEnd = ref<boolean>(true)
+  const isScrollableVertically = ref<boolean>(false)
 
   function updateScrollState(el: HTMLElement): void {
     isScrolledFromLeft.value = el.scrollLeft > 0
     isScrolledToEnd.value = el.scrollLeft + el.clientWidth >= el.scrollWidth - 1
+    isScrollableVertically.value = el.scrollHeight > el.clientHeight
   }
 
   function setScrollContainer(el: HTMLElement): void {
@@ -15,9 +17,14 @@ export function useTableScrollState() {
     el.addEventListener('scroll', () => updateScrollState(el), {
       passive: true,
     })
+
+    const resizeObserver = new ResizeObserver(() => updateScrollState(el))
+
+    resizeObserver.observe(el)
   }
 
   return {
+    isScrollableVertically,
     isScrolledFromLeft,
     isScrolledToEnd,
     setScrollContainer,

--- a/packages/web/design-system/src/ui/table/context/table.context.ts
+++ b/packages/web/design-system/src/ui/table/context/table.context.ts
@@ -9,6 +9,7 @@ interface TableContext {
   isColumnResizeDisabled: ComputedRef<boolean>
   isGroupingEnabled: ComputedRef<boolean>
   isResizingColumn: ComputedRef<boolean>
+  isScrollableVertically: ComputedRef<boolean>
   isScrolledFromLeft: ComputedRef<boolean>
   isScrolledToEnd: ComputedRef<boolean>
   actions: ComputedRef<Action[]>


### PR DESCRIPTION
## Summary
- **Vertical scroll state**: Table now tracks `isScrollableVertically` via a `ResizeObserver` on the scroll container
- **Last row border**: `TableBody` hides the bottom border of the last row when the table is vertically scrollable or uses the `contained` variant (prevents a double-border at the bottom edge)
- **Resize debounce**: Column width capture is debounced by 25ms to reduce layout jank during container resize

## Test plan
- [ ] Verify last row has no bottom border when the table overflows vertically
- [ ] Verify last row has no bottom border in `contained` variant
- [ ] Verify column widths update correctly after container resize (with a slight delay)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)