### PR TITLE
fix(skills): minimal frontmatter + correctness pass for all web skills

### DIFF
--- a/docs/packages/_meta/authoring-skills.md
+++ b/docs/packages/_meta/authoring-skills.md
@@ -28,39 +28,41 @@ Each `SKILL.md` is a YAML frontmatter block followed by Markdown.
 ```markdown
 ---
 name: writing-mutations
-description: Create, update, delete resources using factory-provided useMutation, typed queryKeysToInvalidate, AsyncResult error handling.
-type: core
-library: vue-core-api-utils
-library_version: ">=1.0.0 <2.0.0"
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/composables/useMutation.ts"
-requires:
-  - foundations
+description: Create, update, or delete resources with the api-utils `useMutation` composable — typed `queryKeysToInvalidate`, an awaitable `execute()`, and AsyncResult error handling. Use this whenever wiring a create/update/delete call or invalidating cached queries after a write.
 ---
 
 # Writing Mutations
 
 …body…
+
+## Skill metadata
+
+- **Library:** `@wisemen/vue-core-api-utils` (package `vue-core-api-utils`)
+- **Type:** core
+- **Authored against:** v1.2.0
+- **Prerequisites:** [`foundations`](../foundations/SKILL.md)
+- **Sources:**
+  - `packages/web/api-utils/src/composables/mutation/mutation.composable.ts`
 ```
 
-### Required frontmatter fields
+### Frontmatter: only `name` and `description`
+
+Keep the frontmatter to exactly these two fields. They are the **only** part of a skill an assistant reads when *deciding whether to use it* — the body is loaded only after the skill is selected. So the `description` has to carry all the triggering signal, and everything else (version, sources, prerequisites, classification) belongs in the body, where it is read once the skill is in use.
 
 | Field | Required | Notes |
 |-------|----------|-------|
-| `name` | yes | Kebab-case, unique within the package. Becomes the directory name and the skill identifier. |
-| `description` | yes | One paragraph. Shown in indexes (`AGENTS.md`, `llms.txt`, IDE skill pickers). Lead with concrete API/method names so LLMs can match user requests. |
+| `name` | yes | Kebab-case, unique within the package. Matches the directory name and is the skill identifier. |
+| `description` | yes | One paragraph that doubles as the trigger. Lead with concrete API/method names so an assistant matches user intent, then say *when* to use the skill ("Use this when…") — be specific and a little pushy, since skills tend to under-trigger. Shown in indexes (`AGENTS.md`, `llms.txt`, IDE skill pickers). |
 
-### Optional frontmatter fields
+The CLI requires only `name` and `description`; any other frontmatter keys are ignored by tooling and just bloat the always-loaded selection budget. Put supplementary metadata in a `## Skill metadata` section at the **end of the body** instead:
 
-| Field | Notes |
-|-------|-------|
-| `type` | Free-form classification (`core`, `lifecycle`, `composition`, etc.). |
-| `library` | The package this skill describes. Defaults to the surrounding package. |
-| `library_version` | **Informational only** — describes which version the skill was authored against. The CLI does NOT filter on it (skills always travel with the package version that bundled them). Use a SemVer range when authoring against a stable surface; an exact version is fine for early/breaking work. |
-| `sources` | List of source files this skill is based on (use `<repo>:<path>` so the references survive moves). |
-| `requires` | Other skill names (in this same package) that should be read first. |
-
-Any additional keys you put in frontmatter are preserved in the rendered output — useful for editor-specific annotations.
+| Old frontmatter field | Now in the body as |
+|-----------------------|--------------------|
+| `type` | a `**Type:**` line (free-form: `core`, `lifecycle`, …) |
+| `library` | a `**Library:**` line (the package the skill describes) |
+| `library_version` | an `**Authored against:**` line — informational only; skills travel with the package version that bundled them |
+| `sources` | a `**Sources:**` list citing the source files the skill is based on |
+| `requires` | a `**Prerequisites:**` link to the prerequisite skill(s), plus a one-line "Read _X_ first." pointer near the top of the body |
 
 ## Shipping skills with your package
 
@@ -81,14 +83,14 @@ Verify with `pnpm pack --dry-run`: the output should include every `skills/<name
 
 - **Skill names** are kebab-case: `writing-mutations`, `array-fields`, `transaction-pattern`.
 - Avoid leading verbs that describe the document ("guide-to-X", "intro-X"). Lead with the *thing* (`writing-mutations`, not `guide-to-mutations`).
-- One skill = one focused capability. If you find yourself writing four sub-headings about unrelated topics, split into multiple skills and use `requires` to link them.
+- One skill = one focused capability. If you find yourself writing four sub-headings about unrelated topics, split into multiple skills and link them with a **Prerequisites** line in each skill's `## Skill metadata` section.
 
 ## Writing style
 
 - Lead with concrete code. LLMs match user intent by recognizing API names and call sites — bury the "philosophy" sections beneath the working examples.
 - Show the canonical pattern; show 1-2 anti-patterns to avoid; stop. Skills are not tutorials.
-- Cite source files in `sources:` so future authors can verify the skill is still accurate after refactors.
-- Cap each skill at ~150 lines of body. If it grows beyond that, split it.
+- Cite the source files a skill is based on in its `## Skill metadata` section so future authors can verify it after refactors.
+- Keep each skill focused on one capability and let depth serve correctness — include everything an assistant needs to implement the task right. Split a skill when it starts covering *unrelated* capabilities, not merely when it gets long.
 
 ## Versioning
 

--- a/packages/web/api-utils/skills/asyncresult-handling/SKILL.md
+++ b/packages/web/api-utils/skills/asyncresult-handling/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: asyncresult-handling
-description: >
-  Three-state AsyncResult type (Loading, Ok, Err), isLoading/isOk/isErr type predicates, getValue/getError accessors, match() pattern matching, map/mapErr transformations, safe value extraction without undefined.
-type: core
-library: vue-core-api-utils
-library_version: "1.2.0"
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/async-result/asyncResult.ts"
+description: Work with the three-state `AsyncResult<T, E>` (Loading / Ok / Err) that every api-utils query and mutation `result` returns — narrow with the `isLoading()` / `isOk()` / `isErr()` type predicates, read values via `getValue()` / `getError()`, handle every case with exhaustive `match()`, transform with `map()` / `mapErr()`, and fall back with `unwrapOr()`. Use this whenever rendering query/mutation state, safely extracting a value or error without `undefined`, or pattern-matching loading/ok/err in a component.
 ---
 
 # @wisemen/vue-core-api-utils — Handling AsyncResult Types
