### PR TITLE
feat(tbn-1133): add localized-string skill

### DIFF
--- a/.bumpy/feat-tbn-1133-add-localized-string-agent-skill.md
+++ b/.bumpy/feat-tbn-1133-add-localized-string-agent-skill.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/localized-string": patch
+---
+
+feat(tbn-1133): add localized-string agent skill

--- a/packages/api/localized-string/package.json
+++ b/packages/api/localized-string/package.json
@@ -11,7 +11,8 @@
     "#src/*": "./dist/*"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "skills/"
   ],
   "scripts": {
     "prebuild": "rm -rf ./dist",

--- a/packages/api/localized-string/skills/getting-started/SKILL.md
+++ b/packages/api/localized-string/skills/getting-started/SKILL.md
@@ -5,9 +5,7 @@ description: Use when storing and validating multilingual text in NestJS apis wi
 
 # @wisemen/localized-string - Getting Started
 
-Use `LocalizedString` when a field needs multiple translations. Use
-`LocalizedStringCommand` in DTOs, `@IsLocalizedString(...)` to validate
-languages, and `@LocalizedStringColumn()` to persist the value as `jsonb`.
+Use `LocalizedString` when a field needs multiple translations. Use `LocalizedStringCommand` in DTOs, `@IsLocalizedString(...)` to validate languages, and `@LocalizedStringColumn()` to persist the value as `jsonb`.
 
 ```ts
 import { ApiProperty } from '@nestjs/swagger'

--- a/packages/api/localized-string/skills/getting-started/SKILL.md
+++ b/packages/api/localized-string/skills/getting-started/SKILL.md
@@ -12,16 +12,10 @@ languages, and `@LocalizedStringColumn()` to persist the value as `jsonb`.
 ```ts
 import { ApiProperty } from '@nestjs/swagger'
 import { Entity, PrimaryGeneratedColumn } from 'typeorm'
-import {
-  IsLocalizedString,
-  LocalizedString,
-  LocalizedStringColumn,
-  LocalizedStringCommand,
-  initLocalizedString,
-} from '@wisemen/localized-string'
+import { IsLocalizedString, LocalizedString, LocalizedStringColumn, LocalizedStringCommand, initLocalizedString } from '@wisemen/localized-string'
 
 initLocalizedString({
-  currentLocale: () => 'en',
+  currentLocale: () => 'en', // Replace with your own context-dependent locale resolver.
   missingTranslationBehavior: 'empty'
 })
 
@@ -49,8 +43,3 @@ const label = product.name.translate('nl', {
   fallbackLocales: ['en']
 })
 ```
-
-Use `forbidNonRequiredLanguages: true` in `@IsLocalizedString(...)` when a DTO
-must reject any locale outside the required set. Call `initLocalizedString(...)`
-once during application startup before using `LocalizedString.translate()`
-without an explicit locale.

--- a/packages/api/localized-string/skills/getting-started/SKILL.md
+++ b/packages/api/localized-string/skills/getting-started/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: getting-started
+description: Use when storing and validating multilingual text in NestJS apis with TypeORM and class-validator.
+---
+
+# @wisemen/localized-string - Getting Started
+
+Use `LocalizedString` when a field needs multiple translations. Use
+`LocalizedStringCommand` in DTOs, `@IsLocalizedString(...)` to validate
+languages, and `@LocalizedStringColumn()` to persist the value as `jsonb`.
+
+```ts
+import { ApiProperty } from '@nestjs/swagger'
+import { Entity, PrimaryGeneratedColumn } from 'typeorm'
+import {
+  IsLocalizedString,
+  LocalizedString,
+  LocalizedStringColumn,
+  LocalizedStringCommand,
+  initLocalizedString,
+} from '@wisemen/localized-string'
+
+initLocalizedString({
+  currentLocale: () => 'en',
+  missingTranslationBehavior: 'empty'
+})
+
+export class CreateProductDto {
+  @ApiProperty({ type: LocalizedStringCommand })
+  @IsLocalizedString({
+    requiredLanguages: ['en', 'fr']
+  })
+  name: LocalizedStringCommand
+}
+
+@Entity()
+export class Product {
+  @PrimaryGeneratedColumn()
+  id: number
+
+  @LocalizedStringColumn()
+  name: LocalizedString
+}
+
+const product = new Product()
+product.name = dto.name.parse()
+
+const label = product.name.translate('nl', {
+  fallbackLocales: ['en']
+})
+```
+
+Use `forbidNonRequiredLanguages: true` in `@IsLocalizedString(...)` when a DTO
+must reject any locale outside the required set. Call `initLocalizedString(...)`
+once during application startup before using `LocalizedString.translate()`
+without an explicit locale.


### PR DESCRIPTION
## What changed
- add a `getting-started` skill for `@wisemen/localized-string`
- update `@wisemen/localized-string` to ship `skills/` in the published package
- add the matching `.bumpy` entry for the package release flow

## Why
`@wisemen/localized-string` did not ship an agent skill yet, so consumers using `@wisemen/skills-cli` could not sync guidance for DTO validation, `LocalizedString` translation, and `jsonb` persistence patterns.

## Impact
Projects consuming `@wisemen/localized-string` will now receive a focused skill that guides agents toward the intended NestJS, TypeORM, and validation usage patterns.

## Validation
- no tests run; docs and package-metadata change