### PR TITLE
feat(tbn-1124): add address skill

### DIFF
--- a/.bumpy/address-skill.md
+++ b/.bumpy/address-skill.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/address": patch
+---
+
+add getting started skill for address package

--- a/packages/api/address/skills/getting-started/SKILL.md
+++ b/packages/api/address/skills/getting-started/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: getting-started
+description: Use when working with street addresses.
+---
+
+# @wisemen/address - Getting Started
+
+Use `Address` as the shared type for street addresses. Use `AddressCommand`
+in request DTOs, `@AddressColumn()` in TypeORM entities, and
+`AddressResponse` in API responses.
+
+```ts
+import { ApiProperty } from '@nestjs/swagger'
+import {
+  Address,
+  AddressBuilder,
+  AddressColumn,
+  AddressCommand,
+  AddressResponse,
+  IsAddress,
+} from '@wisemen/address'
+
+export class UpdateAddressDto {
+  @ApiProperty({ type: AddressCommand })
+  @IsAddress({ countryRequired: true, cityRequired: true })
+  address: AddressCommand
+}
+
+export class CustomerResponse {
+  @ApiProperty({ type: AddressResponse, nullable: true })
+  address: AddressResponse | null
+}
+
+@Entity()
+export class Customer {
+  @AddressColumn({ nullable: true })
+  address: Address | null
+}
+
+const address = dto.address.parse()
+
+const fallbackAddress = new AddressBuilder()
+  .withCountry('Belgium')
+  .withCity('Ghent')
+  .build()
+
+return {
+  address: new AddressResponse(customer.address ?? fallbackAddress),
+}
+```

--- a/packages/api/address/skills/getting-started/SKILL.md
+++ b/packages/api/address/skills/getting-started/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: getting-started
-description: Use when working with street addresses.
+description: Use when working with street addresses in apis.
 ---
 
 # @wisemen/address - Getting Started


### PR DESCRIPTION
## What changed
Adds a concise `@wisemen/address` skill under `packages/api/address/skills/getting-started`.

## Why
This gives the address package a focused getting-started skill aligned with the package skill format and common NestJS usage in this repo.

## Impact
Developers and coding agents now have a package-local reference for `Address`, `AddressCommand`, `@AddressColumn()`, `AddressResponse`, and `@ApiProperty(...)` usage.

## Validation
Docs-only change. No tests run.