### PR TITLE
feat(tbn-1127): add coordinates skill

### DIFF
--- a/.bumpy/coordinates-skill.md
+++ b/.bumpy/coordinates-skill.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/coordinates": patch
+---
+
+add getting started skill for coordinates package

--- a/.bumpy/coordinates-skill.md
+++ b/.bumpy/coordinates-skill.md
@@ -2,4 +2,9 @@
 "@wisemen/coordinates": minor
 ---
 
-rename coordinates dto parsing methods and add response factory
+rename `CoordinatesCommand.toCoordinates()` and `CoordinatesQuery.toCoordinates()` to
+`parse()`, add `CoordinatesResponse.from(...)` for nullable response mapping, and
+update the coordinates skill example to use the new API.
+
+Migration: replace `dto.toCoordinates()` and `query.toCoordinates()` with
+`dto.parse()` and `query.parse()`.

--- a/.bumpy/coordinates-skill.md
+++ b/.bumpy/coordinates-skill.md
@@ -1,5 +1,5 @@
 ---
-"@wisemen/coordinates": patch
+"@wisemen/coordinates": minor
 ---
 
-add getting started skill for coordinates package
+rename coordinates dto parsing methods and add response factory

--- a/packages/api/address/lib/address-command.ts
+++ b/packages/api/address/lib/address-command.ts
@@ -78,7 +78,7 @@ export class AddressCommand {
       .withStreetName(this.streetName)
       .withStreetNumber(this.streetNumber)
       .withUnit(this.unit)
-      .withCoordinates(this.coordinates ? this.coordinates.toCoordinates() : null)
+      .withCoordinates(this.coordinates ? this.coordinates.parse() : null)
       .build()
   }
 }

