### PR TITLE
fix(design-system): date-field and time-field improvements

### DIFF
--- a/.bumpy/date-time-field-improvements.md
+++ b/.bumpy/date-time-field-improvements.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/vue-core-design-system": patch
+---
+
+Fix DateField padding style and remove redundant isPickerHidden style variant, fix TimeField padding, use device locale instead of config locale, add isLabelHidden support, and add right slot passthrough

--- a/packages/web/design-system/src/ui/date-field/DateField.vue
+++ b/packages/web/design-system/src/ui/date-field/DateField.vue
@@ -83,7 +83,6 @@ const {
 })
 
 const dateFieldStyle = computed(() => createDateFieldStyle({
-  isPickerHidden: props.isPickerHidden,
   size: props.size,
 }))
 
@@ -112,6 +111,7 @@ useProvideDatePickerContext({
     :for="id"
     :help-text="props.helpText"
     :hide-error-message="props.hideErrorMessage"
+    :is-label-hidden="props.isLabelHidden"
   >
     <template #label-left>
       <slot name="label-left" />

--- a/packages/web/design-system/src/ui/date-field/dateField.style.ts
+++ b/packages/web/design-system/src/ui/date-field/dateField.style.ts
@@ -2,7 +2,7 @@ import { tv } from '@/libs/tailwindVariants.lib'
 
 export const createDateFieldStyle = tv({
   slots: {
-    field: `ml-sm flex h-full flex-1 items-center`,
+    field: `flex h-full flex-1 items-center px-sm`,
     literal: `text-placeholder select-none`,
     segment: `
       rounded-xs px-xxs text-primary tabular-nums caret-transparent outline-none
@@ -14,14 +14,6 @@ export const createDateFieldStyle = tv({
     `,
   },
   variants: {
-    isPickerHidden: {
-      false: {
-        field: 'pl-xxs',
-      },
-      true: {
-        field: 'pl-md',
-      },
-    },
     size: {
       md: {
         field: 'text-xs',

--- a/packages/web/design-system/src/ui/time-field/TimeField.vue
+++ b/packages/web/design-system/src/ui/time-field/TimeField.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Time as TimeValue } from '@internationalized/date'
+import { LocaleUtil } from '@wisemen/vue-core-dates'
 import {
   TimeFieldInput as RekaTimeFieldInput,
   TimeFieldRoot as RekaTimeFieldRoot,
@@ -43,11 +44,12 @@ const modelValue = defineModel<Temporal.PlainTime | null>({
 })
 
 const {
-  hourCycle, locale,
+  hourCycle,
 } = useInjectConfigContext()
 
 const id = props.id ?? useId()
 
+const deviceLocale = LocaleUtil.getCurrentLocale()
 const attrs = useAttrs()
 
 const {
@@ -109,6 +111,7 @@ const timeValue = computed<TimeValue | undefined>({
     :for="id"
     :help-text="props.helpText"
     :hide-error-message="props.hideErrorMessage"
+    :is-label-hidden="props.isLabelHidden"
   >
     <template #label-left>
       <slot name="label-left" />
@@ -137,7 +140,7 @@ const timeValue = computed<TimeValue | undefined>({
         :disabled="props.isDisabled"
         :hour-cycle="hourCycleValue"
         :is-invalid="isError"
-        :locale="locale"
+        :locale="deviceLocale"
         :readonly="props.isReadonly"
         :required="props.isRequired"
         :step-snapping="props.stepSnapping"
@@ -167,6 +170,10 @@ const timeValue = computed<TimeValue | undefined>({
           </RekaTimeFieldInput>
         </template>
       </RekaTimeFieldRoot>
+
+      <template #right>
+        <slot name="right" />
+      </template>
     </FieldWrapper>
   </InputWrapper>
 </template>

--- a/packages/web/design-system/src/ui/time-field/timeField.style.ts
+++ b/packages/web/design-system/src/ui/time-field/timeField.style.ts
@@ -21,10 +21,10 @@ export const createTimeFieldStyle = tv({
   variants: {
     size: {
       md: {
-        field: 'pl-md text-xs',
+        field: 'px-md text-xs',
       },
       sm: {
-        field: 'pl-sm text-xs',
+        field: 'px-sm text-xs',
       },
     },
   },


### PR DESCRIPTION
## Summary
- **DateField**: Fix field padding to use symmetric `px-sm` instead of `ml-sm`, remove now-redundant `isPickerHidden` style variant; forward `isLabelHidden` prop to `FieldWrapper`
- **TimeField**: Fix field padding to use symmetric `px-md`, use device locale (`LocaleUtil.getCurrentLocale()`) instead of the global config locale so time segments display in the user's system format; forward `isLabelHidden` prop; expose `right` slot passthrough

## Test plan
- [ ] Verify DateField field content is correctly padded on both sides
- [ ] Verify TimeField respects the device's locale for AM/PM vs 24h display
- [ ] Verify `isLabelHidden` hides the label on both fields
- [ ] Verify TimeField `right` slot renders custom content

🤖 Generated with [Claude Code](https://claude.ai/claude-code)