### PR TITLE
feat(design-system): add v-maska input masking support to TextField

### DIFF
--- a/.bumpy/text-field-mask.md
+++ b/.bumpy/text-field-mask.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/vue-core-design-system": minor
+---
+
+Add v-maska directive support to TextField via the new mask prop, enabling declarative input masking

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.3.2",
+  "version": "1.3.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",
@@ -80,6 +80,7 @@
     "country-flag-icons": "catalog:general",
     "libphonenumber-js": "catalog:general",
     "vite": "catalog:vite",
+    "maska": "catalog:general",
     "tailwind-merge": "catalog:style",
     "tailwind-variants": "catalog:style",
     "tailwindcss": "catalog:style",

--- a/packages/web/design-system/src/ui/text-field/TextField.vue
+++ b/packages/web/design-system/src/ui/text-field/TextField.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { vMaska } from 'maska/vue'
 import {
   computed,
   useAttrs,
@@ -99,6 +100,7 @@ defineExpose({
       </template>
 
       <input
+        v-maska="props.mask"
         v-bind="attrs"
         :id="id"
         ref="input"

--- a/packages/web/design-system/src/ui/text-field/textField.props.ts
+++ b/packages/web/design-system/src/ui/text-field/textField.props.ts
@@ -1,3 +1,5 @@
+import type { MaskInputOptions } from 'maska'
+
 import type {
   AutocompleteInput,
   FieldWrapper,
@@ -6,6 +8,10 @@ import type {
 } from '@/types/input.type'
 
 export interface TextFieldProps extends Input, AutocompleteInput, InputWrapper, FieldWrapper {
+  /**
+   * Optional v-maska configuration for input masking.
+   */
+  mask?: string | MaskInputOptions
   /**
    * The size of the text field.
    * @default 'md'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ catalogs:
     libphonenumber-js:
       specifier: 1.12.35
       version: 1.12.35
+    maska:
+      specifier: ^3.0.0
+      version: 3.2.0
     pkce-challenge:
       specifier: 5.0.1
       version: 5.0.1
@@ -2678,6 +2681,9 @@ importers:
       libphonenumber-js:
         specifier: catalog:general
         version: 1.12.35
+      maska:
+        specifier: catalog:general
+        version: 3.2.0
       tailwind-merge:
         specifier: catalog:style
         version: 3.4.0
@@ -10971,6 +10977,9 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  maska@3.2.0:
+    resolution: {integrity: sha512-zSmSgs5/q9vMSmrdZT3rKOv9uLznNWR/niuuAdBZDTvB3SMKOX9vhMtDijFyExz+B4UClu2rvksylUh/ea1bLA==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -21950,6 +21959,8 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
+
+  maska@3.2.0: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -143,6 +143,7 @@ catalogs:
     "graphemer": "1.4.0"
     "highlight-words": "2.0.0"
     "libphonenumber-js": "1.12.35"
+    "maska": "^3.0.0"
     "neverthrow": "8.2.0"
     "pkce-challenge": "5.0.1"
     "ts-api-utils": "2.4.0"


### PR DESCRIPTION
## Summary
- Adds `mask` prop to `TextField` (`string | MaskInputOptions` from the `maska` library)
- Applies `v-maska` directive to the underlying input when a mask is provided
- Adds `maska ^3.0.0` to the `general` catalog and as a dependency of `@wisemen/vue-core-design-system`

## Usage
```vue
<TextField :mask="'###-##-####'" label="SSN" />
<!-- or with MaskInputOptions -->
<TextField :mask="{ mask: '##.##.####', eager: true }" label="Date" />
```

## Test plan
- [ ] Verify masked input formats correctly as user types
- [ ] Verify unmasked TextField still behaves normally when no `mask` prop is passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)