### PR TITLE
feat(plain-date): add support for isoweek

### DIFF
--- a/.bumpy/amber-brave-finch.md
+++ b/.bumpy/amber-brave-finch.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/datewise": patch
+---
+
+Add isoWeek support for startOf() and endOf() on PlainDate

--- a/packages/api/datewise/lib/plain-date/plain-date.units.ts
+++ b/packages/api/datewise/lib/plain-date/plain-date.units.ts
@@ -8,6 +8,7 @@ export type ReachablePlainDateUnit
   = 'week'
     | 'month'
     | 'year'
+    | 'isoWeek'
 
 export type GetPlainDateUnit
   = 'day of month' | 'day'

--- a/packages/api/datewise/lib/plain-date/tests/plain-date.manipulation.unit.test.ts
+++ b/packages/api/datewise/lib/plain-date/tests/plain-date.manipulation.unit.test.ts
@@ -101,6 +101,35 @@ describe('PlainDate manipulation', () => {
       expect(new DayjsPlainDate('2024-01-01').add(1, 'week').isSame(new DayjsPlainDate('2024-01-08'))).toBe(true)
     })
 
+    it('startOf isoWeek returns the monday of the same ISO week', () => {
+      const date = new DayjsPlainDate('2025-01-01')
+      const startOfIsoWeek = date.startOf('isoWeek')
+
+      expect(startOfIsoWeek.isSame(new DayjsPlainDate('2024-12-30'))).toBe(true)
+      expect(startOfIsoWeek.isoWeekday()).toBe(1)
+      expect(startOfIsoWeek.isoWeek()).toBe(date.isoWeek())
+    })
+
+    it('endOf isoWeek returns the sunday of the same ISO week', () => {
+      const date = new DayjsPlainDate('2025-01-01')
+      const endOfIsoWeek = date.endOf('isoWeek')
+
+      expect(endOfIsoWeek.isSame(new DayjsPlainDate('2025-01-05'))).toBe(true)
+      expect(endOfIsoWeek.isoWeekday()).toBe(7)
+      expect(endOfIsoWeek.isoWeek()).toBe(date.isoWeek())
+    })
+
+    it('startOf and endOf isoWeek keep ISO week boundaries across year changes', () => {
+      const date = new DayjsPlainDate('2025-12-31')
+      const startOfIsoWeek = date.startOf('isoWeek')
+      const endOfIsoWeek = date.endOf('isoWeek')
+
+      expect(startOfIsoWeek.isSame(new DayjsPlainDate('2025-12-29'))).toBe(true)
+      expect(endOfIsoWeek.isSame(new DayjsPlainDate('2026-01-04'))).toBe(true)
+      expect(startOfIsoWeek.isoWeek()).toBe(1)
+      expect(endOfIsoWeek.isoWeek()).toBe(1)
+    })
+
     it('Increasing the week overflows to the next month', () => {
       const endOfMonth = new DayjsPlainDate(dayjs().startOf('year').endOf('month'))
       const nextMonth = endOfMonth.add(1, 'week')


### PR DESCRIPTION
Add support for isoweek by adding isoweek as an input for startOf() and endOf() methods.
