### PR TITLE
feat(TBN-1130): add datewise skills

### DIFF
--- a/packages/api/datewise/skills/date-range/SKILL.md
+++ b/packages/api/datewise/skills/date-range/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: date-range
+description: Use when working with date-only ranges in APIs, DTOs, and TypeORM entities.
+---
+
+# DateRange
+
+Use `DateRange` for periods bounded by `PlainDate`, such as contract validity or seasonal availability. In DTOs, use `DateRangeDto` with `@IsDateRange()`, parse with `dto.parse()`, return `DateRangeResponse` from APIs, persist with `@DateRangeColumn()`, and query with `ContainsPlainDate(...)`.
+
+```ts
+import {
+  ContainsPlainDate,
+  DateRange,
+  DateRangeColumn,
+  DateRangeDto,
+  DateRangeResponse,
+  IsDateRange,
+  plainDate,
+} from '@wisemen/datewise'
+
+export class UpdateContractCommand {
+  @IsDateRange({ finiteOnly: true })
+  validity: DateRangeDto
+}
+
+@Entity()
+export class Contract {
+  @DateRangeColumn({ finiteOnly: true })
+  validity: DateRange
+}
+
+const validity = dto.validity.parse()
+const response = DateRangeResponse.from(validity)
+const activeOnDate = ContainsPlainDate(plainDate.today())
+```
+
+`DateRange` normalizes boundaries to inclusive dates. Use it only when a day-level range is the right domain model.

--- a/packages/api/datewise/skills/date-time-range/SKILL.md
+++ b/packages/api/datewise/skills/date-time-range/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: date-time-range
+description: Use when working with timestamp ranges, schedules, or multi-range persistence in APIs.
+---
+
+# DateTimeRange
+
+Use `DateTimeRange` for `[from, until)` ranges bounded by `Timestamp`, such as bookings, time slots, and execution windows. In DTOs, use `DateTimeRangeDto` with `@IsDateTimeRange()`, parse with `dto.parse()`, return `DateTimeRangeResponse`, persist with `@DateTimeRangeColumn()`, query with `ContainsTimestamp(...)`, and use `DateTimeMultiRangeColumn()` when a field stores multiple ranges.
+
+```ts
+import {
+  ContainsTimestamp,
+  DateTimeMultiRangeColumn,
+  DateTimeRange,
+  DateTimeRangeColumn,
+  DateTimeRangeDto,
+  DateTimeRangeResponse,
+  IsDateTimeRange,
+  timestamp,
+} from '@wisemen/datewise'
+
+export class CreateBookingCommand {
+  @IsDateTimeRange({ finiteOnly: true })
+  slot: DateTimeRangeDto
+}
+
+@Entity()
+export class Booking {
+  @DateTimeRangeColumn({ finiteOnly: true })
+  slot: DateTimeRange
+
+  @DateTimeMultiRangeColumn({ nullable: true })
+  blockedSlots: DateTimeRange[] | null
+}
+
+const slot = dto.slot.parse()
+const response = DateTimeRangeResponse.from(slot)
+const activeNow = ContainsTimestamp(timestamp())
+```
+
+Prefer `DateTimeRange` over separate `from` and `until` fields when overlap checks, containment, or range arithmetic are part of the model.

--- a/packages/api/datewise/skills/getting-started/SKILL.md
+++ b/packages/api/datewise/skills/getting-started/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: getting-started
+description: Use when working with dates, times, timestamps, or temporal ranges in APIs.
+---
+
+# @wisemen/datewise - Getting Started
+
+Use `@wisemen/datewise` when the domain needs typed temporal values instead of raw
+`Date` objects or unstructured strings. Reach for it when working with date-only
+values, wall-clock times, timezone-aware timestamps, validity periods, booking
+windows, or recurring schedules.
+
+Prefer the type that matches the domain:
+
+- `PlainDate` for calendar dates without time or timezone
+- `PlainTime` for wall-clock times without date or timezone
+- `Timestamp` for absolute instants and timezone-aware datetimes
+- `DateRange` for date-only periods
+- `DateTimeRange` for timestamp ranges and time slots
+- `RRule` for recurring or one-off schedule rules
+
+Use the type-specific skills for concrete usage:
+
+- `plain-date`
+- `plain-time`
+- `timestamp`
+- `date-range`
+- `date-time-range`
+- `rrule`
+
+For more detail, inspect the package README and the matching module under
+`packages/api/datewise/lib/` before inventing custom temporal helpers.

--- a/packages/api/datewise/skills/plain-date/SKILL.md
+++ b/packages/api/datewise/skills/plain-date/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: plain-date
+description: Use when working with calendar dates without time or timezone in APIs.
+---
+
+# PlainDate
+
+Use `PlainDate` for date-only values such as due dates, birthdays, and validity boundaries. Create values with `plainDate(...)`, validate DTO strings with `@IsPlainDate()`, document them with `@PlainDateApiProperty()`, and persist them with `@PlainDateColumn()`.
+
+```ts
+import {
+  IsPlainDate,
+  PlainDate,
+  PlainDateApiProperty,
+  PlainDateColumn,
+  plainDate,
+} from '@wisemen/datewise'
+
+export class UpdateHolidayCommand {
+  @PlainDateApiProperty()
+  @IsPlainDate()
+  date: string
+}
+
+@Entity()
+export class Holiday {
+  @PlainDateColumn()
+  date: PlainDate
+}
+
+const start = plainDate('2026-01-01')
+const nextWeek = start.add(1, 'week')
+```
+
+Use `plainDate.today()`, `plainDate.tomorrow()`, and the infinity helpers only when the domain really needs relative or open-ended dates.

