### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/glad-swift-lake.md
+++ b/.bumpy/glad-swift-lake.md
@@ -1,6 +1,0 @@
----
-"@wisemen/vue-core-filters": patch
-"@wisemen/vue-core-preferences": patch
----
-
-Change `HourCyclePreference` type to `locale-default` instead of `device-default`

--- a/.bumpy/shy-shy-bass.md
+++ b/.bumpy/shy-shy-bass.md
@@ -1,9 +1,0 @@
----
-"@wisemen/vue-core-custom-views": minor
-"@wisemen/vue-core-filters": patch
----
-
-Unsaved view state is now persisted in the URL (`?view-state`). Refreshing the page or navigating away and back restores any unsaved adapter changes (filters, search, columns, etc.). State is cleared automatically when switching views, saving, or deleting.
-
-Added a "Discard changes" action that resets all adapter state back to the last saved view. Only visible when the view is dirty.
-

--- a/.bumpy/tidy-smooth-crane.md
+++ b/.bumpy/tidy-smooth-crane.md
@@ -1,7 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
-"@wisemen/vue-core-filters": patch
-"@wisemen/vue-core-preferences": patch
----
-
-Add `locale-default` to `HourCycle`

--- a/packages/web/custom-views/CHANGELOG.md
+++ b/packages/web/custom-views/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## 0.2.0
+<sub>2026-06-12</sub>
+
+- [#1251](https://github.com/wisemen-digital/wisemen-core/pull/1251)  *(minor)* Thanks [@wouterlms](https://github.com/wouterlms)! - Unsaved view state is now persisted in the URL (`?view-state`). Refreshing the page or navigating away and back restores any unsaved adapter changes (filters, search, columns, etc.). State is cleared automatically when switching views, saving, or deleting.
+  Added a "Discard changes" action that resets all adapter state back to the last saved view. Only visible when the view is dirty.
+
 ## 0.1.0
 <sub>2026-06-08</sub>
 

--- a/packages/web/custom-views/package.json
+++ b/packages/web/custom-views/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
@@ -52,8 +52,8 @@
     "@vueuse/core": "catalog:vue",
     "@vueuse/router": "catalog:vue",
     "@wisemen/vue-core-actions": ">=0.2.0",
-    "@wisemen/vue-core-design-system": ">=1.4.0",
-    "@wisemen/vue-core-filters": ">=5.0.0",
+    "@wisemen/vue-core-design-system": ">=1.4.2",
+    "@wisemen/vue-core-filters": ">=9.0.1",
     "@wisemen/vue-core-icons": ">=0.0.2",
     "@wisemen/vue-core-utils": ">=0.1.0",
     "formango": "catalog:peer",

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 1.4.2
+<sub>2026-06-12</sub>
+
+- [#1252](https://github.com/wisemen-digital/wisemen-core/pull/1252)  *(patch)* Thanks [@wouterlms](https://github.com/wouterlms)! - Add `locale-default` to `HourCycle`
+
 ## 1.4.1
 <sub>2026-06-09</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",

--- a/packages/web/filters/CHANGELOG.md
+++ b/packages/web/filters/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @wisemen/vue-core-filters
 
+
+## 9.0.1
+<sub>2026-06-12</sub>
+
+- [#1251](https://github.com/wisemen-digital/wisemen-core/pull/1251)  *(patch)* Thanks [@wouterlms](https://github.com/wouterlms)! - Unsaved view state is now persisted in the URL (`?view-state`). Refreshing the page or navigating away and back restores any unsaved adapter changes (filters, search, columns, etc.). State is cleared automatically when switching views, saving, or deleting.
+  Added a "Discard changes" action that resets all adapter state back to the last saved view. Only visible when the view is dirty.
+- [#1252](https://github.com/wisemen-digital/wisemen-core/pull/1252)  *(patch)* Thanks [@wouterlms](https://github.com/wouterlms)! - Add `locale-default` to `HourCycle`
+- [#1255](https://github.com/wisemen-digital/wisemen-core/pull/1255)  *(patch)* Thanks [@wouterlms](https://github.com/wouterlms)! - Change `HourCyclePreference` type to `locale-default` instead of `device-default`
+
 ## 9.0.0
 
 ### Patch Changes

--- a/packages/web/filters/package.json
+++ b/packages/web/filters/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "private": false,
   "license": "MIT",
   "repository": {
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@wisemen/vue-core-actions": ">=0.1.3",
     "@wisemen/vue-core-dates": ">=1.0.1",
-    "@wisemen/vue-core-design-system": ">=1.3.1",
+    "@wisemen/vue-core-design-system": ">=1.4.2",
     "@wisemen/vue-core-utils": ">=0.1.0",
     "@wisemen/vue-core-icons": ">=0.0.1",
     "formango": "catalog:peer",

--- a/packages/web/preferences/CHANGELOG.md
+++ b/packages/web/preferences/CHANGELOG.md
@@ -1,6 +1,13 @@
 # @wisemen/vue-core-preferences
 
 
+
+## 1.1.1
+<sub>2026-06-12</sub>
+
+- [#1252](https://github.com/wisemen-digital/wisemen-core/pull/1252)  *(patch)* Thanks [@wouterlms](https://github.com/wouterlms)! - Add `locale-default` to `HourCycle`
+- [#1255](https://github.com/wisemen-digital/wisemen-core/pull/1255)  *(patch)* Thanks [@wouterlms](https://github.com/wouterlms)! - Change `HourCyclePreference` type to `locale-default` instead of `device-default`
+
 ## 1.1.0
 <sub>2026-06-08</sub>
 

--- a/packages/web/preferences/package.json
+++ b/packages/web/preferences/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": false,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/vue-core-custom-views` 0.1.0 → **0.2.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1254/changes#diff-698fe1cb31ce021af5b2ba00ba239f7f739eff1802c11a466be51eac75b7a1ce)</sub>

- Unsaved view state is now persisted in the URL (`?view-state`). Refreshing the page or navigating away and back restores any unsaved adapter changes (filters, search, columns, etc.). State is cleared automatically when switching views, saving, or deleting. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1254/changes#diff-a2e3030ac862a0e5a6b8008fd0c867e8b9d16d934022fb325b11cdf6f42b0de0))
  Added a "Discard changes" action that resets all adapter state back to the last saved view. Only visible when the view is dirty.

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/vue-core-design-system` 1.4.1 → **1.4.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1254/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Add `locale-default` to `HourCycle` ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1254/changes#diff-17770dca49e7478e792d579827e6a8e66f08542339294c78cb9b12da85efde02))

#### `@wisemen/vue-core-filters` 9.0.0 → **9.0.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1254/changes#diff-4e4b7432c573339422f0ac811c7dd40c6088d62f4290427fd0453497607f1be8)</sub>

- Unsaved view state is now persisted in the URL (`?view-state`). Refreshing the page or navigating away and back restores any unsaved adapter changes (filters, search, columns, etc.). State is cleared automatically when switching views, saving, or deleting. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1254/changes#diff-a2e3030ac862a0e5a6b8008fd0c867e8b9d16d934022fb325b11cdf6f42b0de0))
  Added a "Discard changes" action that resets all adapter state back to the last saved view. Only visible when the view is dirty.
- Add `locale-default` to `HourCycle` ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1254/changes#diff-17770dca49e7478e792d579827e6a8e66f08542339294c78cb9b12da85efde02))
- Change `HourCyclePreference` type to `locale-default` instead of `device-default` ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1254/changes#diff-48e89fcd036d008dd939c6ec6365e63e50b20aed57f2af2006da1cf27e53cd4a))

#### `@wisemen/vue-core-preferences` 1.1.0 → **1.1.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1254/changes#diff-cfdc1fee17929d63089c347b317135f368c0977c9f5b5527065f35955de689eb)</sub>

- Add `locale-default` to `HourCycle` ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1254/changes#diff-17770dca49e7478e792d579827e6a8e66f08542339294c78cb9b12da85efde02))
- Change `HourCyclePreference` type to `locale-default` instead of `device-default` ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1254/changes#diff-48e89fcd036d008dd939c6ec6365e63e50b20aed57f2af2006da1cf27e53cd4a))