@@ -25,9 +19,9 @@ const { result } = useQuery('contactDetail', {
 
 // result is a ComputedRef<AsyncResult<Contact, ApiError>>
 // It's always in one of three states:
-// - AsyncResult.Loading()
-// - AsyncResult.Ok(contact: Contact)
-// - AsyncResult.Err(error: ApiError)
+// - loading → AsyncResult.loading()
+// - ok      → AsyncResult.ok(contact)
+// - err     → AsyncResult.err(error)
 ```
 
 ## Core Patterns
@@ -44,7 +38,7 @@ if (result.value.isLoading()) {
   console.log('Name:', contact.name) // TypeScript knows contact is Contact
 } else if (result.value.isErr()) {
   const error = result.value.getError()
-  console.log('Error:', error.detail)
+  console.log('Error:', 'errors' in error ? error.errors[0].detail : error.message)
 }
 ```
 
@@ -55,10 +49,10 @@ The type predicates `isLoading()`, `isOk()`, and `isErr()` narrow the type so `g
 ```typescript
 const { result } = useQuery('contactDetail', { /* ... */ })
 
-result.value.match({
-  loading: () => <div>Loading...</div>,
-  ok: (contact) => <div>Name: {contact.name}</div>,
-  err: (error) => <div>Error: {error.detail}</div>,
+const label = result.value.match({
+  loading: () => 'Loading…',
+  ok: (contact) => `Name: ${contact.name}`,
+  err: (error) => `Error: ${'errors' in error ? error.errors[0].detail : error.message}`,
 })
 ```
 
@@ -73,16 +67,16 @@ const { result } = useQuery('contactDetail', { /* ... */ })
 const contactName = result.value.map(contact => contact.name)
 
 // Transform the error
-const errorMessage = result.value.mapErr(error => error.detail)
+const errorMessage = result.value.mapErr(error => 'errors' in error ? error.errors[0].detail : error.message)
 
 // Chain transformations
 const displayText = result.value
   .map(contact => `Hello, ${contact.name}`)
-  .mapErr(error => `Failed: ${error.detail}`)
+  .mapErr(error => 'errors' in error ? error.errors[0].detail : error.message)
   .unwrapOr('No data')
 ```
 
-`map()` and `mapErr()` return new AsyncResult values, letting you transform without unwrapping.
+`map()` and `mapErr()` return fresh `AsyncResult` values, letting you transform without unwrapping.
 
 ### Use unwrapOr for fallback values
 
@@ -121,31 +115,31 @@ if (result.value.isOk()) {
 
 Calling `getValue()` without `isOk()` returns null if the result is loading or an error. You get no compile error, and the UI renders nothing or crashes at runtime.
 
-Source: `docs/packages/api-utils/pages/concepts/result-types.md`
+Source: `src/async-result/asyncResult.ts`
 
 ### HIGH: Not handle all three states in match()
 
 ```typescript
 // ❌ Wrong: missing loading handler
 result.value.match({
-  ok: (data) => <div>{data.name}</div>,
-  err: (error) => <div>Error: {error.detail}</div>,
-  // Forgot loading!
+  ok: (data) => data.name,
+  err: (error) => ('errors' in error ? error.errors[0].detail : error.message),
+  // Forgot loading! — TypeScript errors: match() requires all three handlers
 })
 ```
 
 ```typescript
 // ✅ Correct: handle all three states
 result.value.match({
-  loading: () => <div>Loading...</div>,
-  ok: (data) => <div>{data.name}</div>,
-  err: (error) => <div>Error: {error.detail}</div>,
+  loading: () => 'Loading…',
+  ok: (data) => data.name,
+  err: (error) => ('errors' in error ? error.errors[0].detail : error.message),
 })
 ```
 
 If you omit a handler, TypeScript errors and the UI renders nothing during the omitted state. The match is exhaustive by design.
 
-Source: `docs/packages/api-utils/pages/concepts/result-types.md` Pattern Matching Section
+Source: `src/async-result/asyncResult.ts` — `match()`
 
 ### HIGH: Use deprecated state flags (isLoading, isError, isSuccess) instead of AsyncResult state
 
@@ -177,3 +171,11 @@ Source: `src/composables/query/query.composable.ts` — `UseQueryReturnType` dep
 
 - [Writing Queries](../writing-queries/SKILL.md) — Fetch single resources with caching
 - [Handling Mutations](../writing-mutations/SKILL.md) — Create/update/delete with result handling
+
+## Skill metadata
+
+- **Library:** `@wisemen/vue-core-api-utils` (package `vue-core-api-utils`)
+- **Type:** core
+- **Authored against:** v1.2.0
+- **Sources:**
+  - `packages/web/api-utils/src/async-result/asyncResult.ts`

--- a/packages/web/api-utils/skills/cache-management/SKILL.md
+++ b/packages/web/api-utils/skills/cache-management/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: cache-management
-description: >
-  Type-safe QueryClient class with get/set/update/invalidate methods, rollback support from update(), predicate-based updates, cascade invalidation strategy, shared cache across components.
-type: core
-library: vue-core-api-utils
-library_version: "1.2.0"
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/utils/query-client/queryClient.ts"
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/config/config.ts"
+description: Read, write, and invalidate the query cache with the type-safe `QueryClient` class (`new QueryClient<Keys>(getTanstackQueryClient())`) — `get`, `set`, `update` (which returns a `rollback`), and `invalidate`, with predicate-based updates and key-or-`[key, params]` targeting. Use this whenever manually reading or patching cached data, building optimistic updates, invalidating specific queries after a mutation, or reasoning about the shared app-wide cache.
 ---
 
 # @wisemen/vue-core-api-utils — Cache Management
@@ -257,3 +250,12 @@ Use this to your advantage: invalidate a query and all components using it refet
 - [Writing Mutations](../writing-mutations/SKILL.md) — Every mutation needs to know which queries to invalidate
 - [Writing Queries](../writing-queries/SKILL.md) — Understanding caching strategy informs cache management choices
 - [Optimistic UIs](../optimistic-uis/SKILL.md) — Full optimistic update pattern using update() and rollback
+
+## Skill metadata
+
+- **Library:** `@wisemen/vue-core-api-utils` (package `vue-core-api-utils`)
+- **Type:** core
+- **Authored against:** v1.2.0
+- **Sources:**
+  - `packages/web/api-utils/src/utils/query-client/queryClient.ts`
+  - `packages/web/api-utils/src/config/config.ts`

--- a/packages/web/api-utils/skills/foundations/SKILL.md
+++ b/packages/web/api-utils/skills/foundations/SKILL.md
@@ -1,33 +1,26 @@
 ---
 name: foundations
-description: >
-  neverthrow Result architectural basis; three-state AsyncResult relationship to Result; @tanstack/vue-query lifecycle (staleTime, gcTime, refetch); composition of TanStack Query + neverthrow + Vue 3 reactivity.
-type: core
-library: vue-core-api-utils
-library_version: "1.2.0"
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/async-result/asyncResult.ts"
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/types/apiError.type.ts"
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/config/config.ts"
+description: Understand the architecture behind api-utils — how the three-state `AsyncResult` (neverthrow's `Result` plus a loading state) relates to `Result`, how `@tanstack/vue-query`'s lifecycle (`staleTime`, `gcTime`, refetch triggers) runs beneath it, and how TanStack Query + neverthrow + Vue 3 reactivity compose into the typed composables. Use this when you need the mental model behind queries and mutations, are reasoning about caching/staleness, or are working out how errors flow through `Result` vs `AsyncResult`.
 ---
 
 # @wisemen/vue-core-api-utils — Foundations
 
-Understand how `AsyncResult` from `neverthrow` and `@tanstack/vue-query` combine to provide structured error handling and reactive query management. This knowledge informs all other skills.
+Understand how api-utils' `AsyncResult`, `neverthrow`, and `@tanstack/vue-query` combine to provide structured error handling and reactive query management. This knowledge informs all other skills.
 
 ## Core Concepts
 
-### AsyncResult: The three-state type system
+### AsyncResult: the three-state type system
 
-`AsyncResult<T, E>` is a Result type from the `neverthrow` library that explicitly models three states:
+`AsyncResult<T, E>` is api-utils' own type (defined in `src/async-result/asyncResult.ts`). It takes neverthrow's two-state `Result` and adds a third **loading** state, so a query is always in exactly one of three states:
 
 ```typescript
-type AsyncResult<T, E> = AsyncResultLoading 
-  | AsyncResultOk<T>
-  | AsyncResultErr<E>
+type AsyncResult<T, E> =
+  | AsyncResultLoading<T, E>
+  | AsyncResultOk<T, E>
+  | AsyncResultErr<T, E>
 ```
 
-The three states replace traditional Vue composition with separate flags:
+It replaces the traditional bag of separate flags:
 
 ```typescript
 // ❌ Old pattern: multiple flags
@@ -37,262 +30,261 @@ const data = ref(null)
 const error = ref(null)
 
 // Which combinations are valid? isLoading + isError? isLoading + data?
-// The state machine is implicit, error-prone
+// The state machine is implicit and error-prone.
 ```
 
 ```typescript
-// ✅ AsyncResult: single discriminated union
-const result = ref<AsyncResult<Contact, ApiError>>(new AsyncResultLoading())
+// ✅ AsyncResult: a single discriminated union
+import { AsyncResult } from '@wisemen/vue-core-api-utils'
 
-// Only three valid states; type system enforces them
-// Pattern matching makes every state explicit
-result.value.match({
-  loading: () => 'Loading...',
+// Construct with the factory — the class constructors are private:
+const result = ref<AsyncResult<Contact, ApiError>>(AsyncResult.loading())
+// AsyncResult.loading() | AsyncResult.ok(value) | AsyncResult.err(error)
+
+// Only three valid states; the type system enforces exhaustive handling.
+const label = result.value.match({
+  loading: () => 'Loading…',
   ok: (contact) => contact.name,
-  err: (error) => error.message,
+  err: (error) => ('errors' in error ? error.errors[0].detail : error.message),
 })
 ```
 
 ### Three-state representation
 
-AsyncResult wraps any promise-based operation:
-
-| State | Setup | Usage | Next |
-|-------|-------|-------|------|
-| **Loading** | Initial state when query starts | Show spinner/skeleton | → Ok or Err |
-| **Ok(T)** | Server returned success with data | Show data with `getValue()` | Stays Ok until refetch |
-| **Err(E)** | Server returned error or network failed | Show error with `getError()` | Query can be retried |
+| State | When | Read with | Next |
+|-------|------|-----------|------|
+| **Loading** | Initial state while the query is in flight | Show spinner/skeleton | → Ok or Err |
+| **Ok(T)** | Server returned success | `isOk()` then `getValue()` | Stays Ok until refetch |
+| **Err(E)** | Server or network error | `isErr()` then `getError()` | Query can be retried |
 
 ```typescript
+import { computed } from 'vue'
 import { useQuery } from '@/api'
 
 const { result } = useQuery('contactDetail', {
+  params: { contactUuid: computed(() => uuid) },
   queryFn: () => ContactService.getDetail(uuid),
 })
 
-// result is computed ref to AsyncResult<Contact, ApiError>
-result.value.match({
-  loading: () => <div>Loading</div>,
-  ok: (contact) => <div>{contact.name}</div>,
-  err: (error) => <div>Error: {error.message}</div>,
+// result is a ComputedRef<AsyncResult<Contact, ApiError>>
+const label = result.value.match({
+  loading: () => 'Loading…',
+  ok: (contact) => contact.name,
+  err: (error) => ('errors' in error ? error.errors[0].detail : error.message),
 })
 ```
 
-### neverthrow Result vs AsyncResult
+### neverthrow `Result` vs `AsyncResult`
 
-neverthrow provides `Result<T, E>` for synchronous operations. `AsyncResult` extends it for async:
+`neverthrow` provides `Result<T, E>` for synchronous success/failure. api-utils builds on it, and the two have **different APIs** — this is the single most common source of mistakes:
+
+- A **service / `queryFn` / `execute()`** returns a neverthrow `Result` (api-utils aliases it as `ApiResult<T>`). Handle it with `isOk()` / `isErr()` and the **`.value`** / **`.error`** properties, or neverthrow's two-argument `match(okFn, errFn)`.
+- A composable's reactive **`result`** is an `AsyncResult`. Handle it with `isLoading()` / `isOk()` / `isErr()` and the **`getValue()`** / **`getError()`** methods, or the object-form `match({ loading, ok, err })`.
 
 ```typescript
-// neverthrow Result: already resolved
-const result: Result<Contact, ApiError> = await contactService.getDetail()
+// neverthrow Result (what a queryFn / execute() resolves to): two-arg match, .value / .error
+const result: ApiResult<Contact> = await ContactService.getDetail(uuid)
 
-result.match({
+result.match(
+  (contact) => console.log(contact.name),
+  (error) => console.error('errors' in error ? error.errors[0].detail : error.message),
+)
+```
+
+```typescript
+// AsyncResult (a composable's reactive result): object-form match with a loading case
+const state: AsyncResult<Contact, ApiError> = AsyncResult.loading()
+
+state.match({
+  loading: () => console.log('Waiting…'),
   ok: (contact) => console.log(contact.name),
-  err: (error) => console.error(error.message),
+  err: (error) => console.error('errors' in error ? error.errors[0].detail : error.message),
 })
 ```
 
-```typescript
-// AsyncResult: waiting for promise
-const result: AsyncResult<Contact, ApiError> = new AsyncResultLoading()
+`AsyncResult` is `Result` plus a loading state. Every composable that fetches data exposes an `AsyncResult`.
 
-result.match({
-  loading: () => console.log('Waiting...'),
-  ok: (contact) => console.log(contact.name),
-  err: (error) => console.error(error.message),
-})
-```
+### Type guards
 
-AsyncResult is Result + loading state. Every composable that fetches data returns AsyncResult.
-
-### Type guards from neverthrow
-
-Safely extract values using type guards:
+`isOk()` / `isErr()` / `isLoading()` are type predicates that narrow the union, making `getValue()` / `getError()` safe:
 
 ```typescript
-const result = new AsyncResultOk(contact)
-
-// Type predicate
+const result = AsyncResult.ok<Contact, ApiError>(contact)
 if (result.isOk()) {
-  const contact = result.getValue() // No type error; TypeScript knows it's Contact
+  const contact = result.getValue() // narrowed to AsyncResultOk → getValue() is available
 }
 
-const errResult = new AsyncResultErr(error)
+const errResult = AsyncResult.err<Contact, ApiError>(error)
 if (errResult.isErr()) {
-  const error = errResult.getError() // No type error; TypeScript knows it's ApiError
-}
-
-if (!result.isLoading()) {
-  // Could be Ok or Err
+  const error = errResult.getError() // narrowed to AsyncResultErr → getError() is available
 }
 ```
 
-## TanStack Query Lifecycle
+> `getValue()` exists only on `AsyncResultOk` and `getError()` only on `AsyncResultErr`. Call them **after** the matching `isOk()` / `isErr()` guard, or use `match()`.
 
-`@tanstack/vue-query` manages the async lifecycle beneath AsyncResult.
+## TanStack Query lifecycle
+
+`@tanstack/vue-query` manages the async lifecycle beneath `AsyncResult`.
 
 ### Query state machine
 
 ```
 [Initial]
-   ↓
-[Fetching] (isLoading)
-   ↓
-[Stale] (cached data exists but flagged for refresh)
-   ↓
-[Inactive] (unused queries auto-cleanup after gcTime)
+   ↓ fetch
+[Fetching]   (isLoading on first load)
+   ↓ success
+[Fresh]  →  [Stale after staleTime]   (cached; refetched on the next trigger)
+   ↓ no observers
+[Inactive]  →  evicted after gcTime
 ```
 
-### Stale time: How long is cached data fresh?
+### staleTime: how long cached data stays fresh
 
 ```typescript
 const { result } = useQuery('contactDetail', {
+  params: { contactUuid: computed(() => uuid) },
   queryFn: () => ContactService.getDetail(uuid),
   staleTime: 5 * 60 * 1000, // 5 minutes
 })
 
-// Timeline:
-// T=0:    First fetch. Result is Ok(contact). freshInterval starts.
-// T=4m59s: Data is still fresh. Returning cached contact instantly.
-// T=5m01s: Data is now stale. Still showing cached contact, but next interaction refetches.
-// T=next-page-view: Fresh fetch triggered automatically.
+// T=0:     First fetch resolves to Ok(contact); the freshness window starts.
+// T=4m59s: Still fresh — cached contact returned instantly, no refetch.
+// T=5m01s: Now stale — cached contact still shown, but the next trigger refetches.
 ```
 
-Stale time is the **grace period** before the cache is considered outdated. While fresh, subsequent requests return cache instantly without refetching.
+`staleTime` is the **grace period** before cached data is considered outdated. While fresh, reads return the cache instantly without refetching. The default is `0` (immediately stale). It is the one TanStack timing option api-utils' `useQuery` exposes per call.
 
-### Garbage collection time: When does cache disappear?
+### gcTime: when unused cache is evicted
+
+`gcTime` controls cache **eviction**; `staleTime` controls **freshness**. After a query has no observers (its component unmounts), its data is kept for `gcTime` and then garbage-collected. api-utils' `useQuery` does not take `gcTime` per call — set it as a TanStack default in your plugin config:
 
 ```typescript
-const gcTime = 5 * 60 * 1000 // 5 minutes
-
-// Query runs, then becomes unused (component unmounts, user navigates away).
-// For gcTime duration, data is kept in memory (but marked as stale).
-// After gcTime, if query hasn't been accessed, it's deleted from cache.
+app.use(apiUtilsPlugin({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000, // fresh for 5 minutes
+      gcTime: 60 * 60 * 1000,   // retain unused cache for 1 hour
+    },
+  },
+}))
 ```
 
-gcTime is cleanup. If you navigate back before gcTime expires, you get the cached (stale) data. After gcTime, next access refetches fresh.
+Navigate back within `gcTime` → cached (possibly stale) data. After `gcTime` → the next access refetches from scratch.
 
 ### Refetch triggers
 
-Queries refetch when:
+A query refetches when:
 
-1. **Manual trigger** — `refetch()` function
-2. **Mutation invalidation** — `queryKeysToInvalidate` in mutation definition
-3. **Stale time expired** — Next component interaction after staleTime passes
-4. **Focus refetch** — Window regains focus (configurable)
-5. **Component mount** — If cache is beyond gcTime
+1. **Manual** — you call `refetch()`
+2. **Invalidation** — a mutation lists the key in `queryKeysToInvalidate`
+3. **Stale access** — the next interaction after `staleTime` elapses
+4. **Window focus** — on refocus (configurable)
+5. **Remount** — a new observer mounts while data is stale or evicted
 
 ```typescript
 const { result, refetch } = useQuery('contactDetail', {
+  params: { contactUuid: computed(() => uuid) },
   queryFn: () => ContactService.getDetail(uuid),
   staleTime: 5 * 60 * 1000,
 })
 
-// Manual refetch
-async function handleRefresh() {
-  await refetch()
-  // result updates to new Ok or Err
-}
+await refetch() // manual
 
-// Automatic refetch on mutation (via queryKeysToInvalidate)
+// Automatic invalidation from a mutation:
 const { execute } = useMutation({
-  queryFn: (data) => ContactService.update(data),
-  queryKeysToInvalidate: { contactDetail: () => true },
+  queryFn: (options: { body: ContactUpdateForm }) => ContactService.update(options.body),
+  queryKeysToInvalidate: {
+    contactDetail: {}, // {} invalidates every contactDetail query; add param extractors to target one
+  },
 })
-// After execute succeeds, contactDetail is invalidated
-// Next useQuery('contactDetail') refetches fresh data
+// After execute() succeeds, contactDetail refetches.
 ```
 
 ## Composable architecture
 
-Each composable in vue-core-api-utils is built from:
+Each composable in api-utils is built from three layers:
 
-1. **TanStack Query composable** — `useQuery`, `useInfiniteQuery`, `useMutation` from @tanstack/vue-query
-2. **AsyncResult wrapper** — Result from neverthrow with loading state
-3. **Type-safe parameters** — ProjectQueryKeys and error codes from your domain
+1. **TanStack Query composable** — `useQuery` / `useInfiniteQuery` / `useMutation` from `@tanstack/vue-query`
+2. **AsyncResult wrapper** — a neverthrow `Result` lifted into the three-state `AsyncResult`
+3. **Typed surface** — your `RegisteredQueryKeys` and error codes via module augmentation
 
 ```typescript
-// High-level (what you use)
-const { result, isLoading, refetch } = useQuery('contactDetail', {
-  params: computed(() => ({ uuid })),
+// What you use:
+const { result, refetch } = useQuery('contactDetail', {
+  params: { contactUuid: computed(() => uuid) },
   queryFn: () => ContactService.getDetail(uuid),
   staleTime: 5 * 60 * 1000,
 })
 
-// Under the hood:
-// 1. TanStack Query manages the fetch lifecycle
-const query = useQueryRaw(queryKey, queryFn, { staleTime })
-
-// 2. Wrap query state in AsyncResult
+// Illustrative pseudocode — the composable lifts TanStack's state into one AsyncResult:
 const result = computed(() => {
-  if (query.isLoading.value) return new AsyncResultLoading()
-  if (query.isError.value) return new AsyncResultErr(query.error.value)
-  return new AsyncResultOk(query.data.value)
+  if (query.isLoading.value) return AsyncResult.loading()
+  if (query.data.value?.isErr()) return AsyncResult.err(query.data.value.getError())
+  return AsyncResult.ok(query.data.value!.getValue())
 })
-
-// 3. Expose typed composable
-return { result, isLoading: query.isLoading, refetch: query.refetch }
 ```
 
-The composables handle this composition. You just use `result.value.match()`.
+You just consume `result.value.match()` or the type guards.
 
 ## Error handling strategy
 
-Errors are typed and structured using `neverthrow`:
+Errors are typed and structured. `ApiError` is the error half of every `ApiResult` / `AsyncResult`:
 
 ```typescript
-// Error type definition
-interface ApiExpectedError {
-  errors: Array<{
-    code: string
-    message: string
-    details?: unknown
-  }>
+// From src/types/apiError.type.ts
+interface ApiKnownErrorObject<TCode extends string = string> {
+  code: TCode
+  detail: string
+  status: string
+  source?: { pointer: string }
 }
 
-type ApiError = ApiExpectedError | ApiUnexpectedError
+interface ApiExpectedError<TCode extends string = string> {
+  errors: ApiErrorObject<TCode>[]
+}
 
-// In AsyncResult
-const result = new AsyncResultErr(apiError)
+// A structured API error OR a native/unexpected Error:
+type ApiError<TCode extends string = string> = ApiExpectedError<TCode> | Error
+```
 
-result.match({
-  ok: (data) => {}, // not executed
+`ApiExpectedError` is a **type**, not a class, so narrow with the `'errors' in error` check (never `instanceof`):
+
+```typescript
+result.value.match({
+  loading: () => {},
+  ok: (data) => { /* … */ },
   err: (error) => {
-    // error is ApiError
-    if (error instanceof ApiExpectedError) {
-      // Handle known API errors
-      const codes = error.errors.map(e => e.code)
+    if ('errors' in error) {
+      // Structured API error
+      const codes = error.errors.map((e) => e.code)
+      console.error(error.errors[0].detail)
     } else {
-      // Handle network/parsing errors
+      // Native / network Error
       console.error(error.message)
     }
   },
 })
 ```
 
-Error types are defined at library initialization via the generic `TErrorCode`. This ensures type-safe error handling across queries and mutations.
+The error-code type comes from the generic `TErrorCode` you register, so `error.errors[0].code` is typed across queries and mutations.
 
 ## Common Mistakes
 
-### CRITICAL: Confuse Result (neverthrow) with AsyncResult; treat ok/err as boolean
+### CRITICAL: Confuse `Result` (neverthrow) with `AsyncResult`
 
 ```typescript
-// ❌ Wrong: neverthrow Result is not AsyncResult
-const result = new Result(contact, null) // This is not how neverthrow works
-if (result.ok) { // `.ok` doesn't exist
-  console.log(result.value)
-}
-
-// Or even worse: treating AsyncResult like a boolean
-const { result } = useQuery(...)
+// ❌ Wrong: treating AsyncResult like a boolean, or using the wrong match form
+const { result } = useQuery(/* … */)
 if (result.value) {
-  // This is always true; result is always defined (Loading | Ok | Err)
+  // Always truthy — result.value is always a Loading | Ok | Err object
 }
+result.value.match(okFn, errFn) // AsyncResult needs the object form, not two args
 ```
 
 ```typescript
-// ✅ Correct: AsyncResult requires exhaustive pattern matching
+// ✅ Correct: AsyncResult → object-form match / getValue()/getError()
 const { result } = useQuery('contactDetail', {
+  params: { contactUuid: computed(() => uuid) },
   queryFn: () => ContactService.getDetail(uuid),
 })
 
@@ -302,159 +294,110 @@ result.value.match({
   err: (error) => showError(error),
 })
 
-// Or use type guards
+// or, with guards:
 if (result.value.isOk()) {
   console.log(result.value.getValue())
 } else if (result.value.isErr()) {
   console.log(result.value.getError())
-} else {
-  showSpinner()
 }
 ```
 
-AsyncResult requires explicit handling of all three states. The type system won't let you skip a state.
+`queryFn` / `execute()` return a neverthrow `Result` (`.value` / `.error`); a composable's `result` is an `AsyncResult` (`getValue()` / `getError()`). Don't mix the two APIs.
 
-Source: `docs/packages/api-utils/pages/concepts/result-types.md`
+Source: `src/async-result/asyncResult.ts`, `src/types/apiError.type.ts`
 
-### MEDIUM: Misunderstand staleTime; think data refreshes automatically after staleTime
+### MEDIUM: Assume `staleTime` auto-refetches
 
 ```typescript
-// ❌ Wrong: assuming staleTime auto-refetches
-const { result } = useQuery('contactDetail', {
-  queryFn: () => ContactService.getDetail(uuid),
-  staleTime: 5 * 60 * 1000, // Not an auto-refresh interval
-})
-
-// At T=5m, data doesn't automatically refetch.
-// It's just marked stale. Refetch happens on next interaction
-// (component mount, user action, mutation invalidation)
+// ❌ Wrong: expecting a refresh exactly at staleTime
+useQuery('contactDetail', { /* … */, staleTime: 5 * 60 * 1000 })
+// At T=5m nothing happens automatically; the data is just marked stale.
 ```
 
 ```typescript
-// ✅ Correct: staleTime is a grace period, not an interval
-const { result, refetch } = useQuery('contactDetail', {
-  queryFn: () => ContactService.getDetail(uuid),
-  staleTime: 5 * 60 * 1000,
-})
+// ✅ Correct: staleTime is a freshness window, not a timer.
+// Refetch happens on the next trigger (access, focus, invalidation, remount).
+// For polling, drive refetch() yourself:
+import { onScopeDispose } from 'vue'
 
-// Data is fresh for 5 minutes (instant returns)
-// After 5 minutes, next access triggers refetch
-// For auto-refresh, use refetch() in a watchEffect or timer
-
-watchEffect(async () => {
-  // Refetch every 10 seconds
-  const interval = setInterval(() => refetch(), 10 * 1000)
-  onCleanup(() => clearInterval(interval))
-})
+const { refetch } = useQuery('contactDetail', { /* … */, staleTime: 5 * 60 * 1000 })
+const id = setInterval(refetch, 10_000)
+onScopeDispose(() => clearInterval(id))
 ```
 
-Stale time is not an auto-refresh interval. It's the duration the cache is considered fresh without refetching. Refetch happens on next access or when explicitly triggered.
+`staleTime` marks data stale; it does not schedule a refetch.
 
-### HIGH: Misunderstand gcTime and cache eviction; assume cache persists forever
+Source: `src/config/config.ts`
 
-```typescript
-// ❌ Wrong: assuming cache is permanent
-const { result } = useQuery('contactDetail', {
-  queryFn: () => ContactService.getDetail(uuid),
-  gcTime: 5 * 60 * 1000, // Default is 5 minutes
-})
+### HIGH: Assume the cache persists forever (gcTime)
 
-// If component unmounts and user is gone for > 5 minutes,
-// Next access refetches fresh (cache is evicted)
-// This is correct behavior, but if you expected cached data...
-```
+If a query has no observers for longer than `gcTime`, it is evicted and the next access refetches. Raise `gcTime` (in the plugin defaults — not per call) when you want longer-lived cache:
 
 ```typescript
-// ✅ Correct: increase gcTime if you want longer-lived cache
-const { result } = useQuery('contactDetail', {
-  queryFn: () => ContactService.getDetail(uuid),
-  staleTime: 5 * 60 * 1000,    // Fresh for 5 minutes
-  gcTime: 60 * 60 * 1000,       // Keep in memory for 1 hour
-})
-
-// After 5 minutes (stale) but before 1 hour (gc),
-// Returning cached data (but trigger refetch automatically)
-// After 1 hour, cache is deleted; next access refetches fresh
-```
-
-gcTime controls cache eviction. Longer gcTime = cache lives longer. Longer staleTime = more queries use cache without refetching. Both are configurable defaults in the plugin config.
-
-Source: `packages/web/api-utils/src/config/config.ts`
-
-### MEDIUM: Forget that QueryClient is shared; one query invalidation affects all components
-
-```typescript
-// ❌ Wrong: not realizing cache is global
-const { execute } = useMutation({
-  queryFn: () => ContactService.update(data),
-  queryKeysToInvalidate: { contactDetail: () => true },
-})
-
-// Component A: detail view
-// Component B: list view (also uses contactDetail)
-// Even though A only updated one contact,
-// B's cache is invalidated too (because same query key)
-```
-
-```typescript
-// ✅ Correct: QueryClient is intentionally shared
-export function useContactMutation() {
-  const { execute } = useMutation({
-    queryFn: () => ContactService.update(data),
-    queryKeysToInvalidate: { 
-      // Invalidates all components using this key
-      contactDetail: () => true,
-      // Also invalidate lists that show this contact
-      contactList: () => true,
+app.use(apiUtilsPlugin({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000, // reads stay fresh for 5 min
+      gcTime: 60 * 60 * 1000,   // unused cache retained for 1 hour
     },
-  })
-  
-  return { execute }
-}
-
-// When A updates a contact, both A and B refetch.
-// This is the intended design: shared cache across app.
+  },
+}))
 ```
 
-QueryClient is application-wide (singleton). Invalidating a query invalidates for all components using that key. This is a feature: synchronized cache across the app.
+Longer `gcTime` keeps cache around longer; longer `staleTime` lets more reads skip refetching.
 
-Source: `packages/web/api-utils/src/utils/query-client/queryClient.ts`
+Source: `src/config/config.ts`
+
+### MEDIUM: Forget the QueryClient is shared app-wide
+
+```typescript
+// One invalidation affects every component using that key — by design.
+const { execute } = useMutation({
+  queryFn: (options: { body: ContactUpdateForm }) => ContactService.update(options.body),
+  queryKeysToInvalidate: {
+    contactDetail: {}, // every component reading contactDetail refetches
+    contactList: {},   // lists that include this contact refetch too
+  },
+})
+```
+
+The QueryClient is an application-wide singleton: invalidating a key refetches it everywhere it is used. That shared cache is the intended design.
+
+Source: `src/utils/query-client/queryClient.ts`
 
 ## Integration pattern
-
-The full integration:
 
 ```
 User interaction
     ↓
-useQuery/useMutation composable
+useQuery / useMutation composable     (typed via RegisteredQueryKeys)
     ↓
-@tanstack/vue-query (fetch + cache mgmt)
+@tanstack/vue-query                   (fetch, cache, lifecycle)
     ↓
-Promise from queryFn
+queryFn → neverthrow Result           (.value / .error)
     ↓
-neverthrow Result handling
+AsyncResult  (Loading | Ok | Err)     (getValue() / getError() / match())
     ↓
-AsyncResult (Loading | Ok | Err)
+Vue computed ref                      (reactive)
     ↓
-Vue computed ref (reactive)
-    ↓
-Template pattern matching with result.value.match()
+Template: result.value.match({ … })
 ```
 
-Each layer adds value:
-- **User interaction** triggers the flow
-- **Composable** provides type safety (ProjectQueryKeys)
-- **TanStack Query** handles caching, refetching, lifecycle
-- **neverthrow** enforces error handling at compile time
-- **AsyncResult** makes state explicit in templates
-- **Vue reactivity** keeps UI synchronized
-
-Understanding this stack helps you use each piece correctly.
+Each layer adds value: composables add type safety, TanStack Query handles caching and lifecycle, neverthrow enforces error handling, `AsyncResult` makes state explicit, and Vue reactivity keeps the UI in sync.
 
 ## See Also
 
-- [AsyncResult Handling](../asyncresult-handling/SKILL.md) — Deep dive into pattern matching and type guards
+- [AsyncResult Handling](../asyncresult-handling/SKILL.md) — Pattern matching and type guards in depth
 - [Writing Queries](../writing-queries/SKILL.md) — Applying staleTime and refetch in real queries
-- [Writing Mutations](../writing-mutations/SKILL.md) — How mutations invalidate cache
-- [Cache Management](../cache-management/SKILL.md) — Manual cache operations behind the scenes
+- [Writing Mutations](../writing-mutations/SKILL.md) — How mutations invalidate the cache
+- [Cache Management](../cache-management/SKILL.md) — Manual cache operations
+
+## Skill metadata
+
+- **Library:** `@wisemen/vue-core-api-utils` (package `vue-core-api-utils`)
+- **Type:** core
+- **Authored against:** v1.2.0
+- **Sources:**
+  - `packages/web/api-utils/src/async-result/asyncResult.ts`
+  - `packages/web/api-utils/src/types/apiError.type.ts`
+  - `packages/web/api-utils/src/config/config.ts`

--- a/packages/web/api-utils/skills/getting-started/SKILL.md
+++ b/packages/web/api-utils/skills/getting-started/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: getting-started
-description: >
-  Install @wisemen/vue-core-api-utils, initialize apiUtilsPlugin with QueryClient config, register typed query keys via module augmentation, re-export composables.
-type: lifecycle
-library: vue-core-api-utils
-library_version: "1.2.0"
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/plugin/apiUtilsPlugin.ts"
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/register.ts"
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/config/config.ts"
+description: Set up `@wisemen/vue-core-api-utils` end to end — install the package, register the `apiUtilsPlugin` (with your QueryClient config) in `main.ts`, define a `ProjectQueryKeys` interface, wire types via `declare module` augmentation of `Register`, and re-export the typed composables from `@/api`. Use this when first adding api-utils to a project, scaffolding the `@/api` barrel, or wiring up typed query keys and error codes.
 ---
 
 # @wisemen/vue-core-api-utils — Getting Started
@@ -51,7 +43,7 @@ export interface ProjectQueryKeys {
 }
 ```
 
-Every key must have both `entity` (response type) and `params` (required parameters).
+Every key is an object with an `entity` (response type); add `params` when the query takes arguments.
 
 ### 3. Initialize the plugin in your main.ts
 
@@ -185,7 +177,7 @@ const { result, refetch } = useContactDetail(props.contactUuid)
       Name: {{ result.getValue().name }}
     </div>
     <div v-else-if="result.isErr()">
-      Error: {{ result.getError().detail }}
+      Failed to load contact
     </div>
     <button @click="refetch">Retry</button>
   </div>
@@ -220,31 +212,30 @@ Without the plugin, composables have no QueryClient and throw immediately.
 
 Source: `src/config/config.ts` — `getQueryClient()` assertion
 
-### HIGH: Define query keys interface without strict entity/params structure
+### HIGH: Give a query key a bare type instead of the `{ entity, params }` shape
 
 ```typescript
-// ❌ Wrong: inconsistent structure
+// ❌ Wrong: bare array instead of an object exposing `entity`
 export interface ProjectQueryKeys {
-  contactDetail: { entity: Contact } // Missing params!
-  contactList: Contact[] // Should wrap in { entity, params }
+  contactList: Contact[] // should be { entity: Contact[] }
 }
 ```
 
 ```typescript
-// ✅ Correct: every key has entity and params
+// ✅ Correct: each key is an object with `entity`, plus `params` when parameterized
 export interface ProjectQueryKeys {
   contactDetail: {
     entity: Contact
     params: { contactUuid: string }
   }
-  contactList: {
-    entity: Contact[]
-    params: { search?: string }
+  // `params` is optional — omit it for a query that takes no arguments:
+  currentUser: {
+    entity: User
   }
 }
 ```
 
-Query keys without proper structure cause TypeScript errors and prevent correct query key resolution.
+Each key must be an object exposing `entity`; add `params` only when the query is parameterized. A bare type (e.g. `Contact[]`) breaks query-key resolution.
 
 Source: `src/register.ts` — `RegisteredQueryKeyEntity` and `RegisteredQueryKeyParams` type derivation
 
@@ -282,3 +273,13 @@ You now have:
 - ✅ Error codes enumerated
 
 Head to [writing-queries](../writing-queries/SKILL.md) to fetch your first resource, or [asyncresult-handling](../asyncresult-handling/SKILL.md) to understand the three-state AsyncResult type.
+
+## Skill metadata
+
+- **Library:** `@wisemen/vue-core-api-utils` (package `vue-core-api-utils`)
+- **Type:** lifecycle
+- **Authored against:** v1.2.0
+- **Sources:**
+  - `packages/web/api-utils/src/plugin/apiUtilsPlugin.ts`
+  - `packages/web/api-utils/src/register.ts`
+  - `packages/web/api-utils/src/config/config.ts`

--- a/packages/web/api-utils/skills/optimistic-uis/SKILL.md
+++ b/packages/web/api-utils/skills/optimistic-uis/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: optimistic-uis
-description: >
-  Combining mutations, QueryClient.update() with built-in rollback, and AsyncResult to create responsive UIs with instant feedback; optimistic updates with automatic error reversal.
-type: core
-library: vue-core-api-utils
-library_version: "1.2.0"
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/composables/mutation/mutation.composable.ts"
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/utils/query-client/queryClient.ts"
+description: Build responsive UIs that update instantly by combining `useMutation`'s `execute()` with `QueryClient.update()` and its built-in `rollback()` — patch the cache optimistically, then revert when the mutation's neverthrow `Result` is `isErr()`. Use this whenever a create/update should feel instant, applying an optimistic cache patch before a request resolves, or reverting cache changes after a failed write.
 ---
 
 # @wisemen/vue-core-api-utils — Optimistic UIs
@@ -93,7 +86,7 @@ async function handleSave(formData) {
 
 Users see changes instantly. No perceived latency. If the server rejects the change, `rollback()` restores the previous cache state automatically.
 
-### Error handling with AsyncResult
+### Error handling on the mutation result
 
 ```typescript
 async function handleSave(formData) {
@@ -104,21 +97,16 @@ async function handleSave(formData) {
   
   const result = await execute({ body: formData })
   
-  result.match({
-    ok: () => {
-      // Server confirmed the update
-      // Cache already reflects the change from the optimistic update
-      showSuccessMessage('Contact updated')
-    },
-    err: (error) => {
-      // Revert optimistic update
-      rollback()
-      showErrorMessage(`Failed: ${'errors' in error ? error.errors[0].detail : error.message}`)
-    },
-    loading: () => {
-      // Won't happen after await, but required by match()
-    },
-  })
+  // `execute()` resolves to a neverthrow Result (not an AsyncResult): read it with isOk()/isErr() + .value/.error
+  if (result.isOk()) {
+    // Server confirmed the update; the cache already reflects the optimistic change
+    showSuccessMessage('Contact updated')
+  } else {
+    // Revert the optimistic update
+    rollback()
+    const error = result.error
+    showErrorMessage(`Failed: ${'errors' in error ? error.errors[0].detail : error.message}`)
+  }
 }
 ```
 
@@ -343,3 +331,12 @@ Source: Architectural consideration from query lifecycle patterns
 - [Writing Mutations](../writing-mutations/SKILL.md) — The `execute()` and result handling that pairs with optimistic updates
 - [Cache Management](../cache-management/SKILL.md) — QueryClient methods for reading and updating cache
 - [Writing Queries](../writing-queries/SKILL.md) — Understanding query results and caching behavior
+
+## Skill metadata
+
+- **Library:** `@wisemen/vue-core-api-utils` (package `vue-core-api-utils`)
+- **Type:** core
+- **Authored against:** v1.2.0
+- **Sources:**
+  - `packages/web/api-utils/src/composables/mutation/mutation.composable.ts`
+  - `packages/web/api-utils/src/utils/query-client/queryClient.ts`

--- a/packages/web/api-utils/skills/writing-infinitequeries/SKILL.md
+++ b/packages/web/api-utils/skills/writing-infinitequeries/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: writing-infinitequeries
-description: >
-  Infinite pagination with useOffsetInfiniteQuery and useKeysetInfiniteQuery, offset vs keyset strategies determined by backend API, fetchNextPage, hasNextPage, isFetchingNextPage, data/meta result structure, proper page assembly.
-type: core
-library: vue-core-api-utils
-library_version: "1.2.0"
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/composables/query/offsetInfiniteQuery.composable.ts"
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/composables/query/keysetInfiniteQuery.composable.ts"
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/types/pagination.type.ts"
-subsystems:
-  - "Offset Pagination"
-  - "Keyset Pagination"
+description: Paginate large lists with the api-utils infinite-query composables — `useOffsetInfiniteQuery` (offset/limit) and `useKeysetInfiniteQuery` (cursor key) — exposing `fetchNextPage`, `hasNextPage`, `isFetchingNextPage`, and a `result` AsyncResult whose pages are assembled into a `{ data, meta }` shape. Use this whenever building "load more" or infinite scroll, choosing offset vs keyset to match a backend endpoint, or wiring a paginated `queryFn` — reach for it instead of the raw `@tanstack/vue-query` `useInfiniteQuery`.
 ---
 
 # @wisemen/vue-core-api-utils — Writing Infinite Queries
@@ -90,7 +79,7 @@ const contacts = computed(() => {
 })
 ```
 
-All pages are automatically concatenated into `data`. Access with `result.getValue().data`.
+All pages are automatically concatenated into one `data` array — read it with `result.value.getValue().data` after an `isOk()` check (as above).
 
 ### Load next page
 
@@ -307,3 +296,14 @@ If your API accepts a cursor `key` parameter, use `useKeysetInfiniteQuery`.
 ## See Also
 
 - [Writing Queries](../writing-queries/SKILL.md) — Infinite queries are queries; all query concepts apply
+
+## Skill metadata
+
+- **Library:** `@wisemen/vue-core-api-utils` (package `vue-core-api-utils`)
+- **Type:** core
+- **Authored against:** v1.2.0
+- **Subsystems:** Offset Pagination, Keyset Pagination
+- **Sources:**
+  - `packages/web/api-utils/src/composables/query/offsetInfiniteQuery.composable.ts`
+  - `packages/web/api-utils/src/composables/query/keysetInfiniteQuery.composable.ts`
+  - `packages/web/api-utils/src/types/pagination.type.ts`

--- a/packages/web/api-utils/skills/writing-mutations/SKILL.md
+++ b/packages/web/api-utils/skills/writing-mutations/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: writing-mutations
-description: >
-  Create, update, delete resources using useMutation, typed queryKeysToInvalidate with optional param extractors, AsyncResult error handling, execute function, request shape with body/params separation.
-type: core
-library: vue-core-api-utils
-library_version: "1.2.0"
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/composables/mutation/mutation.composable.ts"
+description: Create, update, or delete resources with the api-utils `useMutation` composable — a `queryFn` taking `{ body, params }`, typed `queryKeysToInvalidate` (with optional param extractors), an awaitable `execute()` that resolves to a neverthrow `Result`, and a reactive `result` AsyncResult. Use this whenever wiring a create/update/delete call, submitting a form to a backend, or invalidating cached queries after a write — reach for it instead of the raw `@tanstack/vue-query` `useMutation`.
 ---
 
 # @wisemen/vue-core-api-utils — Writing Mutations
@@ -46,10 +40,10 @@ async function handleSubmit(formData: ContactCreateForm) {
   const response = await execute({ body: formData })
   
   if (response.isOk()) {
-    console.log('Created contact:', response.getValue())
+    console.log('Created contact:', response.value)
     // Invalidated queries will refetch automatically
   } else if (response.isErr()) {
-    const error = response.getError()
+    const error = response.error
     if ('errors' in error && error.errors[0].code === 'EMAIL_EXISTS') {
       toast.error('That email is already registered')
     } else {
@@ -59,7 +53,7 @@ async function handleSubmit(formData: ContactCreateForm) {
 }
 ```
 
-Always `await execute()` and check the result state before continuing.
+Always `await execute()` and check the result before continuing. `execute()` resolves to a neverthrow `Result`, so read it with `.value` / `.error` after `isOk()` / `isErr()` — this is distinct from the reactive `result`, which is an `AsyncResult` you read with `.getValue()` / `.getError()`.
 
 ### Update mutation with specific query invalidation using param extractors
 
@@ -263,3 +257,11 @@ Source: `src/composables/mutation/mutation.composable.ts` — `RequestParams` ty
 
 - [Cache Management](../cache-management/SKILL.md) — Understanding which queries to invalidate
 - [Writing Queries](../writing-queries/SKILL.md) — Mutations invalidate queries; understand queries first
+
+## Skill metadata
+
+- **Library:** `@wisemen/vue-core-api-utils` (package `vue-core-api-utils`)
+- **Type:** core
+- **Authored against:** v1.2.0
+- **Sources:**
+  - `packages/web/api-utils/src/composables/mutation/mutation.composable.ts`

--- a/packages/web/api-utils/skills/writing-queries/SKILL.md
+++ b/packages/web/api-utils/skills/writing-queries/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: writing-queries
-description: >
-  Single resource queries using useQuery, computed ref params, staleTime configuration, queryFn, refetch, isFetching vs isLoading distinctions, automatic cache management.
-type: core
-library: vue-core-api-utils
-library_version: "1.2.0"
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/api-utils/src/composables/query/query.composable.ts"
+description: Fetch a single resource with the api-utils `useQuery` composable — a string key, reactive `params` (computed refs/getters), `staleTime`, `queryFn`, `refetch`, an `isEnabled` guard, the `result` AsyncResult, and the `isFetching` vs `isLoading` distinction. Use this whenever loading one resource by id or params, adding caching to a GET, or choosing between initial-load and background-refetch states — reach for it instead of the raw `@tanstack/vue-query` `useQuery`.
 ---
 
 # @wisemen/vue-core-api-utils — Writing Queries
@@ -215,3 +209,11 @@ Source: `src/composables/query/query.composable.ts` — `UseQueryReturnType`
 
 - [Cache Management](../cache-management/SKILL.md) — Understanding caching strategy informs staleTime choices
 - [Writing Infinite Queries](../writing-infinitequeries/SKILL.md) — Pagination uses the same patterns
+
+## Skill metadata
+
+- **Library:** `@wisemen/vue-core-api-utils` (package `vue-core-api-utils`)
+- **Type:** core
+- **Authored against:** v1.2.0
+- **Sources:**
+  - `packages/web/api-utils/src/composables/query/query.composable.ts`

--- a/packages/web/auth/skills/setup/SKILL.md
+++ b/packages/web/auth/skills/setup/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: auth-setup
-description: >
-  Minimal setup for @wisemen/vue-core-auth: create an OIDC client, redirect to
-  login, handle the callback, attach access tokens, and logout.
-type: core
-library: vue-core-auth
+description: Set up OIDC/OAuth2 authentication with `@wisemen/vue-core-auth` — construct an `OidcClient` (PKCE), build a login URL with `getLoginUrl()`, complete the redirect with `loginWithCode()`, attach bearer tokens via `getAccessToken()`, guard routes with `isLoggedIn()`, and `logout()` / `getLogoutUrl()`. Use this whenever wiring up login/logout, handling the OAuth callback, protecting routes, or attaching access tokens to API requests.
 ---
 
 # @wisemen/vue-core-auth - Setup
@@ -116,7 +112,11 @@ oAuthClient.logout()
 window.location.replace(oAuthClient.getLogoutUrl())
 ```
 
-## Source Files
+## Skill metadata
 
-- Client: `src/oidcClient.ts`
-- Types: `src/oidc.type.ts`
+- **Library:** `@wisemen/vue-core-auth` (package `vue-core-auth`)
+- **Type:** core
+- **Authored against:** v3.1.3
+- **Sources:**
+  - `packages/web/auth/src/oidcClient.ts`
+  - `packages/web/auth/src/oidc.type.ts`

--- a/packages/web/formango/skills/array-fields/SKILL.md
+++ b/packages/web/formango/skills/array-fields/SKILL.md
@@ -1,21 +1,6 @@
 ---
 name: array-fields
-description: >
-  Use form.registerArray() to manage dynamic field lists in formango.
-  Covers FieldArray interface: iterate fields with v-for using unique ids
-  as keys, register child fields by index, manipulate with append, remove,
-  insert, prepend, pop, shift, move, empty, setValue. Nested arrays via
-  fieldArray.registerArray(). Load when a form schema contains z.array()
-  or any repeatable field group.
-type: core
-library: formango
-library_version: "3.2.1"
-requires:
-  - form-setup
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/formango/src/lib/useForm.ts"
-  - "wisemen-digital/wisemen-core:packages/web/formango/src/types/form.type.ts"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/api/field-array.md"
+description: Manage dynamic, repeatable field lists in a formango form with `form.registerArray()` and the `FieldArray` API — `append`, `remove`, `insert`, `prepend`, `pop`, `shift`, `move`, `empty`, and `setValue` — iterating `fieldArray.fields` (stable ids) as the v-for `:key` and registering item fields by index, including nested arrays via `fieldArray.registerArray()`. Use this whenever a form schema contains `z.array()` or any repeatable group of inputs.
 ---
 
 This skill builds on [form-setup](../form-setup/SKILL.md). Read it first for `useForm`, `register`, and `Field` concepts.
@@ -222,6 +207,13 @@ See also: [form-setup](../form-setup/SKILL.md) — base form creation and field 
 
 See also: [validation-errors](../validation-errors/SKILL.md) — array field errors are scoped per-item
 
-## Version
+## Skill metadata
 
-Targets formango v3.2.1.
+- **Library:** `formango`
+- **Type:** core
+- **Authored against:** v3.2.4
+- **Prerequisites:** [`form-setup`](../form-setup/SKILL.md)
+- **Sources:**
+  - `packages/web/formango/src/lib/useForm.ts`
+  - `packages/web/formango/src/types/form.type.ts`
+  - `docs/packages/formango/api/field-array.md`

--- a/packages/web/formango/skills/form-setup/SKILL.md
+++ b/packages/web/formango/skills/form-setup/SKILL.md
@@ -1,24 +1,6 @@
 ---
 name: form-setup
-description: >
-  Create a Standard Schema (Zod, Valibot, ArkType), call useForm with
-  schema/initialState/onSubmit/onSubmitError, register fields with
-  form.register(), build a toFormField mapper for v-bind, compose subforms
-  by passing Field<T> to child components where they call field.register()
-  for nested paths. Covers Form, Field, UseFormOptions types, submit,
-  reset, setValues, blurAll, unregister. Load when building any Vue 3 form
-  with formango.
-type: core
-library: formango
-library_version: "3.2.3"
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/formango/src/lib/useForm.ts"
-  - "wisemen-digital/wisemen-core:packages/web/formango/src/types/form.type.ts"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/guide/getting-started.md"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/api/useForm.md"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/api/field.md"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/best-practices/custom-input.md"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/examples/subforms.md"
+description: Build a Vue 3 form with formango — create a Standard Schema (Zod, Valibot, or ArkType), call `useForm({ schema, initialState, onSubmit, onSubmitError })` (which returns the `Form` directly), register fields with `form.register()`, map them onto custom inputs with a `toFormField` helper for `v-bind`, and compose subforms by passing a `Field` to child components that call `field.register()`. Use this whenever creating any formango form, binding fields to custom inputs, or splitting a form across child components.
 ---
 
 # Formango — Form Setup & Field Binding
@@ -318,6 +300,16 @@ See also: [array-fields](../array-fields/SKILL.md) — for dynamic lists, use `r
 
 See also: [validation-errors](../validation-errors/SKILL.md) — error display, i18n, server-side errors
 
-## Version
+## Skill metadata
 
-Targets formango v3.2.1.
+- **Library:** `formango`
+- **Type:** core
+- **Authored against:** v3.2.4
+- **Sources:**
+  - `packages/web/formango/src/lib/useForm.ts`
+  - `packages/web/formango/src/types/form.type.ts`
+  - `docs/packages/formango/guide/getting-started.md`
+  - `docs/packages/formango/api/useForm.md`
+  - `docs/packages/formango/api/field.md`
+  - `docs/packages/formango/best-practices/custom-input.md`
+  - `docs/packages/formango/examples/subforms.md`

--- a/packages/web/formango/skills/validation-errors/SKILL.md
+++ b/packages/web/formango/skills/validation-errors/SKILL.md
@@ -1,25 +1,6 @@
 ---
 name: validation-errors
-description: >
-  Schema-driven validation in formango: automatic validation on state change,
-  displaying errors with formatErrorsToZodFormattedError, Field.errors,
-  Field.rawErrors, Form.addErrors for server-side errors, isDirty vs
-  isChanged vs isTouched, Form.isValid, Form.hasAttemptedToSubmit,
-  Form.blurAll, Form.reset, onSubmitError callback, Zod refine/superRefine
-  for cross-field validation, Zod custom error map for i18n with vue-i18n.
-  Load when handling form errors, server validation, or i18n error messages.
-type: core
-library: formango
-library_version: "3.2.1"
-requires:
-  - form-setup
-sources:
-  - "wisemen-digital/wisemen-core:packages/web/formango/src/lib/useForm.ts"
-  - "wisemen-digital/wisemen-core:packages/web/formango/src/lib/formatErrors.ts"
-  - "wisemen-digital/wisemen-core:packages/web/formango/src/types/form.type.ts"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/api/useForm.md"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/best-practices/i18n.md"
-  - "wisemen-digital/wisemen-core:docs/packages/formango/examples/external-errors.md"
+description: Handle formango validation and errors — automatic validation on state change, displaying messages via `formatErrorsToZodFormattedError` / `field.errors` / `field.rawErrors`, injecting server-side errors with `form.addErrors` (dot-notation paths), the `isDirty` vs `isChanged` vs `isTouched` distinction, `form.isValid` / `form.hasAttemptedToSubmit` / `form.blurAll` / `form.reset`, the `onSubmitError` callback, Zod `refine`/`superRefine` for cross-field rules, and a Zod 4 custom error map for i18n. Use this whenever showing form errors, wiring up server-side validation, or localizing validation messages.
 ---
 
 This skill builds on [form-setup](../form-setup/SKILL.md). Read it first for `useForm`, `register`, and `Field` concepts.
@@ -97,43 +78,36 @@ const form = useForm({
 })
 ```
 
-### Set up i18n with Zod custom error map
+### Set up i18n with a Zod custom error map
 
-Create a Zod error map that translates validation messages using vue-i18n.
+Register a global error map with `z.config` (Zod 4) that translates validation messages using vue-i18n.
 
 ```ts
 // zod.config.ts
 import { z } from 'zod'
 import i18n from '@/plugins/i18n'
 
-const customErrorMap: z.ZodErrorMap = (issue, ctx) => {
-  const t = i18n.global.t
+z.config({
+  customError: (issue) => {
+    const t = i18n.global.t
 
-  if (issue.code === z.ZodIssueCode.invalid_type)
-    return { message: t('errors.invalid_type') }
-  if (issue.code === z.ZodIssueCode.invalid_string) {
-    if (issue.validation === 'email')
-      return { message: t('errors.invalid_email') }
-    return { message: t('errors.invalid_string') }
-  }
-  if (issue.code === z.ZodIssueCode.too_small) {
-    if (issue.type === 'string')
-      return { message: t('errors.too_small_string', { count: issue.minimum }) }
-    return { message: t('errors.too_small', { count: issue.minimum }) }
-  }
-  if (issue.code === z.ZodIssueCode.too_big) {
-    if (issue.type === 'string')
-      return { message: t('errors.too_big_string', { count: issue.maximum }) }
-    return { message: t('errors.too_big', { count: issue.maximum }) }
-  }
+    // In Zod 4, `issue.code` is a string literal and string formats use 'invalid_format'.
+    if (issue.code === 'invalid_type')
+      return t('errors.invalid_type')
+    if (issue.code === 'invalid_format' && issue.format === 'email')
+      return t('errors.invalid_email')
+    if (issue.code === 'too_small')
+      return t('errors.too_small', { count: Number(issue.minimum) })
+    if (issue.code === 'too_big')
+      return t('errors.too_big', { count: Number(issue.maximum) })
 
-  return { message: ctx.defaultError }
-}
-
-z.setErrorMap(customErrorMap)
+    // Return undefined to fall back to Zod's default message.
+    return undefined
+  },
+})
 ```
 
-Import this file in your app entry point:
+Import this file once in your app entry point:
 
 ```ts
 // main.ts
@@ -268,6 +242,16 @@ See also: [form-setup](../form-setup/SKILL.md) — the `toFormField` mapper brid
 
 See also: [array-fields](../array-fields/SKILL.md) — array field errors are scoped per-item via path matching
 
-## Version
+## Skill metadata
 
-Targets formango v3.2.1.
+- **Library:** `formango`
+- **Type:** core
+- **Authored against:** v3.2.4
+- **Prerequisites:** [`form-setup`](../form-setup/SKILL.md)
+- **Sources:**
+  - `packages/web/formango/src/lib/useForm.ts`
+  - `packages/web/formango/src/lib/formatErrors.ts`
+  - `packages/web/formango/src/types/form.type.ts`
+  - `docs/packages/formango/api/useForm.md`
+  - `docs/packages/formango/best-practices/i18n.md`
+  - `docs/packages/formango/examples/external-errors.md`

--- a/packages/web/telemetry/skills/setup/SKILL.md
+++ b/packages/web/telemetry/skills/setup/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: telemetry-setup
-description: >
-  Initialize Telemetry with OpenTelemetry tracing, metrics, and logging.
-  Covers setup with Vue app, error recording, user context, logging,
-  and custom attributes. Auto-captures Vue component errors and browser
-  unhandled errors.
-type: core
-library: vue-core-telemetry
+description: Initialize `@wisemen/vue-core-telemetry` — construct a `Telemetry` instance with OpenTelemetry tracing/metrics/logging options, call `telemetry.init(app)` (which auto-captures Vue component errors and browser unhandled errors), then use `recordException()`, `setUser()`, `log()`, `setAttributes()`, and `registerAppInstrumentations()`. Use this whenever adding observability to a Vue app, reporting errors/metrics/logs to an OTLP backend, or setting user context and custom span attributes.
 ---
 
 # @wisemen/vue-core-telemetry — Setup
@@ -107,12 +101,14 @@ Cross-origin APIs that receive trace headers must allow `traceparent` and
 `tracestate` in CORS. Pass `tracePropagationUrls: []` to disable cross-origin
 trace header propagation.
 
-## Source Files
+## Skill metadata
 
-For full API details, read the source files.
-
-- Telemetry class: `src/index.ts`
-- Types: `src/types.ts`
-- Tracing: `src/opentelemetry/tracing/tracer.ts`
-- Metrics: `src/opentelemetry/metrics/meter.ts`
-- Logging: `src/opentelemetry/logging/logger.ts`
+- **Library:** `@wisemen/vue-core-telemetry` (package `vue-core-telemetry`)
+- **Type:** core
+- **Authored against:** v2.0.0
+- **Sources:** (read these for full API details)
+  - `packages/web/telemetry/src/index.ts` — `Telemetry` class
+  - `packages/web/telemetry/src/types.ts` — options & types
+  - `packages/web/telemetry/src/opentelemetry/tracing/tracer.ts`
+  - `packages/web/telemetry/src/opentelemetry/metrics/meter.ts`
+  - `packages/web/telemetry/src/opentelemetry/logging/logger.ts`


### PR DESCRIPTION
## What & why

Only `name` + `description` are read when an assistant *selects* a skill — the body is loaded only after selection. So the extra frontmatter (`type`, `library`, `library_version`, `sources`, `requires`, `subsystems`) was dead weight at selection time, several descriptions were bare keyword lists with no real trigger, and `writing-mutations` was outright malformed (its metadata had leaked into the body).

This converts all **13** `packages/web` skills to **`name` + `description` only**, relocates every other field — nothing lost — into a `## Skill metadata` body footer, and rewrites each description to lead with concrete API names plus an explicit "Use this when…" trigger.

## Correctness fixes (verified against current source)

| Skill | Fix |
|---|---|
| writing-mutations | malformed frontmatter; `execute()` returns a neverthrow `Result` → read `.value`/`.error`, not `getValue()`/`getError()` |
| asyncresult-handling | `error.detail` → narrowed `errors[0].detail`/`message`; lowercase `AsyncResult` factories; drop JSX from a Vue-library example |
| optimistic-uis | object-form `match()` on a neverthrow `Result` → `isOk()`/`isErr()` |
| foundations | private `AsyncResult` constructors, `instanceof` on a type, wrong `ApiError` shape, invalid `queryKeysToInvalidate` shape, `gcTime` as a per-call `useQuery` option → all corrected |
| validation-errors | Zod 3 error-map API (`setErrorMap`/`ZodIssueCode`) → Zod 4 `z.config({ customError })` |
| getting-started | nonexistent `result.getError().detail`; relaxed an over-strict "params required" claim |

Stale versions refreshed (formango `3.2.4`, auth `3.1.3`, telemetry `2.0.0`). `docs/packages/_meta/authoring-skills.md` updated to document the new `name`+`description`-only convention and the body metadata footer.

## Verification

- All 13 parse with the skills-cli's exact `parseFrontmatter` (its regex + `js-yaml`), each with precisely `name` + `description` and no leaked body metadata.
- Grep sweeps confirm zero remaining bug signatures (bare `error.detail`, Zod-3 APIs, private-constructor calls, `instanceof` on a type, JSX-in-`match()`).

## Not included

`design-system` (~39 skills) and `components-next` (4 skills) live on separate, unmerged branches (`lean-skills/bundle-design-system`, `feat/skills-components-next`) and are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