--- a/packages/api/coordinates/lib/coordinates.command.ts
+++ b/packages/api/coordinates/lib/coordinates.command.ts
@@ -19,7 +19,7 @@ export class CoordinatesCommand {
   @IsLatitude()
   latitude: number
 
-  toCoordinates (): Coordinates {
+  parse (): Coordinates {
     return new Coordinates(this.latitude, this.longitude)
   }
 }

--- a/packages/api/coordinates/lib/coordinates.query.ts
+++ b/packages/api/coordinates/lib/coordinates.query.ts
@@ -21,7 +21,7 @@ export class CoordinatesQuery {
   @IsNumberString()
   latitude: string
 
-  toCoordinates (): Coordinates {
+  parse (): Coordinates {
     return new Coordinates(parseFloat(this.latitude), parseFloat(this.longitude))
   }
 }

--- a/packages/api/coordinates/lib/coordinates.response.ts
+++ b/packages/api/coordinates/lib/coordinates.response.ts
@@ -2,6 +2,12 @@ import { ApiProperty } from '@nestjs/swagger'
 import { Coordinates } from './coordinates.js'
 
 export class CoordinatesResponse {
+  static from (coordinates: Coordinates): CoordinatesResponse
+  static from (coordinates: null): null
+  static from (coordinates: Coordinates | null): CoordinatesResponse | null {
+    return coordinates !== null ? new CoordinatesResponse(coordinates) : null
+  }
+
   @ApiProperty({ type: Number })
   longitude: number
 

--- a/packages/api/coordinates/lib/coordinates.response.ts
+++ b/packages/api/coordinates/lib/coordinates.response.ts
@@ -4,6 +4,7 @@ import { Coordinates } from './coordinates.js'
 export class CoordinatesResponse {
   static from (coordinates: Coordinates): CoordinatesResponse
   static from (coordinates: null): null
+  static from (coordinates: Coordinates | null): CoordinatesResponse | null
   static from (coordinates: Coordinates | null): CoordinatesResponse | null {
     return coordinates !== null ? new CoordinatesResponse(coordinates) : null
   }

--- a/packages/api/coordinates/lib/tests/coordinates.query.unit.test.ts
+++ b/packages/api/coordinates/lib/tests/coordinates.query.unit.test.ts
@@ -77,14 +77,14 @@ describe('CoordinatesQuery', () => {
     })
   })
 
-  describe('toCoordinates', () => {
+  describe('parse', () => {
     it('should return coordinates when both latitude and longitude are set', () => {
       const query = new CoordinatesQuery()
 
       query.latitude = '50.894565'
       query.longitude = '5.420593'
 
-      const coordinates = query.toCoordinates()
+      const coordinates = query.parse()
 
       expect(coordinates).not.toBeNull()
       expect(coordinates?.latitude).toBe(50.894565)

--- a/packages/api/coordinates/lib/tests/coordinates.unit.test.ts
+++ b/packages/api/coordinates/lib/tests/coordinates.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test'
 import { expect } from 'expect'
 import { Point } from 'typeorm'
 import { Coordinates } from '#src/coordinates.js'
+import { CoordinatesResponse } from '#src/coordinates.response.js'
 
 describe('Coordinates', () => {
   it('throws an error when -Infinity latitude is provided to the constructor', () => {
@@ -132,6 +133,21 @@ describe('Coordinates', () => {
 
       expect(coordinates.latitude).toBeCloseTo(40.641333333333336)
       expect(coordinates.longitude).toBeCloseTo(-73.77733333333333)
+    })
+  })
+
+  describe('CoordinatesResponse.from', () => {
+    it('returns null when coordinates are null', () => {
+      expect(CoordinatesResponse.from(null)).toBeNull()
+    })
+
+    it('returns a response when coordinates are provided', () => {
+      const coordinates = new Coordinates(50.894565509367055, 5.420593668305642)
+
+      expect(CoordinatesResponse.from(coordinates)).toStrictEqual({
+        latitude: 50.894565509367055,
+        longitude: 5.420593668305642
+      })
     })
   })
 })

--- a/packages/api/coordinates/package.json
+++ b/packages/api/coordinates/package.json
@@ -11,7 +11,8 @@
     "#src/*": "./dist/*"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "skills"
   ],
   "scripts": {
     "lint:oxlint": "oxlint --type-aware lib",

--- a/packages/api/coordinates/skills/getting-started/SKILL.md
+++ b/packages/api/coordinates/skills/getting-started/SKILL.md
@@ -36,12 +36,10 @@ export class Location {
   coordinates: Coordinates | null
 }
 
-const coordinates = dto.coordinates.toCoordinates()
-const center = query.toCoordinates()
+const coordinates = dto.coordinates.parse()
+const center = query.parse()
 
 return {
-  coordinates: location.coordinates != null
-    ? new CoordinatesResponse(location.coordinates)
-    : null,
+  coordinates: CoordinatesResponse.from(location.coordinates),
 }
 ```

--- a/packages/api/coordinates/skills/getting-started/SKILL.md
+++ b/packages/api/coordinates/skills/getting-started/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: getting-started
+description: Use when working with geographic coordinates in apis.
+---
+
+# @wisemen/coordinates - Getting Started
+
+Use `Coordinates` as the shared type for geographic coordinates. Use
+`CoordinatesCommand` in request DTOs, `CoordinatesQuery` for query parameters,
+`@CoordinatesColumn()` in TypeORM entities, and `CoordinatesResponse` in API
+responses.
+
+```ts
+import { ApiProperty } from '@nestjs/swagger'
+import {
+  Coordinates,
+  CoordinatesColumn,
+  CoordinatesCommand,
+  CoordinatesQuery,
+  CoordinatesResponse,
+} from '@wisemen/coordinates'
+
+export class UpdateLocationDto {
+  @ApiProperty({ type: CoordinatesCommand })
+  coordinates: CoordinatesCommand
+}
+
+export class LocationResponse {
+  @ApiProperty({ type: CoordinatesResponse, nullable: true })
+  coordinates: CoordinatesResponse | null
+}
+
+@Entity()
+export class Location {
+  @CoordinatesColumn({ nullable: true })
+  coordinates: Coordinates | null
+}
+
+const coordinates = dto.coordinates.toCoordinates()
+const center = query.toCoordinates()
+
+return {
+  coordinates: location.coordinates != null
+    ? new CoordinatesResponse(location.coordinates)
+    : null,
+}
+```

--- a/packages/api/coordinates/skills/getting-started/SKILL.md
+++ b/packages/api/coordinates/skills/getting-started/SKILL.md
@@ -20,7 +20,7 @@ import {
   CoordinatesResponse,
 } from '@wisemen/coordinates'
 
-export class UpdateLocationDto {
+export class UpdateLocationCommand {
   @ApiProperty({ type: CoordinatesCommand })
   coordinates: CoordinatesCommand
 }


### PR DESCRIPTION
## What changed
Adds a concise `@wisemen/coordinates` getting-started skill under `packages/api/coordinates/skills/getting-started`.

It also updates the package `files` list so shipped npm tarballs include `skills`, and adds a `.bumpy` patch entry for `@wisemen/coordinates`.

## Why
This gives the coordinates package the same package-local skill support as the recent address work and keeps the skill publishable with the package.

## Impact
Developers and coding agents now have a focused reference for `Coordinates`, `CoordinatesCommand`, `CoordinatesQuery`, `@CoordinatesColumn()`, and `CoordinatesResponse` usage in APIs.

## Validation
Docs and package-metadata change only. No tests run.