### PR TITLE
feat(tbn-1126): add app-container skill

### DIFF
--- a/.bumpy/app-container-skill.md
+++ b/.bumpy/app-container-skill.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/app-container": patch
+---
+
+add getting started skill for app-container package

--- a/packages/api/app-container/package.json
+++ b/packages/api/app-container/package.json
@@ -20,7 +20,8 @@
     }
   },
   "files": [
-    "dist/"
+    "dist/",
+    "skills"
   ],
   "scripts": {
     "lint:oxlint": "oxlint --type-aware lib",

--- a/packages/api/app-container/skills/getting-started/SKILL.md
+++ b/packages/api/app-container/skills/getting-started/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: getting-started
+description: Use when bootstrapping NestJS api, worker, or job containers with Express or Fastify.
+---
+
+# @wisemen/app-container - Getting Started
+
+Extend `ExpressContainer` or `FastifyContainer` to bootstrap a Nest app with
+built-in startup, shutdown, and probe endpoints. Use `JobContainer` for
+run-once processes and `WorkerContainer` for long-running consumers.
+
+```ts
+import { NestFactory } from '@nestjs/core'
+import { Module, type INestApplicationContext } from '@nestjs/common'
+import { FastifyAdapter } from '@nestjs/platform-fastify'
+import { FastifyContainer } from '@wisemen/app-container/fastify'
+
+@Module({})
+class AppModule {}
+
+class Api extends FastifyContainer {
+  async bootstrap (adapter: FastifyAdapter): Promise<INestApplicationContext> {
+    const app = await NestFactory.create(AppModule, adapter)
+
+    app.setGlobalPrefix('api')
+    app.enableCors()
+
+    return app
+  }
+}
+
+const _api = new Api()
+```
+
+Use `@wisemen/app-container/express` for Express-based apps. Switch to
+`JobContainer` when the process should execute work once and shut down after
+`execute()`.


### PR DESCRIPTION
## What changed
Adds a concise `@wisemen/app-container` getting-started skill under `packages/api/app-container/skills/getting-started`.

It also updates the package `files` list so published tarballs include `skills`, and adds a `.bumpy` patch entry for `@wisemen/app-container`.

## Why
This gives the app-container package the same package-local skill support as the recent address and coordinates work.

## Impact
Developers and coding agents now have a focused reference for bootstrapping NestJS api, worker, and job containers with `ExpressContainer`, `FastifyContainer`, `JobContainer`, and `WorkerContainer`.

## Validation
Docs and package-metadata change only. No tests run.