### PR TITLE
feat(tbn-1150): add twilio skill

### DIFF
--- a/.bumpy/feat-tbn-1150-add-twilio-agent-skill.md
+++ b/.bumpy/feat-tbn-1150-add-twilio-agent-skill.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/twilio": patch
+---
+
+feat(tbn-1150): add twilio agent skill

--- a/packages/api/twilio/package.json
+++ b/packages/api/twilio/package.json
@@ -6,11 +6,16 @@
   },
   "type": "module",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./skills/*": "./skills/*"
   },
   "imports": {
     "#*": "./lib/*"
   },
+  "files": [
+    "dist/",
+    "skills/"
+  ],
   "scripts": {
     "prebuild": "rm -rf ./dist",
     "clean": "rm -rf ./dist",

--- a/packages/api/twilio/skills/getting-started/SKILL.md
+++ b/packages/api/twilio/skills/getting-started/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: getting-started
+description: Use when configuring Twilio SMS or voice calls in NestJS apis.
+---
+
+# @wisemen/twilio - Getting Started
+
+Register `TwilioModule` once with your account credentials, then inject
+`Twilio` anywhere you need to send SMS messages or trigger phone calls.
+
+## Register The Module
+
+```ts
+import { Module } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { TwilioModule } from '@wisemen/twilio'
+
+@Module({
+  imports: [TwilioModule.forRootAsync({
+    inject: [ConfigService],
+    useFactory: (config: ConfigService) => ({
+      accountSid: config.getOrThrow('TWILIO_ACCOUNT_SID'),
+      authToken: config.getOrThrow('TWILIO_AUTH_TOKEN'),
+      phoneNumber: config.getOrThrow('TWILIO_PHONE_NUMBER'),
+    })
+  })],
+  exports: [TwilioModule]
+})
+export class NotificationsModule {}
+```
+
+Use `TwilioModule.forRoot(...)` instead when the credentials are already
+available as static values.
+
+## Send Messages And Calls
+
+```ts
+import { Injectable } from '@nestjs/common'
+import { Twilio } from '@wisemen/twilio'
+
+@Injectable()
+export class NotificationService {
+  constructor (private readonly twilio: Twilio) {}
+
+  async sendVerificationCode(to: string, code: string) {
+    return await this.twilio.createMessage(
+      to,
+      `Your verification code is ${code}.`
+    )
+  }
+
+  async sendReminderCall(to: string, message: string) {
+    return await this.twilio.createCall(to, message)
+  }
+}
+```
+
+Pass the already-formatted E.164 destination number as `to`; the package uses
+the configured `phoneNumber` as the sender automatically.

--- a/packages/api/twilio/skills/getting-started/SKILL.md
+++ b/packages/api/twilio/skills/getting-started/SKILL.md
@@ -26,7 +26,7 @@ import { TwilioModule } from '@wisemen/twilio'
   })],
   exports: [TwilioModule]
 })
-export class NotificationsModule {}
+export class DefaultTwilioModule {}
 ```
 
 Use `TwilioModule.forRoot(...)` instead when the credentials are already
@@ -40,13 +40,12 @@ import { Twilio } from '@wisemen/twilio'
 
 @Injectable()
 export class NotificationService {
-  constructor (private readonly twilio: Twilio) {}
+  constructor (
+    private twilio: Twilio
+  ) {}
 
   async sendVerificationCode(to: string, code: string) {
-    return await this.twilio.createMessage(
-      to,
-      `Your verification code is ${code}.`
-    )
+    return await this.twilio.createMessage(to, `Your verification code is ${code}.`)
   }
 
   async sendReminderCall(to: string, message: string) {

--- a/packages/api/twilio/skills/getting-started/SKILL.md
+++ b/packages/api/twilio/skills/getting-started/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: getting-started
-description: Use when configuring Twilio SMS or voice calls in NestJS apis.
+description: Use when sending SMS or voice calls in NestJS apis.
 ---
 
 # @wisemen/twilio - Getting Started
 
-Register `TwilioModule` once with your account credentials, then inject
-`Twilio` anywhere you need to send SMS messages or trigger phone calls.
+Register `TwilioModule` once with your account credentials, then inject `Twilio` anywhere you need to send SMS messages or trigger phone calls.  
 
 ## Register The Module
 
@@ -29,8 +28,7 @@ import { TwilioModule } from '@wisemen/twilio'
 export class DefaultTwilioModule {}
 ```
 
-Use `TwilioModule.forRoot(...)` instead when the credentials are already
-available as static values.
+Use `TwilioModule.forRoot(...)` instead when the credentials are already available as static values.  
 
 ## Send Messages And Calls
 
@@ -54,5 +52,4 @@ export class NotificationService {
 }
 ```
 
-Pass the already-formatted E.164 destination number as `to`; the package uses
-the configured `phoneNumber` as the sender automatically.
+Pass the already-formatted E.164 destination number as `to`; the package uses the configured `phoneNumber` as the sender automatically.  


### PR DESCRIPTION
## What changed
- add a `getting-started` skill for `@wisemen/twilio`
- document the canonical NestJS module registration flow with `TwilioModule.forRootAsync(...)`
- show the injected `Twilio` service pattern for sending SMS messages and voice calls

## Why
`@wisemen/twilio` did not ship any agent skill yet, while the other backend packages already expose a focused getting-started skill. This adds the package guidance consumers need when syncing Wisemen skills into their projects.

## Impact
Projects using `@wisemen/skills-cli` will now receive a Twilio skill that helps agents generate the intended setup and usage patterns for the package.

## Validation
- no tests run; documentation-only change under `packages/api/twilio/skills/`