### PR TITLE
fix: correct design system main entry

### DIFF
--- a/.bumpy/fix-design-system-main.md
+++ b/.bumpy/fix-design-system-main.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/vue-core-design-system": patch
+---
+
+Fix the package `main` entry to point at the emitted CommonJS bundle.

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -25,7 +25,7 @@
     "./style.css": "./dist/style.css"
   },
   "style": "./dist/index.css",
-  "main": "./dist/index.umd.cjs",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "typings": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- point `@wisemen/vue-core-design-system` `main` at `./dist/index.cjs`
- align the CommonJS entry with the file emitted by the current Vite library build and present in the published package

## Verification

- `npm pack @wisemen/vue-core-design-system@1.6.0 --json`
- confirmed the published tarball contains `package/dist/index.cjs`, `package/dist/index.js`, and `package/dist/index.d.ts`
- confirmed the published tarball does not contain `package/dist/index.umd.cjs`, despite current `main` pointing there
- node assertion that `packages/web/design-system/package.json` now has `main: "./dist/index.cjs"`
- `git diff --check`