### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/shy-zany-wasp.md
+++ b/.bumpy/shy-zany-wasp.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": minor
----
-
-Add "Discard changes" and "Keep editing" action buttons to the default unsaved-changes chin in `UIFormDialog`

--- a/.bumpy/warm-smooth-swift.md
+++ b/.bumpy/warm-smooth-swift.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-feature-flags": patch
----
-
-Use pathToFileURL for absolute path resolution

--- a/packages/api/nestjs-feature-flags/CHANGELOG.md
+++ b/packages/api/nestjs-feature-flags/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+
+## 0.0.4
+<sub>2026-07-03</sub>
+
+- [#1357](https://github.com/wisemen-digital/wisemen-core/pull/1357)  *(patch)* Thanks [@sander-coemans](https://github.com/sander-coemans)! - Use pathToFileURL for absolute path resolution
+
 ## 0.0.3
 <sub>2026-06-30</sub>
 

--- a/packages/api/nestjs-feature-flags/package.json
+++ b/packages/api/nestjs-feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-feature-flags",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -15,6 +15,12 @@
 
 
 
+
+## 1.11.0
+<sub>2026-07-03</sub>
+
+- [#1351](https://github.com/wisemen-digital/wisemen-core/pull/1351)  *(minor)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Add "Discard changes" and "Keep editing" action buttons to the default unsaved-changes chin in `UIFormDialog`
+
 ## 1.10.1
 <sub>2026-07-02</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/vue-core-design-system` 1.10.1 → **1.11.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1360/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Add "Discard changes" and "Keep editing" action buttons to the default unsaved-changes chin in `UIFormDialog` ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1360/changes#diff-783f56e953cabb6c0b5515999c16c0689f91adb025213ffaec8f1e73ac9e0bee))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/nestjs-feature-flags` 0.0.3 → **0.0.4** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1360/changes#diff-890a7f6a0164fc3abf7011317a3c8f9a872ad7a91e002cf2e61bf1ce54e570d1)</sub>

- Use pathToFileURL for absolute path resolution ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1360/changes#diff-72989913aa435bc76a94d843c8d685dc226b9751c22c889d143f3f582ffd529e))
