### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/pink-fresh-lily.md
+++ b/.bumpy/pink-fresh-lily.md
@@ -1,7 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Add an optional `getItemKey` prop to `UIAutocomplete` and `UISelect` for supplying a stable, unique key per item (defaults to `JSON.stringify(value)` when not provided).
-
-Also fixes `UISelect`: dropdown items were previously keyed with a random string regenerated on every render, so Vue tore down and recreated every option on any items/search/selection change instead of patching them. Item identity (for selected/non-selected matching) is now derived consistently from the same key.

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -16,6 +16,13 @@
 
 
 
+
+## 1.11.1
+<sub>2026-07-06</sub>
+
+- [#1371](https://github.com/wisemen-digital/wisemen-core/pull/1371)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Add an optional `getItemKey` prop to `UIAutocomplete` and `UISelect` for supplying a stable, unique key per item (defaults to `JSON.stringify(value)` when not provided).
+  Also fixes `UISelect`: dropdown items were previously keyed with a random string regenerated on every render, so Vue tore down and recreated every option on any items/search/selection change instead of patching them. Item identity (for selected/non-selected matching) is now derived consistently from the same key.
+
 ## 1.11.0
 <sub>2026-07-03</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/vue-core-design-system` 1.11.0 → **1.11.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1372/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Add an optional `getItemKey` prop to `UIAutocomplete` and `UISelect` for supplying a stable, unique key per item (defaults to `JSON.stringify(value)` when not provided). ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1372/changes#diff-f605aee1df69ca4df336df5c9c34b00124b7eddcdf087fb2006d025ddc332144))
  Also fixes `UISelect`: dropdown items were previously keyed with a random string regenerated on every render, so Vue tore down and recreated every option on any items/search/selection change instead of patching them. Item identity (for selected/non-selected matching) is now derived consistently from the same key.
