### PR TITLE
feat(tbn-1142): add one-of agent skill

### DIFF
--- a/.bumpy/feat-tbn-1142-add-one-of-agent-skill.md
+++ b/.bumpy/feat-tbn-1142-add-one-of-agent-skill.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/one-of": patch
+---
+
+feat(tbn-1142): add one-of agent skill

--- a/packages/api/one-of/package.json
+++ b/packages/api/one-of/package.json
@@ -8,7 +8,8 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "files": [
-    "dist/"
+    "dist/",
+    "skills/"
   ],
   "scripts": {
     "prebuild": "rm -rf ./dist",

--- a/packages/api/one-of/skills/getting-started/SKILL.md
+++ b/packages/api/one-of/skills/getting-started/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: getting-started
+description: Use when documenting discriminated NestJS API responses with Swagger.
+---
+
+# @wisemen/one-of - Getting Started
+
+Use `@wisemen/one-of` when an API response has a shared shape with a `type`
+discriminator and variant-specific `meta`.
+
+## Define The Response Shape
+
+```ts
+import { ApiProperty } from '@nestjs/swagger'
+import {
+  OneOfMeta,
+  OneOfMetaApiProperty,
+  OneOfResponse,
+  OneOfTypeApiProperty,
+} from '@wisemen/one-of'
+
+enum NotificationType {
+  DRIVER_CREATED = 'driver.created',
+  DRIVER_UPDATED = 'driver.updated',
+}
+
+class Notification {}
+
+@OneOfResponse(Notification)
+class NotificationResponse {
+  @ApiProperty({ type: String, format: 'uuid' })
+  uuid: string
+
+  @OneOfTypeApiProperty()
+  type: NotificationType
+
+  @OneOfMetaApiProperty()
+  meta: unknown
+}
+
+@OneOfMeta(Notification, NotificationType.DRIVER_CREATED)
+class DriverCreatedNotificationMeta {
+  @ApiProperty({ type: String, format: 'uuid' })
+  driverUuid: string
+}
+
+@OneOfMeta(Notification, NotificationType.DRIVER_UPDATED)
+class DriverUpdatedNotificationMeta {
+  @ApiProperty({ type: String, format: 'uuid' })
+  driverUuid: string
+}
+```
+
+Always pair `@OneOfResponse(...)` with both `@OneOfTypeApiProperty()` and
+`@OneOfMetaApiProperty()`. Each `@OneOfMeta(...)` registers one allowed
+discriminator value.
+
+## Expose It In Swagger
+
+Use `@OneOfApiResponse(...)` for direct controller responses:
+
+```ts
+import { Controller, Get } from '@nestjs/common'
+import { OneOfApiResponse } from '@wisemen/one-of'
+
+@Controller('/notifications')
+class NotificationController {
+  @Get()
+  @OneOfApiResponse(Notification)
+  async getNotification(): Promise<NotificationResponse> {
+    throw new Error('not implemented')
+  }
+}
+```
+
+Use `@OneOfApiExtraModels(...)` and `@OneOfApiProperty(...)` when the one-of
+response is nested inside another DTO:
+
+```ts
+import { OneOfApiExtraModels, OneOfApiProperty } from '@wisemen/one-of'
+
+@OneOfApiExtraModels(Notification)
+class GetNotificationsResponse {
+  @OneOfApiProperty(Notification, { isArray: true })
+  items: NotificationResponse[]
+}
+```

--- a/packages/api/one-of/skills/getting-started/SKILL.md
+++ b/packages/api/one-of/skills/getting-started/SKILL.md
@@ -19,7 +19,7 @@ enum NotificationType {
   DRIVER_UPDATED = 'driver.updated',
 }
 
-class Notification {}
+class Notification {} // example class that anchors the type and meta
 
 @OneOfResponse(Notification)
 class NotificationResponse {
@@ -37,12 +37,18 @@ class NotificationResponse {
 class DriverCreatedNotificationMeta {
   @ApiProperty({ type: String, format: 'uuid' })
   driverUuid: string
+
+  @ApiProperty({type: String, format: 'date-time'})
+  createdAt: Date
 }
 
 @OneOfMeta(Notification, NotificationType.DRIVER_UPDATED)
 class DriverUpdatedNotificationMeta {
   @ApiProperty({ type: String, format: 'uuid' })
   driverUuid: string
+
+  @ApiProperty({type: String, format: 'date-time'})
+  updatedAt: Date
 }
 ```
 

--- a/packages/api/one-of/skills/getting-started/SKILL.md
+++ b/packages/api/one-of/skills/getting-started/SKILL.md
@@ -12,12 +12,7 @@ discriminator and variant-specific `meta`.
 
 ```ts
 import { ApiProperty } from '@nestjs/swagger'
-import {
-  OneOfMeta,
-  OneOfMetaApiProperty,
-  OneOfResponse,
-  OneOfTypeApiProperty,
-} from '@wisemen/one-of'
+import { OneOfMeta, OneOfMetaApiProperty, OneOfResponse, OneOfTypeApiProperty } from '@wisemen/one-of'
 
 enum NotificationType {
   DRIVER_CREATED = 'driver.created',


### PR DESCRIPTION
## Summary
- add a concise `@wisemen/one-of` skill focused on documenting discriminated NestJS Swagger responses
- show the canonical `@OneOfResponse`, `@OneOfMeta`, `@OneOfApiResponse`, and nested `@OneOfApiProperty` usage patterns
- include `skills/` in the published package files and add a patch bumpy entry for `@wisemen/one-of`

## Validation
- `npm_config_cache=/private/tmp/npm-cache npm pack --dry-run`
- tests not run because this is a documentation-only change
