### PR TITLE
fix: add overloads on timestamp.locale to better indicate the returned type

### DIFF
--- a/.bumpy/proud-copper-robin.md
+++ b/.bumpy/proud-copper-robin.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/datewise": patch
+---
+
+fix: add overloads on timestamp.locale to better indicate the returned type

--- a/packages/api/datewise/lib/timestamp/timestamp.ts
+++ b/packages/api/datewise/lib/timestamp/timestamp.ts
@@ -96,7 +96,8 @@ export interface Timestamp {
   isSame(other: TimestampInput, unit?: OpUnitType): boolean
   isSameOrAfter(other: TimestampInput, unit?: OpUnitType): boolean
   isSameOrBefore(other: TimestampInput, unit?: OpUnitType): boolean
-  locale(preset?: string | ILocale, object?: Partial<ILocale>): Timestamp | string
+  locale (): string
+  locale (preset: string | ILocale, object?: Partial<ILocale>): Timestamp
   /** returns with a plain date based on the current timezone of the timestamp */
   toPlainDate(): PlainDate
   /** returns with a plain time based on the current timezone of the timestamp */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13064,8 +13064,8 @@ packages:
   vue-component-type-helpers@3.3.0:
     resolution: {integrity: sha512-vwR8DDsBysI9NWXa0okPFpCcW+BUC3sPTuLBNo1faMzw4QWMFd+3/lFYFu29ZN0q+8UReXWJHEYesC9dcXYCLg==}
 
-  vue-component-type-helpers@3.3.3:
-    resolution: {integrity: sha512-x4nsFpy5Pe8fqPzp/5vkTPeTTDBpAx4WVtV47Ejt0+2FQrq4pRRsJs7JmYRqMFzTu/LW+pCWEjQ3YVCkPV7f9g==}
+  vue-component-type-helpers@3.3.4:
+    resolution: {integrity: sha512-joip1uZTaQR0nD23N400gIdJ7xY+WiiiMA/BCKz842gvGBknqDQAzklUvDEhqFvvrhQY8S2ZANBMu4X70VMFGw==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -17832,7 +17832,7 @@ snapshots:
       storybook: 10.3.0(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.27(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.3
+      vue-component-type-helpers: 3.3.4
 
   '@stylistic/eslint-plugin@5.10.0(eslint@10.2.1(jiti@2.6.1))':
     dependencies:
@@ -24497,7 +24497,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.0: {}
 
-  vue-component-type-helpers@3.3.3: {}
+  vue-component-type-helpers@3.3.4: {}
 
   vue-demi@0.14.10(vue@3.5.27(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION

### Description
fix: add overloads on timestamp.locale to better indicate the returned type