### PR TITLE
feat: add bottom slot to action menus and new action groups

### DIFF
--- a/.bumpy/action-menu-enhancements.md
+++ b/.bumpy/action-menu-enhancements.md
@@ -1,0 +1,6 @@
+---
+"@wisemen/vue-core-design-system": minor
+"@wisemen/vue-core-actions": minor
+---
+
+Add bottom slot to ActionContextMenu and ActionDropdownMenu for custom footer content; add settings and application action groups; fix filter input visibility to use sr-only instead of v-if so keyboard-initiated typing is captured immediately

--- a/packages/web/actions/src/composables/actionGroup.composable.ts
+++ b/packages/web/actions/src/composables/actionGroup.composable.ts
@@ -9,8 +9,10 @@ export enum GroupPriority {
   GENERAL = 4,
   NAVIGATION = 5,
   PREFERENCES = 6,
-  ACCOUNT = 7,
-  DEVELOPER = 8,
+  SETTINGS = 7,
+  APPLICATION = 8,
+  ACCOUNT = 9,
+  DEVELOPER = 10,
 }
 
 export function useActionGroup() {
@@ -20,6 +22,10 @@ export function useActionGroup() {
     account: {
       name: i18n.t('action.group.account'),
       priority: GroupPriority.ACCOUNT,
+    },
+    application: {
+      name: i18n.t('action.group.application'),
+      priority: GroupPriority.APPLICATION,
     },
     developer: {
       name: i18n.t('action.group.developer'),
@@ -36,6 +42,10 @@ export function useActionGroup() {
     preferences: {
       name: i18n.t('action.group.preferences'),
       priority: GroupPriority.PREFERENCES,
+    },
+    settings: {
+      name: i18n.t('action.group.settings'),
+      priority: GroupPriority.SETTINGS,
     },
   } satisfies Record<string, ActionGroup>
 }

--- a/packages/web/actions/src/locales/en-US.json
+++ b/packages/web/actions/src/locales/en-US.json
@@ -1,9 +1,11 @@
 {
   "action.group.account": "Account",
+  "action.group.application": "Application",
   "action.group.developer": "Developer",
   "action.group.general": "General",
   "action.group.navigation": "Navigation",
   "action.group.preferences": "Preferences",
+  "action.group.settings": "Settings",
   "search": "Search...",
   "type_a_command_or_search": "Type a command or search..."
 }

--- a/packages/web/actions/src/locales/nl-BE.json
+++ b/packages/web/actions/src/locales/nl-BE.json
@@ -1,9 +1,11 @@
 {
   "action.group.account": "Account",
+  "action.group.application": "Applicatie",
   "action.group.developer": "Ontwikkelaar",
   "action.group.general": "Algemeen",
   "action.group.navigation": "Navigatie",
   "action.group.preferences": "Voorkeuren",
+  "action.group.settings": "Instellingen",
   "search": "Zoeken...",
   "type_a_command_or_search": "Type een command of zoek..."
 }

--- a/packages/web/design-system/src/ui/action-context-menu/ActionContextMenu.vue
+++ b/packages/web/design-system/src/ui/action-context-menu/ActionContextMenu.vue
@@ -39,7 +39,11 @@ if (!props.currentContextOnly) {
         :actions="props.actions ?? []"
         :parent-action="props.parentAction"
         :models="props.models ?? []"
-      />
+      >
+        <template #bottom>
+          <slot name="bottom" />
+        </template>
+      </ActionContextMenuContent>
     </template>
   </UIContextMenu>
 </template>

--- a/packages/web/design-system/src/ui/action-context-menu/ActionContextMenuContent.vue
+++ b/packages/web/design-system/src/ui/action-context-menu/ActionContextMenuContent.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useEventListener } from '@vueuse/core'
 import type {
   Action,
   ActionModel,
@@ -7,6 +8,7 @@ import { useActionDropdownMenuContent } from '@wisemen/vue-core-actions'
 import { DropdownMenuFilter } from 'reka-ui'
 import {
   computed,
+  ref,
   toRef,
   useTemplateRef,
 } from 'vue'
@@ -35,6 +37,8 @@ const i18n = useI18n()
 
 const scrollContainerRef = useTemplateRef<HTMLElement>('scrollContainer')
 
+const userHasTyped = ref<boolean>(false)
+
 const {
   isLoading,
   actionGroups,
@@ -58,12 +62,18 @@ const isFilterVisible = computed<boolean>(
       (a) => a.subActions !== undefined,
     ),
 )
+
+useEventListener('keydown', () => {
+  userHasTyped.value = true
+})
 </script>
 
 <template>
   <div class="group/content flex max-h-[inherit] flex-col overflow-hidden">
     <div
-      v-if="isFilterVisible"
+      :class="{
+        'sr-only': !isFilterVisible && !userHasTyped,
+      }"
       class="p-xs pb-none"
     >
       <DropdownMenuFilter
@@ -133,5 +143,7 @@ const isFilterVisible = computed<boolean>(
         />
       </div>
     </div>
+
+    <slot name="bottom" />
   </div>
 </template>

--- a/packages/web/design-system/src/ui/action-dropdown-menu/ActionDropdownMenu.vue
+++ b/packages/web/design-system/src/ui/action-dropdown-menu/ActionDropdownMenu.vue
@@ -64,7 +64,11 @@ const hasApplicableActions = computed<boolean>(() => {
         :actions="props.actions ?? []"
         :parent-action="props.parentAction"
         :models="props.models ?? []"
-      />
+      >
+        <template #bottom>
+          <slot name="bottom" />
+        </template>
+      </ActionDropdownMenuContent>
     </template>
   </UIDropdownMenu>
 

--- a/packages/web/design-system/src/ui/action-dropdown-menu/ActionDropdownMenuContent.vue
+++ b/packages/web/design-system/src/ui/action-dropdown-menu/ActionDropdownMenuContent.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useEventListener } from '@vueuse/core'
 import type {
   Action,
   ActionModel,
@@ -7,6 +8,7 @@ import { useActionDropdownMenuContent } from '@wisemen/vue-core-actions'
 import { DropdownMenuFilter } from 'reka-ui'
 import {
   computed,
+  ref,
   toRef,
   useTemplateRef,
 } from 'vue'
@@ -32,6 +34,7 @@ const props = withDefaults(defineProps<{
 })
 
 const i18n = useI18n()
+const userHasTyped = ref<boolean>(false)
 
 const scrollContainerRef = useTemplateRef<HTMLElement>('scrollContainer')
 
@@ -58,12 +61,18 @@ const isFilterVisible = computed<boolean>(
       (a) => a.subActions !== undefined,
     ),
 )
+
+useEventListener('keydown', () => {
+  userHasTyped.value = true
+})
 </script>
 
 <template>
   <div class="group/content flex max-h-[inherit] flex-col overflow-hidden">
     <div
-      v-if="isFilterVisible"
+      :class="{
+        'sr-only': !isFilterVisible && !userHasTyped,
+      }"
       class="p-xs pb-none"
     >
       <DropdownMenuFilter
@@ -133,5 +142,7 @@ const isFilterVisible = computed<boolean>(
         />
       </div>
     </div>
+
+    <slot name="bottom" />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- **ActionContextMenu / ActionDropdownMenu**: Expose a `bottom` slot that renders below the action list — useful for custom footers or supplemental controls
- **ActionContextMenuContent / ActionDropdownMenuContent**: Fix filter input to use `sr-only` instead of `v-if` so keyboard events are captured from the first keypress even before the filter becomes visible
- **`@wisemen/vue-core-actions`**: Add `settings` (priority 7) and `application` (priority 8) action groups; existing `account` and `developer` groups shift to 9 and 10; add EN/NL translations for both

## Test plan
- [ ] Verify `bottom` slot renders content below the action list in both context and dropdown menus
- [ ] Verify typing immediately filters actions without requiring the filter to be visible first
- [ ] Verify the new `settings` and `application` groups appear and are ordered correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)