### PR TITLE
feat(TBN-946): streamline nats exception filters

### DIFF
--- a/packages/api/nestjs-nats/lib/consumers/nats-consumption.ts
+++ b/packages/api/nestjs-nats/lib/consumers/nats-consumption.ts
@@ -1,11 +1,12 @@
 import type { Consumer, ConsumerInfo, ConsumerMessages, JsMsg } from '@nats-io/jetstream'
 import { Logger } from '@nestjs/common'
-import { captureException } from '@wisemen/opentelemetry'
 import { plainToInstance } from 'class-transformer'
 import { validate } from 'class-validator'
 import type { CloudEventHandlerOptions } from '#src/message-handler/on-nats-message.decorator.js'
 import type { NatsMessageHandlerFunction } from '#src/message-handler/nats-message-handler.js'
 import { CloudEvent } from '#src/cloud-event/cloud-event.js'
+import { NatsExceptionHandler } from '#src/exception-filters/nats-exception-handler.js'
+import type { ResolvedNatsExceptionFilter } from '#src/exception-filters/nats-exception-filter.js'
 
 type CloudEventKey = string
 
@@ -13,12 +14,24 @@ export class NatsConsumption {
   private fallbackHandler: NatsMessageHandlerFunction | undefined
   private cloudEventHandlers: Map<CloudEventKey, NatsMessageHandlerFunction> = new Map()
   private messages: ConsumerMessages | undefined
+  private readonly exceptionFilters: ResolvedNatsExceptionFilter[] = []
+  private readonly exceptionHandler = new NatsExceptionHandler()
 
   constructor (
     private readonly consumerInfo: ConsumerInfo,
     private readonly consumer: Consumer,
     private readonly nakBackoff?: number
   ) {}
+
+  addExceptionFilters (filters: ResolvedNatsExceptionFilter[]): void {
+    for (const filter of filters) {
+      if (this.exceptionFilters.some(existing => existing.filter === filter.filter)) {
+        continue
+      }
+
+      this.exceptionFilters.push(filter)
+    }
+  }
 
   addCloudEventHandler (
     eventOptions: CloudEventHandlerOptions,
@@ -77,20 +90,21 @@ export class NatsConsumption {
   }
 
   private async handleMessage (message: JsMsg): Promise<void> {
+    let handler: NatsMessageHandlerFunction | undefined
+
     try {
-      const handler = await this.getHandler(message)
+      handler = await this.getHandler(message)
 
       await handler.handle(message)
       message.ack()
     } catch (e) {
-      const errorMessage = e instanceof Error ? e.message : 'unknown cause'
-      const error = new Error('unable to handle consumption message', { cause: e })
-
-      Logger.error(
-        `Nats message handler threw error ${errorMessage}`,
-        `NATS consumer ${this.consumerInfo.name}`
-      )
-      captureException(error)
+      await this.exceptionHandler.handle(e, {
+        captureMessage: 'unable to handle consumption message',
+        filters: handler?.filters ?? this.exceptionFilters,
+        handlerName: handler?.handlerContext,
+        logContext: `NATS consumer ${this.consumerInfo.name}`,
+        message
+      })
       message.nak(this.nakBackoff)
     }
   }

--- a/packages/api/nestjs-nats/lib/exception-filters/get-nats-exception-filters.ts
+++ b/packages/api/nestjs-nats/lib/exception-filters/get-nats-exception-filters.ts
@@ -1,0 +1,39 @@
+import type { Type } from '@nestjs/common'
+import type { MethodName } from '#src/parameters/nats-parameter.js'
+import type { ProvidersExplorer } from '#src/providers/providers-explorer.js'
+import type { NatsExceptionFilter, ResolvedNatsExceptionFilter } from './nats-exception-filter.js'
+
+type FilterMetadata = NatsExceptionFilter | Type<NatsExceptionFilter>
+const EXCEPTION_FILTERS_METADATA = '__exceptionFilters__'
+const FILTER_CATCH_EXCEPTIONS = '__filterCatchExceptions__'
+
+export function getNatsExceptionFilters (
+  providersExplorer: ProvidersExplorer,
+  target: Type<unknown>,
+  methodName?: MethodName
+): ResolvedNatsExceptionFilter[] {
+  const classFilters = getExceptionFilterMetadata(target)
+  const methodFilters = methodName === undefined
+    ? []
+    : getExceptionFilterMetadata(target.prototype[methodName] as object)
+
+  return [...methodFilters, ...classFilters].map(filter => resolveExceptionFilter(providersExplorer, filter))
+}
+
+function getExceptionFilterMetadata (target: object): FilterMetadata[] {
+  return Reflect.getMetadata(EXCEPTION_FILTERS_METADATA, target) as FilterMetadata[] ?? []
+}
+
+function resolveExceptionFilter (
+  providersExplorer: ProvidersExplorer,
+  filterMetadata: FilterMetadata
+): ResolvedNatsExceptionFilter {
+  const filter = typeof filterMetadata === 'function'
+    ? providersExplorer.getProviderInstance(filterMetadata) ?? new filterMetadata()
+    : filterMetadata
+
+  return {
+    exceptions: Reflect.getMetadata(FILTER_CATCH_EXCEPTIONS, filter.constructor) as Type<unknown>[] ?? [],
+    filter
+  }
+}

--- a/packages/api/nestjs-nats/lib/exception-filters/nats-arguments-host.ts
+++ b/packages/api/nestjs-nats/lib/exception-filters/nats-arguments-host.ts
@@ -1,0 +1,106 @@
+import type { ArgumentsHost } from '@nestjs/common'
+import type { JsMsg } from '@nats-io/jetstream'
+import type { ServiceMsg } from '@nats-io/services'
+import type { Msg } from '@nats-io/transport-node'
+
+export type NatsContextMessage = Msg | JsMsg | ServiceMsg
+
+export interface NatsContextHost {
+  getHandlerName (): string | undefined
+  getMessage<TMessage extends NatsContextMessage = NatsContextMessage> (): TMessage
+  getSubject (): string
+}
+
+export interface NatsArgumentsHost extends ArgumentsHost {
+  getType<TContext extends string = 'nats'> (): TContext
+  switchToNats (): NatsContextHost
+}
+
+type HttpArgumentsHost = ReturnType<ArgumentsHost['switchToHttp']>
+type RpcArgumentsHost = ReturnType<ArgumentsHost['switchToRpc']>
+type WsArgumentsHost = ReturnType<ArgumentsHost['switchToWs']>
+
+export class NatsExecutionContextHost implements NatsArgumentsHost {
+  private readonly message: NatsContextMessage
+  private responded = false
+
+  constructor (
+    message: NatsContextMessage,
+    private readonly handlerName?: string
+  ) {
+    this.message = this.wrapMessage(message)
+  }
+
+  get hasResponded (): boolean {
+    return this.responded
+  }
+
+  getArgs<T extends unknown[] = unknown[]> (): T {
+    return [this.message] as T
+  }
+
+  getArgByIndex<T = unknown> (index: number): T {
+    return this.getArgs()[index] as T
+  }
+
+  switchToHttp (): HttpArgumentsHost {
+    return {
+      getNext: <T = unknown> (): T => undefined as T,
+      getRequest: <T = unknown> (): T => undefined as T,
+      getResponse: <T = unknown> (): T => undefined as T
+    }
+  }
+
+  switchToRpc (): RpcArgumentsHost {
+    return {
+      getContext: <T = unknown> (): T => this.message as T,
+      getData: <T = unknown> (): T => this.message as T
+    }
+  }
+
+  switchToWs (): WsArgumentsHost {
+    return {
+      getClient: <T = unknown> (): T => undefined as T,
+      getData: <T = unknown> (): T => this.message as T,
+      getPattern: <T = unknown> (): T => this.message.subject as T
+    }
+  }
+
+  getType<TContext extends string = 'nats'> (): TContext {
+    return 'nats' as TContext
+  }
+
+  switchToNats (): NatsContextHost {
+    return {
+      getHandlerName: () => this.handlerName,
+      getMessage: <TMessage extends NatsContextMessage = NatsContextMessage> (): TMessage => this.message as TMessage,
+      getSubject: () => this.message.subject
+    }
+  }
+
+  private wrapMessage (message: NatsContextMessage): NatsContextMessage {
+    if (!this.isServiceMessage(message)) {
+      return message
+    }
+
+    return new Proxy(message, {
+      get: (target, property, receiver) => {
+        if (property === 'respond' || property === 'respondError') {
+          const original = Reflect.get(target, property, receiver) as (...args: unknown[]) => unknown
+
+          return (...args: unknown[]) => {
+            this.responded = true
+
+            return original.apply(target, args)
+          }
+        }
+
+        return Reflect.get(target, property, receiver)
+      }
+    })
+  }
+
+  private isServiceMessage (message: NatsContextMessage): message is ServiceMsg {
+    return typeof (message as ServiceMsg).respondError === 'function'
+  }
+}

--- a/packages/api/nestjs-nats/lib/exception-filters/nats-exception-filter.ts
+++ b/packages/api/nestjs-nats/lib/exception-filters/nats-exception-filter.ts
@@ -1,0 +1,27 @@
+import type { ExceptionFilter, Type } from '@nestjs/common'
+import type { NatsArgumentsHost } from './nats-arguments-host.js'
+
+export interface NatsServiceErrorResponse {
+  code: number
+  description: string
+  data?: string
+}
+
+export interface NatsExceptionFilter<T = unknown, TResult = unknown> extends ExceptionFilter<T> {
+  catch (exception: T, host: NatsArgumentsHost): TResult | Promise<TResult>
+}
+
+export interface ResolvedNatsExceptionFilter {
+  exceptions: Type<unknown>[]
+  filter: NatsExceptionFilter
+}
+
+export function isNatsServiceErrorResponse (value: unknown): value is NatsServiceErrorResponse {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const response = value as Partial<NatsServiceErrorResponse>
+
+  return typeof response.code === 'number' && typeof response.description === 'string'
+}

--- a/packages/api/nestjs-nats/lib/exception-filters/nats-exception-handler.ts
+++ b/packages/api/nestjs-nats/lib/exception-filters/nats-exception-handler.ts
@@ -1,0 +1,76 @@
+import { Logger } from '@nestjs/common'
+import { JsonApiError } from '@wisemen/api-error'
+import { captureException } from '@wisemen/opentelemetry'
+import { NatsExecutionContextHost, type NatsContextMessage } from './nats-arguments-host.js'
+import { isNatsServiceErrorResponse, type NatsServiceErrorResponse, type ResolvedNatsExceptionFilter } from './nats-exception-filter.js'
+
+interface NatsExceptionContext {
+  captureMessage: string
+  filters?: ResolvedNatsExceptionFilter[]
+  handlerName?: string
+  logContext: string
+  message: NatsContextMessage
+}
+
+export interface NatsExceptionHandlingResult {
+  handled: boolean
+  responded: boolean
+  response?: NatsServiceErrorResponse
+}
+
+export class NatsExceptionHandler {
+  async handle (
+    exception: unknown,
+    context: NatsExceptionContext
+  ): Promise<NatsExceptionHandlingResult> {
+    const host = new NatsExecutionContextHost(context.message, context.handlerName)
+
+    for (const filter of context.filters ?? []) {
+      if (!this.matches(filter, exception)) {
+        continue
+      }
+
+      const result = await filter.filter.catch(exception, host)
+
+      return {
+        handled: true,
+        responded: host.hasResponded,
+        response: isNatsServiceErrorResponse(result) ? result : undefined
+      }
+    }
+
+    const errorMessage = this.getErrorMessage(exception)
+    const error = new Error(`${context.captureMessage}: ${errorMessage}`, { cause: exception })
+
+    Logger.error(
+      `Nats message handler threw error ${errorMessage}`,
+      context.logContext
+    )
+    captureException(error)
+
+    return {
+      handled: false,
+      responded: host.hasResponded
+    }
+  }
+
+  private matches (filter: ResolvedNatsExceptionFilter, exception: unknown): boolean {
+    if (filter.exceptions.length === 0) {
+      return true
+    }
+
+    return filter.exceptions.some(exceptionType => exception instanceof exceptionType)
+  }
+
+  private getErrorMessage (exception: unknown): string {
+    if (exception instanceof JsonApiError) {
+      return `[${exception.status}]: ${JSON.stringify(exception.errors)}`
+    }
+
+    if (exception instanceof Error) {
+      return exception.message ?? 'unknown cause'
+    }
+
+    return 'unknown cause'
+  }
+}

--- a/packages/api/nestjs-nats/lib/index.ts
+++ b/packages/api/nestjs-nats/lib/index.ts
@@ -9,6 +9,8 @@ export { NatsClient } from './nats.client.js'
 
 // Errors
 export { NatsUnavailableError } from './errors/nats-unavailable.error.js'
+export type { NatsArgumentsHost } from './exception-filters/nats-arguments-host.js'
+export type { NatsExceptionFilter, NatsServiceErrorResponse } from './exception-filters/nats-exception-filter.js'
 
 // Utility
 export { natsSubject } from './nats-subject.js'

--- a/packages/api/nestjs-nats/lib/message-handler/nats-message-handler.ts
+++ b/packages/api/nestjs-nats/lib/message-handler/nats-message-handler.ts
@@ -6,6 +6,7 @@ import type { Context } from '@opentelemetry/api'
 import { propagation, context, trace, SpanStatusCode } from '@opentelemetry/api'
 import { getOtelTracer, type TraceContextCarrier } from '@wisemen/opentelemetry'
 import type { NatsParameter } from '#src/parameters/nats-parameter.js'
+import type { ResolvedNatsExceptionFilter } from '#src/exception-filters/nats-exception-filter.js'
 
 export class NatsMessageHandlerFunction {
   /**
@@ -16,8 +17,17 @@ export class NatsMessageHandlerFunction {
   constructor (
     private parameters: NatsParameter[],
     private handler: (...args: unknown[]) => unknown,
-    private context?: string
+    private context?: string,
+    private readonly exceptionFilters: ResolvedNatsExceptionFilter[] = []
   ) {}
+
+  get handlerContext (): string | undefined {
+    return this.context
+  }
+
+  get filters (): ResolvedNatsExceptionFilter[] {
+    return Array.from(this.exceptionFilters)
+  }
 
   async handle (message: Msg | JsMsg): Promise<unknown> {
     const traceContext: TraceContextCarrier = {

--- a/packages/api/nestjs-nats/lib/nats-application-factory.ts
+++ b/packages/api/nestjs-nats/lib/nats-application-factory.ts
@@ -11,6 +11,7 @@ import { isNatsServiceEndpoint, getNatsServiceEndpointConfig } from './services/
 import { NATS_STREAMS_TOKEN } from './tokens.js'
 import type { NestjsProvider } from './providers/providers-explorer.js'
 import { ProvidersExplorer } from './providers/providers-explorer.js'
+import { getNatsExceptionFilters } from './exception-filters/get-nats-exception-filters.js'
 
 @Injectable()
 export class NatsApplicationFactory {
@@ -57,34 +58,66 @@ export class NatsApplicationFactory {
   async addSubscriberHandler (app: NatsApplication, provider: NestjsProvider): Promise<void> {
     const handlers = getNatsMessageHandlerConfig(provider.providerClass)
     const subscriber = getNatsSubscriberHandlerConfig(provider.providerClass, this.config)
+    const classExceptionFilters = getNatsExceptionFilters(this.providerExplorer, provider.providerClass)
 
     for (const handler of handlers) {
       const parameters = getNatsParameters(provider.providerClass, handler.methodName)
       const callback = this.bind(provider.providerInstance, handler.methodName)
+      const exceptionFilters = getNatsExceptionFilters(
+        this.providerExplorer,
+        provider.providerClass,
+        handler.methodName
+      )
 
-      await app.addSubscriberHandler({ parameters, subscriber, callback, event: handler.event })
+      await app.addSubscriberHandler({
+        parameters,
+        subscriber,
+        callback,
+        event: handler.event,
+        classExceptionFilters,
+        exceptionFilters
+      })
     }
   }
 
   async addConsumerHandler (app: NatsApplication, provider: NestjsProvider): Promise<void> {
     const handlers = getNatsMessageHandlerConfig(provider.providerClass)
     const consumer = getNatsConsumerHandlerConfig(provider.providerClass, this.config)
+    const classExceptionFilters = getNatsExceptionFilters(this.providerExplorer, provider.providerClass)
 
     for (const handler of handlers) {
       const parameters = getNatsParameters(provider.providerClass, handler.methodName)
       const callback = this.bind(provider.providerInstance, handler.methodName)
+      const exceptionFilters = getNatsExceptionFilters(
+        this.providerExplorer,
+        provider.providerClass,
+        handler.methodName
+      )
 
-      await app.addConsumerHandler({ parameters, consumer, callback, event: handler.event })
+      await app.addConsumerHandler({
+        parameters,
+        consumer,
+        callback,
+        event: handler.event,
+        classExceptionFilters,
+        exceptionFilters
+      })
     }
   }
 
   async addServiceEndpoint (app: NatsApplication, provider: NestjsProvider): Promise<void> {
     const handlers = getNatsMessageHandlerConfig(provider.providerClass)
     const endpoint = getNatsServiceEndpointConfig(provider.providerClass, this.config)
+    const classExceptionFilters = getNatsExceptionFilters(this.providerExplorer, provider.providerClass)
 
     for (const handler of handlers) {
       const parameters = getNatsParameters(provider.providerClass, handler.methodName)
       const callback = this.bind(provider.providerInstance, handler.methodName)
+      const exceptionFilters = getNatsExceptionFilters(
+        this.providerExplorer,
+        provider.providerClass,
+        handler.methodName
+      )
 
       await app.addServiceEndpoint({
         name: endpoint.name,
@@ -95,7 +128,9 @@ export class NatsApplicationFactory {
         subject: endpoint.subject,
         parameters,
         callback,
-        event: handler.event
+        event: handler.event,
+        classExceptionFilters,
+        exceptionFilters
       })
     }
   }

--- a/packages/api/nestjs-nats/lib/nats-application.ts
+++ b/packages/api/nestjs-nats/lib/nats-application.ts
@@ -12,6 +12,7 @@ import { NatsConsumerManager } from './consumers/nats-consumer.manager.js'
 import { NatsMessageHandlerFunction } from './message-handler/nats-message-handler.js'
 import { NatsStreamManager } from './streams/nats-stream.manager.js'
 import type { NatsParameter, NatsParameterContext } from './parameters/nats-parameter.js'
+import type { ResolvedNatsExceptionFilter } from './exception-filters/nats-exception-filter.js'
 
 export type CreateStreamConfig = Parameters<StreamAPI['add']>['0'] & {
   connectionOptions: NamedConnectionOptions
@@ -22,22 +23,28 @@ export interface CreateServiceConfig extends ServiceConfig {
 }
 
 export interface CreateServiceEndpointConfig extends EndpointOptions {
+  classExceptionFilters: ResolvedNatsExceptionFilter[]
   name: string
   event?: CloudEventHandlerOptions
+  exceptionFilters: ResolvedNatsExceptionFilter[]
   service: CreateServiceConfig
   parameters: NatsParameter[]
   callback: (...args: unknown[]) => Promise<unknown>
 }
 
 export interface CreateConsumerHandlerConfig {
+  classExceptionFilters: ResolvedNatsExceptionFilter[]
   event?: CloudEventHandlerOptions
   consumer: NatsConsumerConfig
+  exceptionFilters: ResolvedNatsExceptionFilter[]
   parameters: NatsParameter[]
   callback: (...args: unknown[]) => Promise<unknown>
 }
 
 export interface CreateSubscriberHandlerConfig {
+  classExceptionFilters: ResolvedNatsExceptionFilter[]
   event?: CloudEventHandlerOptions
+  exceptionFilters: ResolvedNatsExceptionFilter[]
   subscriber: NatsSubscriberConfig
   parameters: NatsParameter[]
   callback: (...args: unknown[]) => Promise<unknown>
@@ -82,8 +89,11 @@ export class NatsApplication {
     const handler = new NatsMessageHandlerFunction(
       config.parameters, 
       config.callback,
-      config.consumer.name + '.' + config.callback.name
+      config.consumer.name + '.' + config.callback.name,
+      config.exceptionFilters
     )
+
+    consumer.addExceptionFilters(config.classExceptionFilters)
 
     if (config.event !== undefined) {
       consumer.addCloudEventHandler(config.event, handler)
@@ -101,8 +111,11 @@ export class NatsApplication {
     const handler = new NatsMessageHandlerFunction(
       config.parameters,
       config.callback,
-      config.subscriber.name + '.' + config.callback.name
+      config.subscriber.name + '.' + config.callback.name,
+      config.exceptionFilters
     )
+
+    subscriber.addExceptionFilters(config.classExceptionFilters)
 
     if (config.event !== undefined) {
       subscriber.addCloudEventHandler(config.event, handler)

--- a/packages/api/nestjs-nats/lib/providers/providers-explorer.ts
+++ b/packages/api/nestjs-nats/lib/providers/providers-explorer.ts
@@ -42,4 +42,10 @@ export class ProvidersExplorer {
 
     return Array.from(this._providers)
   }
+
+  getProviderInstance<T> (providerClass: Type<T>): T | undefined {
+    const provider = this.providers.find(p => p.providerClass === providerClass)
+
+    return provider?.providerInstance as T | undefined
+  }
 }

--- a/packages/api/nestjs-nats/lib/services/nats-service-endpoint.decorator.ts
+++ b/packages/api/nestjs-nats/lib/services/nats-service-endpoint.decorator.ts
@@ -16,7 +16,7 @@ type ConfigFunction = (config: ConfigService) => NatsServiceEndpointDecoratorOpt
 
 export type NatsServiceEndpointDecoratorConfig = Omit<
   CreateServiceEndpointConfig,
-  'parameters' | 'callback' | 'event'
+  'parameters' | 'callback' | 'event' | 'classExceptionFilters' | 'exceptionFilters'
 >
 
 export function NatsServiceEndpoint (configFn: ConfigFunction): ClassDecorator {

--- a/packages/api/nestjs-nats/lib/services/nats-service-endpoint.ts
+++ b/packages/api/nestjs-nats/lib/services/nats-service-endpoint.ts
@@ -6,17 +6,31 @@ import type { ServiceMsg } from '@nats-io/services'
 import type { NatsMessageHandlerFunction } from '#src/message-handler/nats-message-handler.js'
 import type { CloudEventHandlerOptions } from '#src/message-handler/on-nats-message.decorator.js'
 import { CloudEvent } from '#src/cloud-event/cloud-event.js'
+import { NatsExceptionHandler } from '#src/exception-filters/nats-exception-handler.js'
+import type { ResolvedNatsExceptionFilter } from '#src/exception-filters/nats-exception-filter.js'
 
 type CloudEventKey = string
 
 export class NatsServiceEndpoint {
   private fallbackHandler: NatsMessageHandlerFunction | undefined
   private cloudEventHandlers: Map<CloudEventKey, NatsMessageHandlerFunction> = new Map()
+  private readonly exceptionFilters: ResolvedNatsExceptionFilter[] = []
+  private readonly exceptionHandler = new NatsExceptionHandler()
 
   constructor (
     private name: string,
     private stream: QueuedIterator<ServiceMsg>
   ) {}
+
+  addExceptionFilters (filters: ResolvedNatsExceptionFilter[]): void {
+    for (const filter of filters) {
+      if (this.exceptionFilters.some(existing => existing.filter === filter.filter)) {
+        continue
+      }
+
+      this.exceptionFilters.push(filter)
+    }
+  }
 
   addCloudEventHandler (
     eventOptions: CloudEventHandlerOptions,
@@ -63,8 +77,10 @@ export class NatsServiceEndpoint {
   }
 
   private async handleMessage (message: ServiceMsg): Promise<void> {
+    let handler: NatsMessageHandlerFunction | undefined
+
     try {
-      const handler = await this.getHandler(message)
+      handler = await this.getHandler(message)
       const response = await handler.handle(message)
 
       if (response instanceof Uint8Array) {
@@ -73,11 +89,30 @@ export class NatsServiceEndpoint {
         message.respond(new TextEncoder().encode(JSON.stringify(response)))
       }
     } catch (e) {
-      message.respondError(
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        (e as Error).message,
-        JSON.stringify(e)
-      )
+      const result = await this.exceptionHandler.handle(e, {
+        captureMessage: 'unable to handle service request message',
+        filters: handler?.filters ?? this.exceptionFilters,
+        handlerName: handler?.handlerContext,
+        logContext: `NATS endpoint ${this.name}`,
+        message
+      })
+
+      if (result.response !== undefined) {
+        message.respondError(
+          result.response.code,
+          result.response.description,
+          result.response.data
+        )
+        return
+      }
+
+      if (!result.responded) {
+        message.respondError(
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          e instanceof Error ? e.message : 'unknown cause',
+          JSON.stringify(e)
+        )
+      }
     }
   }
 

--- a/packages/api/nestjs-nats/lib/services/nats-service.ts
+++ b/packages/api/nestjs-nats/lib/services/nats-service.ts
@@ -21,6 +21,8 @@ export class NatsService {
       this.endpoints.set(config.name, endpoint)
     }
 
+    endpoint.addExceptionFilters(config.classExceptionFilters)
+
     const paramContext: NatsParameterContext = { subject: config.subject ?? '' }
 
     config.parameters.forEach(param => param.setContext(paramContext))
@@ -28,7 +30,8 @@ export class NatsService {
     const handler = new NatsMessageHandlerFunction(
       config.parameters, 
       config.callback,
-      config.service.name + '.' + config.callback.name
+      config.service.name + '.' + config.callback.name,
+      config.exceptionFilters
     )
 
     if (config.event !== undefined) {

--- a/packages/api/nestjs-nats/lib/subscribers/nats-subscription.ts
+++ b/packages/api/nestjs-nats/lib/subscribers/nats-subscription.ts
@@ -1,20 +1,32 @@
 import type { Msg, Subscription } from '@nats-io/transport-node'
 import { Logger } from '@nestjs/common'
-import { captureException } from '@wisemen/opentelemetry'
 import { plainToInstance } from 'class-transformer'
 import { validate } from 'class-validator'
-import { JsonApiError } from '@wisemen/api-error'
 import type { NatsMessageHandlerFunction } from '#src/message-handler/nats-message-handler.js'
 import type { CloudEventHandlerOptions } from '#src/message-handler/on-nats-message.decorator.js'
 import { CloudEvent } from '#src/cloud-event/cloud-event.js'
+import { NatsExceptionHandler } from '#src/exception-filters/nats-exception-handler.js'
+import type { ResolvedNatsExceptionFilter } from '#src/exception-filters/nats-exception-filter.js'
 
 type CloudEventKey = string
 
 export class NatsSubscription {
   private fallbackHandler: NatsMessageHandlerFunction | undefined
   private cloudEventHandlers: Map<CloudEventKey, NatsMessageHandlerFunction> = new Map()
+  private readonly exceptionFilters: ResolvedNatsExceptionFilter[] = []
+  private readonly exceptionHandler = new NatsExceptionHandler()
 
   constructor (private subscription: Subscription) {}
+
+  addExceptionFilters (filters: ResolvedNatsExceptionFilter[]): void {
+    for (const filter of filters) {
+      if (this.exceptionFilters.some(existing => existing.filter === filter.filter)) {
+        continue
+      }
+
+      this.exceptionFilters.push(filter)
+    }
+  }
 
   addCloudEventHandler (
     eventOptions: CloudEventHandlerOptions,
@@ -72,26 +84,20 @@ export class NatsSubscription {
   }
 
   private async handleMessage (message: Msg): Promise<void> {
+    let handler: NatsMessageHandlerFunction | undefined
+
     try {
-      const handler = await this.getHandler(message)
+      handler = await this.getHandler(message)
 
       await handler.handle(message)
     } catch (e) {
-      let msg: string = 'unknown cause'
-
-      if (e instanceof JsonApiError) {
-        msg = `[${e.status}]: ${JSON.stringify(e.errors)}`
-      } else if (e instanceof Error) {
-        msg = e.message ?? 'unknown cause'
-      }
-
-      const error = new Error(`unable to handle subscription message: ${msg}`, { cause: e })
-
-      Logger.error(
-        `Nats message handler threw error ${msg}`,
-        `NATS Subscriber ${this.subscription.getSubject()}`
-      )
-      captureException(error)
+      await this.exceptionHandler.handle(e, {
+        captureMessage: 'unable to handle subscription message',
+        filters: handler?.filters ?? this.exceptionFilters,
+        handlerName: handler?.handlerContext,
+        logContext: `NATS Subscriber ${this.subscription.getSubject()}`,
+        message
+      })
     }
   }
 

--- a/packages/api/nestjs-nats/package.json
+++ b/packages/api/nestjs-nats/package.json
@@ -23,7 +23,7 @@
     "clean": "rm -rf ./dist",
     "build": "tsc",
     "pretest": "pnpm build",
-    "test": "node --test ./dist/lib/**/*.test.js",
+    "test": "node --test ./test/**/*.test.js",
     "prerelease": "npm run build",
     "release": "pnpx release-it"
   },

--- a/packages/api/nestjs-nats/test/get-nats-exception-filters.test.js
+++ b/packages/api/nestjs-nats/test/get-nats-exception-filters.test.js
@@ -1,0 +1,47 @@
+import 'reflect-metadata'
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { Catch, UseFilters } from '@nestjs/common'
+import { getNatsExceptionFilters } from '../dist/exception-filters/get-nats-exception-filters.js'
+
+class TestError extends Error {}
+
+class ClassFilter {
+  catch () {}
+}
+
+class MethodFilter {
+  catch () {}
+}
+
+Catch(TestError)(ClassFilter)
+
+const methodFilter = new MethodFilter()
+
+class Handler {
+  handle () {}
+}
+
+UseFilters(ClassFilter)(Handler)
+UseFilters(methodFilter)(
+  Handler.prototype,
+  'handle',
+  Object.getOwnPropertyDescriptor(Handler.prototype, 'handle')
+)
+
+describe('getNatsExceptionFilters', () => {
+  it('resolves method and class filters in execution order', () => {
+    const classFilter = new ClassFilter()
+    const providersExplorer = {
+      getProviderInstance: (providerClass) => providerClass === ClassFilter ? classFilter : undefined
+    }
+
+    const filters = getNatsExceptionFilters(providersExplorer, Handler, 'handle')
+
+    assert.equal(filters.length, 2)
+    assert.equal(filters[0]?.filter, methodFilter)
+    assert.deepEqual(filters[0]?.exceptions, [])
+    assert.equal(filters[1]?.filter, classFilter)
+    assert.deepEqual(filters[1]?.exceptions, [TestError])
+  })
+})

--- a/packages/api/nestjs-nats/test/nats-service-endpoint.test.js
+++ b/packages/api/nestjs-nats/test/nats-service-endpoint.test.js
@@ -1,0 +1,96 @@
+import 'reflect-metadata'
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { Catch } from '@nestjs/common'
+import { NatsServiceEndpoint } from '../dist/services/nats-service-endpoint.js'
+
+class TestError extends Error {}
+
+class ReturningFilter {
+  catch (exception) {
+    return {
+      code: 422,
+      description: exception.message,
+      data: JSON.stringify({ handled: true })
+    }
+  }
+}
+
+class RespondingFilter {
+  catch (_exception, host) {
+    host
+      .switchToNats()
+      .getMessage()
+      .respondError(409, 'handled in filter', JSON.stringify({ responded: true }))
+  }
+}
+
+Catch(TestError)(ReturningFilter)
+Catch(TestError)(RespondingFilter)
+
+describe('NatsServiceEndpoint', () => {
+  it('uses filter return values for request-reply errors', async () => {
+    const endpoint = new NatsServiceEndpoint('TestEndpoint', createStream())
+    endpoint.addFallBackHandler({
+      filters: [{
+        exceptions: [TestError],
+        filter: new ReturningFilter()
+      }],
+      handlerContext: 'TestEndpoint.handle',
+      handle: async () => {
+        throw new TestError('boom')
+      }
+    })
+
+    const replies = []
+    const message = createMessage(replies)
+
+    await endpoint.handleMessage(message)
+
+    assert.deepEqual(replies, [
+      [422, 'boom', JSON.stringify({ handled: true })]
+    ])
+  })
+
+  it('does not send a fallback response when the filter already responded', async () => {
+    const endpoint = new NatsServiceEndpoint('TestEndpoint', createStream())
+    endpoint.addFallBackHandler({
+      filters: [{
+        exceptions: [TestError],
+        filter: new RespondingFilter()
+      }],
+      handlerContext: 'TestEndpoint.handle',
+      handle: async () => {
+        throw new TestError('boom')
+      }
+    })
+
+    const replies = []
+    const message = createMessage(replies)
+
+    await endpoint.handleMessage(message)
+
+    assert.deepEqual(replies, [
+      [409, 'handled in filter', JSON.stringify({ responded: true })]
+    ])
+  })
+})
+
+function createMessage (replies) {
+  return {
+    data: new Uint8Array(),
+    respond: () => true,
+    respondError: (code, description, data) => {
+      replies.push([code, description, data])
+
+      return true
+    },
+    subject: 'service.subject'
+  }
+}
+
+function createStream () {
+  return {
+    async *[Symbol.asyncIterator] () {}
+  }
+}


### PR DESCRIPTION
## What changed
- consolidated NATS subscriber, consumer, and service endpoint error handling behind a shared exception handler
- added Nest-style NATS exception filter support with a NATS arguments host and filter resolution during handler registration
- updated the `@wisemen/nestjs-nats` test wiring and added focused tests for filter resolution and request-reply error behavior

## Why
The package had duplicated error logging and handling responsibilities across transport classes and the underlying handler path. This change centralizes that responsibility and lets package consumers define their own exception filters for request-reply flows.

## Impact
Users of `@wisemen/nestjs-nats` can now bind Nest-style exception filters to handlers and service endpoints, while the package keeps transport-level ack/nak/respond behavior separate from error processing.

## Validation
- `pnpm --filter @wisemen/api-error build`
- `pnpm --filter @wisemen/opentelemetry build`
- `pnpm --filter @wisemen/nestjs-nats test`