### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/gentle-lively-mist.md
+++ b/.bumpy/gentle-lively-mist.md
@@ -1,5 +1,0 @@
----
-"@wisemen/datewise": patch
----
-
-Export TimestampTransformer

--- a/.bumpy/young-neat-glow.md
+++ b/.bumpy/young-neat-glow.md
@@ -1,5 +1,0 @@
----
-"@wisemen/monetary": patch
----
-
-Add optional persistence of precision on monetary column

--- a/packages/api/datewise/CHANGELOG.md
+++ b/packages/api/datewise/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 1.0.14
+<sub>2026-07-04</sub>
+
+- [#1365](https://github.com/wisemen-digital/wisemen-core/pull/1365)  *(patch)* Thanks [@YuHangHuu](https://github.com/YuHangHuu)! - Export TimestampTransformer
+
 ## 1.0.13
 <sub>2026-06-25</sub>
 

--- a/packages/api/datewise/package.json
+++ b/packages/api/datewise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/datewise",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/monetary/CHANGELOG.md
+++ b/packages/api/monetary/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 
 
+
+## 0.5.2
+<sub>2026-07-04</sub>
+
+- [#1364](https://github.com/wisemen-digital/wisemen-core/pull/1364)  *(patch)* Thanks [@YuHangHuu](https://github.com/YuHangHuu)! - Add optional persistence of precision on monetary column
+
 ## 0.5.1
 <sub>2026-06-17</sub>
 

--- a/packages/api/monetary/package.json
+++ b/packages/api/monetary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/monetary",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/datewise` 1.0.13 → **1.0.14** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1366/changes#diff-88a4357e34692fb8c47dd40f7e67e57f7dcddebdfabc0748f8ae39987bb00f80)</sub>

- Export TimestampTransformer ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1366/changes#diff-e2ca68bb8a0c79ec025f4a7e22feeabf77bd29ae4343887fcea5b92c8ccf3766))

#### `@wisemen/monetary` 0.5.1 → **0.5.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1366/changes#diff-6fef78bc0eff06a7e167873054f51680fe05003d64da6bce2c0827e36e633fa3)</sub>

- Add optional persistence of precision on monetary column ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1366/changes#diff-4f9494cc3b25efc281c12dd04a8a46ab0c27f529c9902ca63053927a595c3c9a))
