### PR TITLE
feat(tbn-1140): add nestjs-typeorm skill bumpy file

### DIFF
--- a/.bumpy/feat-tbn-1140-add-nestjs-typeorm-agent-skill.md
+++ b/.bumpy/feat-tbn-1140-add-nestjs-typeorm-agent-skill.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/nestjs-typeorm": patch
+---
+
+feat(tbn-1140): add nestjs-typeorm agent skill


### PR DESCRIPTION
## What changed
- add the missing `.bumpy` entry for `@wisemen/nestjs-typeorm`

## Why
The `@wisemen/nestjs-typeorm` skill and package metadata are already present on `main`, but there was no bump file to carry that skill work into the release flow.

## Impact
The existing `nestjs-typeorm` agent skill can now be released as a patch version.

## Validation
- no tests run; metadata-only change under `.bumpy/`