### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/cool-jolly-ram.md
+++ b/.bumpy/cool-jolly-ram.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-redis": patch
----
-
-Add Redis distributed locking with setLock and releaseLock

--- a/.bumpy/cool-rusty-wasp.md
+++ b/.bumpy/cool-rusty-wasp.md
@@ -1,5 +1,0 @@
----
-"@wisemen/csv": minor
----
-
-feat: RFC escaping of values

--- a/packages/api/csv/CHANGELOG.md
+++ b/packages/api/csv/CHANGELOG.md
@@ -1,6 +1,12 @@
 # @wisemen/csv
 
 
+
+## 0.2.0
+<sub>2026-06-29</sub>
+
+- [#1256](https://github.com/wisemen-digital/wisemen-core/pull/1256)  *(minor)* Thanks [@G0maa](https://github.com/G0maa)! - feat: RFC escaping of values
+
 ## 0.1.1
 <sub>2026-06-16</sub>
 

--- a/packages/api/csv/package.json
+++ b/packages/api/csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/csv",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/nestjs-redis/CHANGELOG.md
+++ b/packages/api/nestjs-redis/CHANGELOG.md
@@ -1,6 +1,12 @@
 # @wisemen/nestjs-redis
 
 
+
+## 1.0.2
+<sub>2026-06-29</sub>
+
+- [#1312](https://github.com/wisemen-digital/wisemen-core/pull/1312)  *(patch)* Thanks [@SebastiaanVanspauwen](https://github.com/SebastiaanVanspauwen)! - Add Redis distributed locking with setLock and releaseLock
+
 ## 1.0.1
 <sub>2026-06-16</sub>
 

--- a/packages/api/nestjs-redis/package.json
+++ b/packages/api/nestjs-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-redis",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/csv` 0.1.1 → **0.2.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1322/changes#diff-04a0e22a3e3783ec9bc4c4d103100f9e448e31a91ac59bd6bbe7c344ad21eff1)</sub>

- feat: RFC escaping of values ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1322/changes#diff-1084d99a0619eca7f08fcb1158e2e97fa1241cfb49364860f41c98bc3c1368f5))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/nestjs-redis` 1.0.1 → **1.0.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1322/changes#diff-adea7960faef76179c559df25509dc6de014f6526a86700b7724ffe66e1dda76)</sub>

- Add Redis distributed locking with setLock and releaseLock ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1322/changes#diff-db397dbd86be3c8efb372cd1944f31622e7ba793c16ab34e220949a7311f4b35))
