### PR TITLE
fix(nestjs-typeorm): custom data types initialization

### DIFF
--- a/.bumpy/red-zany-nest.md
+++ b/.bumpy/red-zany-nest.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/nestjs-typeorm": patch
+---
+
+Add custom data types before initializing datasource

--- a/packages/api/nestjs-typeorm/lib/extensions/module.ts
+++ b/packages/api/nestjs-typeorm/lib/extensions/module.ts
@@ -33,9 +33,9 @@ export class TypeOrmModule extends TM {
   static forRootAsync (options: NestjsTypeOrmModuleAsyncOptions): DynamicModule {
     options.dataSourceFactory = async (dataSourceOptions: DataSourceOptions) => {
       const source =  new DataSource(dataSourceOptions)
-      await source.initialize()
-
       source.driver.supportedDataTypes.push(...(options.customDataTypes ?? []) as ColumnType[])
+
+      await source.initialize()
 
       return source
     }


### PR DESCRIPTION
Adding custom data types in higher versions of typeorm (1.x.x) broke

<img width="1429" height="87" alt="CleanShot 2026-06-25 at 09 41 24@2x" src="https://github.com/user-attachments/assets/eda3fe57-72e8-455d-9623-ad093f8d32c3" />

Reason is because it tries we initialize first, and then add types later, resulting in initialize not finding the custom type
<img width="1618" height="1194" alt="image" src="https://github.com/user-attachments/assets/0edd1d1a-5641-46d5-bd2a-375c9d3a7d0d" />

<img width="3158" height="874" alt="image" src="https://github.com/user-attachments/assets/dd2cd4bd-120c-4a81-8981-1da35cc80ec2" />
