### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/old-dry-newt.md
+++ b/.bumpy/old-dry-newt.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": minor
----
-
-Add a built in unsaved changes pop-up in the form dialogs using the dialog chin

--- a/.bumpy/red-rare-snow.md
+++ b/.bumpy/red-rare-snow.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Add export for the `useDialogChin`

--- a/.bumpy/rusty-happy-crab.md
+++ b/.bumpy/rusty-happy-crab.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Add horizontal scroll to tabs when overflowing

--- a/.bumpy/shy-safe-hen.md
+++ b/.bumpy/shy-safe-hen.md
@@ -1,9 +1,0 @@
----
-"@wisemen/vue-core-components": patch
-"@wisemen/vue-core-custom-views": none
-"@wisemen/vue-core-design-system": patch
-"@wisemen/vue-core-utils": patch
-"@wisemen/vue-core-zod-validation": patch
----
-
-Added libphonenumber-js max + bumped the dependency

--- a/.bumpy/thin-thin-urchin.md
+++ b/.bumpy/thin-thin-urchin.md
@@ -1,9 +1,0 @@
----
-"@wisemen/vue-core-components": none
-"@wisemen/vue-core-custom-views": patch
-"@wisemen/vue-core-design-system": none
-"@wisemen/vue-core-utils": none
-"@wisemen/vue-core-zod-validation": none
----
-
-Fixed peer dependency versioning

--- a/packages/web/components-next/CHANGELOG.md
+++ b/packages/web/components-next/CHANGELOG.md
@@ -1,6 +1,12 @@
 # @wisemen/vue-core-components
 
 
+
+## 3.0.3
+<sub>2026-06-30</sub>
+
+- [#1260](https://github.com/wisemen-digital/wisemen-core/pull/1260)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Added libphonenumber-js max + bumped the dependency
+
 ## 3.0.2
 <sub>2026-06-09</sub>
 

--- a/packages/web/components-next/package.json
+++ b/packages/web/components-next/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/packages/web/custom-views/CHANGELOG.md
+++ b/packages/web/custom-views/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 
 
+
+## 0.3.1
+<sub>2026-06-30</sub>
+
+- [#1260](https://github.com/wisemen-digital/wisemen-core/pull/1260)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Fixed peer dependency versioning
+
 ## 0.3.0
 <sub>2026-06-12</sub>
 

--- a/packages/web/custom-views/package.json
+++ b/packages/web/custom-views/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -10,6 +10,15 @@
 
 
 
+
+## 1.8.0
+<sub>2026-06-30</sub>
+
+- [#1249](https://github.com/wisemen-digital/wisemen-core/pull/1249)  *(minor)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Add a built in unsaved changes pop-up in the form dialogs using the dialog chin
+- [#1260](https://github.com/wisemen-digital/wisemen-core/pull/1260)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Added libphonenumber-js max + bumped the dependency
+- [#1311](https://github.com/wisemen-digital/wisemen-core/pull/1311)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Add horizontal scroll to tabs when overflowing
+- [#1327](https://github.com/wisemen-digital/wisemen-core/pull/1327)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Add export for the `useDialogChin`
+
 ## 1.7.1
 <sub>2026-06-25</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",

--- a/packages/web/utils/CHANGELOG.md
+++ b/packages/web/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @wisemen/vue-core-utils
 
+
+## 0.1.1
+<sub>2026-06-30</sub>
+
+- [#1260](https://github.com/wisemen-digital/wisemen-core/pull/1260)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Added libphonenumber-js max + bumped the dependency
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/web/utils/package.json
+++ b/packages/web/utils/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/packages/web/zod-validation/CHANGELOG.md
+++ b/packages/web/zod-validation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @wisemen/vue-core-zod-validation
 
+
+## 0.0.4
+<sub>2026-06-30</sub>
+
+- [#1260](https://github.com/wisemen-digital/wisemen-core/pull/1260)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Added libphonenumber-js max + bumped the dependency
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/web/zod-validation/package.json
+++ b/packages/web/zod-validation/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/vue-core-design-system` 1.7.1 → **1.8.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Added libphonenumber-js max + bumped the dependency ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-351e18f4690a94914e744884da3c5ca985e9ed95c9450d9e286d01b7d2bc2088))
- Add a built in unsaved changes pop-up in the form dialogs using the dialog chin ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-d40719f2f29a96dd4dc1b25aa6b45fc38273af6af78c6a8c3cfda6010eb8a7b0))
- Add horizontal scroll to tabs when overflowing ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-b261aa40a361ffabdd21162607a8a038d9514a904aedb798b477e7caa6832326))
- Add export for the `useDialogChin` ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-7f002f00acbaec23b60434969a8a29b36db7051778b6cdc7516d078510596d07))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/vue-core-components` 3.0.2 → **3.0.3** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-dacd957532d07c2981690c94fd022af305f9e1423c1e310c9aa0f63ce5c5ac3c)</sub>

- Added libphonenumber-js max + bumped the dependency ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-351e18f4690a94914e744884da3c5ca985e9ed95c9450d9e286d01b7d2bc2088))

#### `@wisemen/vue-core-custom-views` 0.3.0 → **0.3.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-698fe1cb31ce021af5b2ba00ba239f7f739eff1802c11a466be51eac75b7a1ce)</sub>

- Fixed peer dependency versioning ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-c0863f906fbbdcc8b435ec98ba01690a84206a4c81da7c0f4621cbf7ad15d93a))

#### `@wisemen/vue-core-utils` 0.1.0 → **0.1.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-2c3cc3bb7969ba02b693280a3a4cd8bbfc5a231e57d280d7ecc7b4024fb34461)</sub>

- Added libphonenumber-js max + bumped the dependency ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-351e18f4690a94914e744884da3c5ca985e9ed95c9450d9e286d01b7d2bc2088))

#### `@wisemen/vue-core-zod-validation` 0.0.3 → **0.0.4** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-fc6b2d2f7bd09868774384a3879454947ed70a7bd86464953f46b48e26a4acb5)</sub>

- Added libphonenumber-js max + bumped the dependency ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1325/changes#diff-351e18f4690a94914e744884da3c5ca985e9ed95c9450d9e286d01b7d2bc2088))
