### PR TITLE
feat(tbn-1132): add express-dto-router skill

### DIFF
--- a/.bumpy/feat-tbn-1132-add-express-dto-router-agent-skill.md
+++ b/.bumpy/feat-tbn-1132-add-express-dto-router-agent-skill.md
@@ -1,0 +1,5 @@
+---
+"@appwise/express-dto-router": patch
+---
+
+feat(tbn-1132): add express-dto-router agent skill

--- a/packages/api/express-dto-router/package.json
+++ b/packages/api/express-dto-router/package.json
@@ -7,7 +7,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/"
+    "dist/",
+    "skills/"
   ],
   "scripts": {
     "lint:oxlint": "oxlint --type-aware lib",

--- a/packages/api/express-dto-router/skills/getting-started/SKILL.md
+++ b/packages/api/express-dto-router/skills/getting-started/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: getting-started
+description: Use when building Express routes with validated body and query DTOs plus standardized error responses.
+---
+
+# @appwise/express-dto-router - Getting Started
+
+Use `DtoRouter` when an Express route should validate request DTOs before it
+reaches the controller. Extend `Dto` for request models, register them in
+`dtos`, and throw `CustomError` for client-facing failures.
+
+```ts
+import { IsOptional, IsString } from 'class-validator'
+import express from 'express'
+import {
+  ControllerOptions,
+  CustomError,
+  Dto,
+  DtoRouter,
+} from '@appwise/express-dto-router'
+
+class CreateUserBodyDto extends Dto {
+  @IsString()
+  name: string
+
+  @IsOptional()
+  @IsString()
+  role?: string
+}
+
+class ListUsersQueryDto extends Dto {
+  @IsOptional()
+  @IsString()
+  search?: string
+}
+
+class UsersController {
+  async createUser (
+    { body, query }: ControllerOptions<{ body: CreateUserBodyDto, query: ListUsersQueryDto }>
+  ) {
+    if (body.name === 'blocked') {
+      throw new CustomError('validation_error')
+    }
+
+    return {
+      name: body.name,
+      search: query?.search ?? null
+    }
+  }
+}
+
+const controller = new UsersController()
+const router = new DtoRouter()
+
+router.post({
+  path: '/users',
+  dtos: {
+    body: CreateUserBodyDto,
+    query: ListUsersQueryDto
+  },
+  controller: controller.createUser.bind(controller)
+})
+
+router.uuidParam('userUuid')
+
+const app = express()
+app.use(express.json())
+app.use(router.router)
+app.use((err, req, res, _next) => {
+  DtoRouter.handleError(err, req, res).catch(console.error)
+})
+```
+
+Use `groups` inside `dtos` when the same DTO class needs different validation
+rules per route. Return `ApiResponse` instead of plain JSON when the route must
+control headers or status handling explicitly.

--- a/packages/api/express-dto-router/skills/getting-started/SKILL.md
+++ b/packages/api/express-dto-router/skills/getting-started/SKILL.md
@@ -69,6 +69,4 @@ app.use((err, req, res, _next) => {
 })
 ```
 
-Use `groups` inside `dtos` when the same DTO class needs different validation
-rules per route. Return `ApiResponse` instead of plain JSON when the route must
-control headers or status handling explicitly.
+Use `groups` inside `dtos` when the same DTO class needs different validation rules per route. Return `ApiResponse` instead of plain JSON when the route must control headers or status handling explicitly.

--- a/packages/api/express-dto-router/skills/getting-started/SKILL.md
+++ b/packages/api/express-dto-router/skills/getting-started/SKILL.md
@@ -5,9 +5,7 @@ description: Use when building Express routes with validated body and query DTOs
 
 # @appwise/express-dto-router - Getting Started
 
-Use `DtoRouter` when an Express route should validate request DTOs before it
-reaches the controller. Extend `Dto` for request models, register them in
-`dtos`, and throw `CustomError` for client-facing failures.
+Use `DtoRouter` when an Express route should validate request DTOs before it reaches the controller. Extend `Dto` for request models, register them in `dtos`, and throw `CustomError` for client-facing failures.
 
 ```ts
 import { IsOptional, IsString } from 'class-validator'


### PR DESCRIPTION
## What changed
- add a `getting-started` skill for `@appwise/express-dto-router`
- update the package to ship `skills/` in the published tarball
- add the matching `.bumpy` entry for the release flow

## Why
`@appwise/express-dto-router` did not ship an agent skill yet, so consumers could not sync guidance for `DtoRouter`, DTO validation, route registration, and standardized error handling.

## Impact
Projects consuming `@appwise/express-dto-router` will now receive a focused skill that guides agents toward the intended Express routing and DTO-validation patterns.

## Validation
- no tests run; docs and package-metadata change