--- a/packages/api/datewise/skills/plain-time/SKILL.md
+++ b/packages/api/datewise/skills/plain-time/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: plain-time
+description: Use when working with wall-clock times without a date or timezone in APIs.
+---
+
+# PlainTime
+
+Use `PlainTime` for local times such as opening hours, cutoff times, and shift starts. Validate DTO strings with `@IsPlainTime()` or the comparison decorators, document them with `@PlainTimeApiProperty()`, and persist them with `@PlainTimeColumn()`.
+
+```ts
+import {
+  IsPlainTimeAfter,
+  IsPlainTime,
+  PlainTime,
+  PlainTimeApiProperty,
+  PlainTimeColumn,
+  timestamp,
+} from '@wisemen/datewise'
+
+export class CreateWindowCommand {
+  @PlainTimeApiProperty()
+  @IsPlainTime()
+  opensAt: string
+
+  @PlainTimeApiProperty()
+  @IsPlainTime()
+  @IsPlainTimeAfter((dto: CreateWindowCommand) => dto.opensAt)
+  closesAt: string
+}
+
+@Entity()
+export class OpeningHours {
+  @PlainTimeColumn()
+  opensAt: PlainTime
+}
+
+const noon = timestamp('2026-01-01T12:00:00.000Z').toPlainTime()
+const opensAt = timestamp('2026-01-01T08:30:00.000Z').toPlainTime()
+const opensBeforeNoon = opensAt.isBefore(noon)
+```
+
+Use `PlainTime` only for timezone-agnostic clock time. Switch to `Timestamp` once the date or timezone matters.

--- a/packages/api/datewise/skills/rrule/SKILL.md
+++ b/packages/api/datewise/skills/rrule/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: rrule
+description: Use when modeling recurring schedules or one-off occurrences as reusable temporal rules.
+---
+
+# RRule
+
+Use `RRule` for recurring schedules that combine a date range, timezone, start time, duration, frequency, interval, and exceptions. Create rules with `rrule(...)` or `rrule.once(...)`, persist them with `@RRuleColumn()`, and iterate occurrences with `occurrences(...)`.
+
+```ts
+import { Duration, DurationUnit } from '@wisemen/quantity'
+import {
+  DateTimeRange,
+  RRule,
+  RRuleColumn,
+  RRuleFrequency,
+  rrule,
+  timestamp,
+} from '@wisemen/datewise'
+
+@Entity()
+export class AvailabilityTemplate {
+  @RRuleColumn()
+  schedule: RRule
+}
+
+const start = timestamp('2026-01-01T09:00:00.000+01:00')
+
+const schedule = rrule({
+  range: new DateTimeRange('2026-01-01T00:00:00.000Z', '2026-02-01T00:00:00.000Z'),
+  timezone: 'Europe/Brussels',
+  startDate: start.toPlainDate(),
+  startTime: start.toPlainTime(),
+  duration: new Duration(2, DurationUnit.HOURS),
+  frequency: RRuleFrequency.WEEKLY,
+  interval: 1,
+  exceptions: [timestamp('2026-01-08T08:00:00.000Z')],
+})
+```
+
+Use `rrule.once(...)` when the domain wants the same rule shape for both recurring and single occurrences.

--- a/packages/api/datewise/skills/timestamp/SKILL.md
+++ b/packages/api/datewise/skills/timestamp/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: timestamp
+description: Use when working with absolute instants, timezone-aware datetimes, or open-ended datetime boundaries.
+---
+
+# Timestamp
+
+Use `Timestamp` for real moments in time such as audit fields, deadlines, and scheduled execution times. Create values with `timestamp(...)`, validate DTO strings with `@IsTimestamp(...)`, document them with `@TimestampApiProperty()`, and persist them with `@TimestampColumn()`.
+
+```ts
+import {
+  IsTimestamp,
+  Timestamp,
+  TimestampApiProperty,
+  TimestampColumn,
+  timestamp,
+} from '@wisemen/datewise'
+
+export class ScheduleJobCommand {
+  @TimestampApiProperty()
+  @IsTimestamp()
+  runAt: string
+
+  @TimestampApiProperty()
+  @IsTimestamp({ isAfter: (dto: ScheduleJobCommand) => dto.runAt })
+  expiresAt: string
+}
+
+@Entity()
+export class Job {
+  @TimestampColumn()
+  runAt: Timestamp
+}
+
+const scheduledAt = timestamp('2026-01-01T09:00:00.000+01:00')
+const scheduledDate = scheduledAt.toPlainDate()
+```
+
+Use `timestamp.futureInfinity()` and `timestamp.pastInfinity()` only for open-ended temporal models such as ranges.


### PR DESCRIPTION
## What changed
- added focused Datewise skills for `plain-date`, `plain-time`, `timestamp`, `date-range`, `date-time-range`, and `rrule`
- kept each skill concise and aligned with the existing `packages/api/*/skills` style
- documented when to use each type and the main DTO, TypeORM, and helper APIs around it

## Why
- `@wisemen/datewise` covers multiple temporal concepts and needs more targeted guidance than the simpler API packages
- splitting the package into type-specific skills keeps the instructions short and easier to apply

## Validation
- reviewed all existing API package skills for format and tone
- checked the new skill files against the current Datewise exports and examples
- no runtime tests were run because this change only adds Markdown skill files