### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/clean-violet-crab.md
+++ b/.bumpy/clean-violet-crab.md
@@ -1,5 +1,0 @@
----
-"@wisemen/datewise": patch
----
-
-Added isoWeekday and isoWeek to the package.

--- a/.bumpy/coral-pink-pug.md
+++ b/.bumpy/coral-pink-pug.md
@@ -1,5 +1,0 @@
----
-"@wisemen/datewise": patch
----
-
-feat: support localization in datewise timestamps

--- a/.bumpy/proud-copper-robin.md
+++ b/.bumpy/proud-copper-robin.md
@@ -1,5 +1,0 @@
----
-"@wisemen/datewise": patch
----
-
-fix: add overloads on timestamp.locale to better indicate the returned type

--- a/packages/api/datewise/CHANGELOG.md
+++ b/packages/api/datewise/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @wisemen/datewise
 
+
+## 1.0.11
+<sub>2026-06-11</sub>
+
+- [#1246](https://github.com/wisemen-digital/wisemen-core/pull/1246)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - fix: add overloads on timestamp.locale to better indicate the returned type
+- [#1248](https://github.com/wisemen-digital/wisemen-core/pull/1248)  *(patch)* Thanks [@SebastiaanVanspauwen](https://github.com/SebastiaanVanspauwen)! - Added isoWeekday and isoWeek to the package.
+- [#1250](https://github.com/wisemen-digital/wisemen-core/pull/1250)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - feat: support localization in datewise timestamps
+
 ## 1.0.10
 
 ### Patch Changes

--- a/packages/api/datewise/package.json
+++ b/packages/api/datewise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/datewise",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/datewise` 1.0.10 → **1.0.11** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1247/changes#diff-88a4357e34692fb8c47dd40f7e67e57f7dcddebdfabc0748f8ae39987bb00f80)</sub>

- fix: add overloads on timestamp.locale to better indicate the returned type ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1247/changes#diff-1a325b00d49bb9aa571c292b7079fb5e0009709188cf83be20cb0143bff650f0))
- Added isoWeekday and isoWeek to the package. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1247/changes#diff-5b3767f9c03e788049aed716dbe3b9045693c80aca12ac2fd273b6e7dfaeb520))
- feat: support localization in datewise timestamps ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1247/changes#diff-9b6cfd494d616b33f9198491f29eda763dd1b77ce1c8d784f5902d89fc22536f))
