### PR TITLE
feat(rate-limit): rate-limited jobs for external APIs

### DIFF
--- a/packages/api/pgboss-nestjs-job/README.md
+++ b/packages/api/pgboss-nestjs-job/README.md
@@ -263,7 +263,9 @@ Each request the instrumented client sends consumes one token from the shared bu
 { source: "headers", remainingHeader?: string, resetHeader?: string, retryAfterHeader?: string }
 ```
 
-The headers default to `x-ratelimit-remaining`, `x-ratelimit-reset` (epoch seconds) and `retry-after`, and can be overridden per config. On **every** response the interceptor records the API's reported remaining/reset, so exhaustion is tracked proactively — not discovered one request too late on a failure. When the API reports the budget is spent, jobs for this key stop being fetched until the reset passes.
+The headers default to `x-ratelimit-remaining`, `x-ratelimit-reset` and `retry-after`, and can be overridden per config. On **every** response the interceptor records the API's reported remaining/reset, so exhaustion is tracked proactively — not discovered one request too late on a failure. When the API reports the budget is spent, jobs for this key stop being fetched until the reset passes.
+
+> The reset header is interpreted as a Unix timestamp in **seconds** (the common convention). APIs that report reset in epoch **milliseconds** are not supported — a millisecond value would be read as a far-future time and over-block the key. If you need one, normalize it before it reaches the limiter, or open an issue.
 
 ### `failure`: no header/limit info, only a backoff after a rejection
 
@@ -282,13 +284,23 @@ Rate-limit state is kept in Postgres (table `pgboss.rate_limit`, created automat
 On every poll, the worker asks the limiter which keys are currently blocked and excludes jobs carrying those keys from the fetch. Concretely:
 
 - A job that opts in is enqueued with its `rateLimited` key as a pg-boss group id.
-- When a key is exhausted (or backed off), jobs in that group simply stay in the `created` state — they are not fetched, not failed, not retried; they just wait.
-- Jobs in **other** groups on the same queue are unaffected and keep being fetched and processed normally.
-- Once the window rolls over (`static`), the reported `resetAt`/`remaining` allow it again (`headers`), or the backoff elapses (`failure`), the key stops being blocked and its jobs resume flowing on the next poll.
+- When a key is blocked, jobs in that group stay in the `created` (or `retry`) state — not fetched — until the block clears. Jobs in **other** groups on the same queue are unaffected and keep flowing.
+- The block clears when the window rolls over (`static`), the reported `resetAt` passes (`headers`), or the backoff/cooldown elapses (`failure`, or any mode after a `429`).
+
+#### Discovering a limit costs one retry
+
+The limiter learns a key is exhausted in one of two ways:
+
+- **Proactively** — the `static` token bucket runs out, or `headers` mode sees `remaining: 0`. Jobs for the key then wait in `created`, untouched: **not fetched, not failed.**
+- **Reactively** — a job that *was* already fetched makes a call that returns a **`429`**. On a 429 (in **any** mode) the interceptor blocks the key **and throws**, so that job **fails and consumes one `retryLimit` attempt**; it then waits for the block and re-runs.
+
+Because a reactive 429 fails the job, **give rate-limited jobs an adequate `retryLimit`** — under sustained limiting a job can burn through its retries across cooldown cycles and eventually dead-letter (a rate limit is not a permanent failure, but pg-boss can't tell the difference once retries are exhausted). When a 429 carries no `Retry-After`, the key blocks for a default **60 seconds** (`failure` mode uses its configured `backoffSeconds` instead).
 
 ### Overshoot caveat
 
 Gating happens once per poll and is binary (a key is either fetchable or not for that whole poll) — it is not a token bucket consulted per-job-per-worker. That means a single poll can fetch up to `batchSize` jobs for a not-yet-blocked key, and this can happen concurrently across all workers polling that queue, so a burst can overshoot the configured limit by up to `batchSize × workers` before the key is observed as blocked on the next poll. For hot queues where staying close to the limit matters, lower `batchSize` to reduce the size of a possible overshoot.
+
+The limiter throttles **across jobs** (it gates which jobs are fetched) and counts **per request**. It does **not** throttle the call volume **within** a single handler: `onRequest` counts each call but does not pause or block it, so a handler that makes many API calls in a loop will send them all in one run — potentially exceeding the limit for that job. If a single job legitimately makes many rate-limited calls, split the work across more jobs (one call each), or throttle inside the handler yourself.
 
 ### Producers vs. workers
 

--- a/packages/api/pgboss-nestjs-job/README.md
+++ b/packages/api/pgboss-nestjs-job/README.md
@@ -162,3 +162,134 @@ export class CuoptWorkerBouncer extends QueueBouncer {
   }
 }
 ```
+
+## Rate limiting
+
+Some jobs call an external API that has its own rate limit. Rate limiting lets the worker stop fetching those jobs once the limit is exhausted, instead of fetching them and having them fail (or hammering the external API).
+
+It has two halves:
+
+1. **Declare the limits centrally**, once per API, in the worker's `rateLimits` config (keyed by a rate-limit key).
+2. **Opt a job into a limit** by tagging it with that key via `super(data, { rateLimited: key })`.
+
+The config lives with the worker (not on each job class) because a rate limit is a property of the downstream API, shared by every job that calls it. The key rides with the job as a pg-boss group id, so the worker gates fetching and counts usage without any job-class discovery.
+
+### Declaring limits (worker config)
+
+```ts
+PgBossWorkerModule.forRoot({
+  queues: [{ queueName: "queue-name" }],
+  pgBossOptions: { /* ... */ },
+  rateLimits: {
+    "my-external-api": { source: "static", limit: 100, windowSeconds: 60 },
+  },
+});
+```
+
+`forRootAsync` accepts `rateLimits` as a static field alongside `inject`/`useFactory`:
+
+```ts
+PgBossWorkerModule.forRootAsync({
+  inject: [ConfigService],
+  useFactory: (config: ConfigService) => ({ pgBossOptions: { /* ... */ } }),
+  rateLimits: {
+    "my-external-api": { source: "static", limit: 100, windowSeconds: 60 },
+  },
+});
+```
+
+### Opting a job in
+
+```ts
+import { PgBossJob, BaseJob, BaseJobData } from "@wisemen/pgboss-nestjs-job";
+
+export interface MyApiJobData extends BaseJobData {
+  uuid: string;
+}
+
+@PgBossJob("queue-name")
+export class MyApiJob extends BaseJob<MyApiJobData> {
+  constructor(uuid: string) {
+    super({ uuid }, { rateLimited: "my-external-api" });
+  }
+}
+```
+
+The key identifies the shared limit bucket: jobs from different classes share a budget by using the same key. Jobs that hit the same API from different queues also share the one budget, since the config is keyed globally. `source` is a discriminated union with three modes (covered below).
+
+### Instrumenting API calls
+
+Accounting — counting usage, reading limit headers, reacting to 429s — happens **at the HTTP call**, via interceptors on a [`@wisemen/node-fetch`](../node-fetch) client. Register them once with `useRateLimiting(client, rateLimiter)`, then make the job's API calls through that client:
+
+```ts
+import { Injectable } from "@nestjs/common";
+import { createClient } from "@wisemen/node-fetch";
+import {
+  JobHandler, PgBossJobHandler, PgbossRateLimiter, useRateLimiting,
+} from "@wisemen/pgboss-nestjs-job";
+
+@Injectable()
+@PgBossJobHandler(MyApiJob)
+export class MyApiJobHandler extends JobHandler<MyApiJob> {
+  private readonly api = createClient({ baseUrl: "https://api.example.com" });
+
+  constructor(rateLimiter: PgbossRateLimiter) {
+    super();
+    useRateLimiting(this.api, rateLimiter);
+  }
+
+  async run(data: MyApiJobData): Promise<void> {
+    const res = await this.api.get("/resource");
+    // ...handle the response — no manual limiter calls needed
+  }
+}
+```
+
+While a rate-limited job runs, every request the instrumented client makes is attributed to that job's key automatically (through async context) — no key threading, no manual limiter calls. Requests made **outside** a rate-limited job are left untouched, so the client is safe to share. What each mode does with those requests:
+
+> **Important:** accounting only happens for calls that go through an instrumented client. A rate-limited job that calls a bare `fetch` (or any un-instrumented client) will **not** be counted, and its key will never be gated. Route all of a rate-limited job's API calls through a `useRateLimiting` client.
+
+### `static`: a known, fixed budget
+
+```ts
+{ source: "static", limit: 100, windowSeconds: 60 } // 100 requests per 60s window
+```
+
+Each request the instrumented client sends consumes one token from the shared budget, counted per **request attempt** — so retries and requests that end up failing still count, because they still hit the API. Once the window's tokens are exhausted, the worker stops fetching jobs for this key until the window rolls over.
+
+### `headers`: the API reports its own limit via response headers
+
+```ts
+{ source: "headers", remainingHeader?: string, resetHeader?: string, retryAfterHeader?: string }
+```
+
+The headers default to `x-ratelimit-remaining`, `x-ratelimit-reset` (epoch seconds) and `retry-after`, and can be overridden per config. On **every** response the interceptor records the API's reported remaining/reset, so exhaustion is tracked proactively — not discovered one request too late on a failure. When the API reports the budget is spent, jobs for this key stop being fetched until the reset passes.
+
+### `failure`: no header/limit info, only a backoff after a rejection
+
+```ts
+{ source: "failure", backoffSeconds: 30, maxBackoffSeconds?: number }
+```
+
+Use this when the API gives no usable rate-limit metadata, only a rejection. On a `429` the interceptor blocks the key and throws a `RateLimitError`, so the current job fails and retries after the block clears; a transport error (network failure/abort) is treated the same way. The block lasts `backoffSeconds` — or the response's `Retry-After` if present — capped at `maxBackoffSeconds`. Note: `backoffSeconds` is your own fixed guess for an API that gives no metadata; it is **not** derived from the server (unless `Retry-After` is present) and does **not** grow on repeated throttling.
+
+You can still `throw new RateLimitError({ throttled: true })` by hand from a handler if you want to signal a throttle without going through the instrumented client — it fails the job the same way — but with the client you don't need to.
+
+### How gating works
+
+Rate-limit state is kept in Postgres (table `pgboss.rate_limit`, created automatically on worker startup), not in memory, so it is shared across all worker instances/processes reading the same database — one worker's usage counts against the shared budget seen by all of them.
+
+On every poll, the worker asks the limiter which keys are currently blocked and excludes jobs carrying those keys from the fetch. Concretely:
+
+- A job that opts in is enqueued with its `rateLimited` key as a pg-boss group id.
+- When a key is exhausted (or backed off), jobs in that group simply stay in the `created` state — they are not fetched, not failed, not retried; they just wait.
+- Jobs in **other** groups on the same queue are unaffected and keep being fetched and processed normally.
+- Once the window rolls over (`static`), the reported `resetAt`/`remaining` allow it again (`headers`), or the backoff elapses (`failure`), the key stops being blocked and its jobs resume flowing on the next poll.
+
+### Overshoot caveat
+
+Gating happens once per poll and is binary (a key is either fetchable or not for that whole poll) — it is not a token bucket consulted per-job-per-worker. That means a single poll can fetch up to `batchSize` jobs for a not-yet-blocked key, and this can happen concurrently across all workers polling that queue, so a burst can overshoot the configured limit by up to `batchSize × workers` before the key is observed as blocked on the next poll. For hot queues where staying close to the limit matters, lower `batchSize` to reduce the size of a possible overshoot.
+
+### Producers vs. workers
+
+The `PgbossRateLimiter` is provided automatically by `PgBossWorkerModule` (configured from its `rateLimits` option) — worker apps get rate limiting for free, nothing extra to import. It is not pulled in by `PgBossSchedulerModule`; producer-only apps that just schedule jobs don't need it and don't declare `rateLimits` — the `rateLimited` key is read from the job at schedule time to tag its group, which requires no module or config on the producer side. A key that no worker declares in `rateLimits` is simply never gated (jobs flow normally).

--- a/packages/api/pgboss-nestjs-job/docs/superpowers/plans/2026-07-03-rate-limited-jobs.md
+++ b/packages/api/pgboss-nestjs-job/docs/superpowers/plans/2026-07-03-rate-limited-jobs.md
@@ -1,0 +1,1712 @@
+# Rate-limited jobs Implementation Plan
+
+> **⚠️ Superseded discovery mechanism (read first).** This plan was executed as
+> written, but a final whole-branch review found the design's discovery mechanism
+> was inert: `@RateLimited` was placed on **job classes**, which are not DI
+> providers, so the provider-scanning `PgbossRateLimitRegistry` never found them
+> and rate limiting never engaged. The implementation was pivoted (approach "D"):
+> the key is now a **job option** (`super(data, { rateLimited: key })`) carried as
+> the pg-boss group id and read off `job.groupId` at execution; the config is
+> declared **centrally** on the worker (`PgBossWorkerModule.forRoot({ rateLimits })`).
+> The `@RateLimited` decorator and provider scanning were removed. See the design
+> spec's **Revision** note for the final design. The enforcement layer (group-gated
+> fetch, atomic token bucket, three strategies) below is unchanged and still valid;
+> the decorator/registry-discovery tasks (1, 5) reflect the superseded mechanism.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `@wisemen/pgboss-nestjs-job` a reusable way to make jobs respect an external API's rate limit by gating pg-boss `fetch` per group, so exhausted jobs wait in `created` state instead of failing and requeuing.
+
+**Architecture (as implemented):** A job opts into a limit with the `rateLimited` job option, read at three points — enqueue (tag the job's pg-boss `group`), fetch (exclude exhausted groups via `ignoreGroups`), and execution (count/report usage, keyed off `job.groupId`). Limit strategy/config is declared centrally via `PgBossWorkerModule.forRoot({ rateLimits })`. A shared, Postgres-backed `PgbossRateLimiter` with three pluggable strategies (static / headers / failure-backoff) owns the state. Strategies are pure functions over a `RateLimitStore` seam so logic is unit-testable without a database.
+
+**Tech Stack:** TypeScript (ESM, NodeNext), NestJS, pg-boss 12.15.0, TypeORM (via `@wisemen/nestjs-typeorm`), `node:test` + `node:assert` test runner.
+
+## Global Constraints
+
+- **Package:** all edits are inside `packages/api/pgboss-nestjs-job/`. Run commands from that directory.
+- **ESM imports:** every relative import MUST end in `.js` (NodeNext), even from `.ts` files. Match the existing style.
+- **Tests:** written as `lib/**/*.test.ts`, run via `pnpm test` (which builds first, then `node --test ./dist/**/*.test.js`). Use `node:test` (`describe`/`it`) + `node:assert/strict`. No third-party test libs.
+- **Decorator metadata:** use `Reflect.defineMetadata` / `Reflect.getMetadata` with a module-private `Symbol` token, mirroring `lib/worker/pgboss-bouncer.decorator.ts`.
+- **Provider scanning:** reuse the existing `ProvidersExplorer` (`lib/providers/providers-explorer.ts`), exactly as `PgbossBouncerRegistry` does.
+- **Naming:** exported public symbols are prefixed `Pgboss`. The decorator is `RateLimited` (matches the bare `Bouncer` export style).
+- **Backward compatibility:** untagged jobs and existing bouncers behave exactly as today. The rate-limit gate is a separate mechanism; **the `PgbossBouncer` interface is NOT changed** (resolves the spec §7.2 open question — the worker consults the limiter directly for `ignoreGroups`, the bouncer stays boolean).
+- **Rate-limit table:** created idempotently at runtime via `CREATE TABLE IF NOT EXISTS pgboss.rate_limit (...)` on module init (same self-managing-schema pattern pg-boss uses), so consumers need no migration.
+- **Insert path detail:** pg-boss `manager.insert` JSON-stringifies job objects straight into `json_to_recordset`, whose column is `"groupId"` — so serialized jobs need a **top-level `groupId`** string, not a nested `group`.
+
+---
+
+## Phase 1 — Static-rate mode (shippable MVP)
+
+Delivers a complete, working rate limiter for the "we know N per window" case: gate at fetch, atomic token bucket in Postgres, auto-consume one token per successful job. Header/failure modes come in Phase 2.
+
+### Task 1: `@RateLimited` decorator + metadata + first test scaffold
+
+**Files:**
+- Create: `lib/rate-limit/rate-limit-config.ts`
+- Create: `lib/rate-limit/rate-limit.decorator.ts`
+- Test: `lib/rate-limit/rate-limit.decorator.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type RateLimitConfig = StaticRateLimitConfig | HeaderRateLimitConfig | FailureBackoffConfig`
+  - `interface StaticRateLimitConfig { source: 'static', limit: number, windowSeconds: number }`
+  - `interface HeaderRateLimitConfig { source: 'headers', remainingHeader?: string, resetHeader?: string, retryAfterHeader?: string }`
+  - `interface FailureBackoffConfig { source: 'failure', backoffSeconds: number, maxBackoffSeconds?: number }`
+  - `interface RateLimitSignal { status?: number, retryAfterSeconds?: number, remaining?: number, resetAt?: Date, throttled?: boolean }`
+  - `function RateLimited(key: string, config: RateLimitConfig): ClassDecorator`
+  - `interface RateLimitMetadata { key: string, config: RateLimitConfig }`
+  - `function getRateLimitMetadata(target: object): RateLimitMetadata | undefined`
+
+- [ ] **Step 1: Write the config types**
+
+Create `lib/rate-limit/rate-limit-config.ts`:
+
+```ts
+export interface StaticRateLimitConfig {
+  source: 'static'
+  /** Maximum number of requests allowed per window. */
+  limit: number
+  /** Length of the window in seconds. */
+  windowSeconds: number
+}
+
+export interface HeaderRateLimitConfig {
+  source: 'headers'
+  remainingHeader?: string
+  resetHeader?: string
+  retryAfterHeader?: string
+}
+
+export interface FailureBackoffConfig {
+  source: 'failure'
+  backoffSeconds: number
+  maxBackoffSeconds?: number
+}
+
+export type RateLimitConfig =
+  | StaticRateLimitConfig
+  | HeaderRateLimitConfig
+  | FailureBackoffConfig
+
+/** What execution observed after calling the API. */
+export interface RateLimitSignal {
+  status?: number
+  retryAfterSeconds?: number
+  remaining?: number
+  resetAt?: Date
+  throttled?: boolean
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `lib/rate-limit/rate-limit.decorator.test.ts`:
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { RateLimited, getRateLimitMetadata } from './rate-limit.decorator.js'
+
+describe('RateLimited decorator', () => {
+  it('attaches key and config metadata to the class', () => {
+    @RateLimited('stripe', { source: 'static', limit: 100, windowSeconds: 60 })
+    class ChargeJob {}
+
+    const meta = getRateLimitMetadata(ChargeJob)
+    assert.equal(meta?.key, 'stripe')
+    assert.deepEqual(meta?.config, { source: 'static', limit: 100, windowSeconds: 60 })
+  })
+
+  it('returns undefined for undecorated classes', () => {
+    class Plain {}
+    assert.equal(getRateLimitMetadata(Plain), undefined)
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm test`
+Expected: build fails / test FAILs — `rate-limit.decorator.js` has no `RateLimited` export.
+
+- [ ] **Step 4: Implement the decorator**
+
+Create `lib/rate-limit/rate-limit.decorator.ts`:
+
+```ts
+import type { ClassConstructor } from 'class-transformer'
+import { RateLimitConfig } from './rate-limit-config.js'
+
+const PGBOSS_RATE_LIMIT_TOKEN = Symbol('wisemen.pgboss-rate-limit')
+
+export interface RateLimitMetadata {
+  key: string
+  config: RateLimitConfig
+}
+
+/**
+ * Declares that jobs of this class are governed by the rate limit `key`.
+ * Read at three points: enqueue (group tag), fetch (ignoreGroups), execution (usage).
+ * Place on the job class, next to `@PgBossJob`.
+ */
+export function RateLimited (key: string, config: RateLimitConfig): ClassDecorator {
+  return (target: object): void => {
+    const metadata: RateLimitMetadata = { key, config }
+    Reflect.defineMetadata(PGBOSS_RATE_LIMIT_TOKEN, metadata, target)
+  }
+}
+
+export function getRateLimitMetadata (target: object): RateLimitMetadata | undefined {
+  return Reflect.getMetadata(PGBOSS_RATE_LIMIT_TOKEN, target) as RateLimitMetadata | undefined
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm test`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/rate-limit/rate-limit-config.ts lib/rate-limit/rate-limit.decorator.ts lib/rate-limit/rate-limit.decorator.test.ts
+git commit -m "feat(rate-limit): @RateLimited decorator and config types"
+```
+
+---
+
+### Task 2: Token-bucket refill math (pure)
+
+**Files:**
+- Create: `lib/rate-limit/refill.ts`
+- Test: `lib/rate-limit/refill.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface Bucket { tokens: number, windowStartAt: Date }`
+  - `function refill(bucket: Bucket | null, config: StaticRateLimitConfig, now: Date): Bucket` — returns a full bucket at a fresh window boundary when `bucket` is null or its window has elapsed; otherwise returns it unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/rate-limit/refill.test.ts`:
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { refill } from './refill.js'
+
+const config = { source: 'static' as const, limit: 3, windowSeconds: 60 }
+
+describe('refill', () => {
+  it('creates a full bucket when none exists', () => {
+    const now = new Date('2026-07-03T10:00:00Z')
+    const b = refill(null, config, now)
+    assert.equal(b.tokens, 3)
+    assert.equal(b.windowStartAt.toISOString(), now.toISOString())
+  })
+
+  it('keeps the bucket unchanged inside the window', () => {
+    const start = new Date('2026-07-03T10:00:00Z')
+    const now = new Date('2026-07-03T10:00:30Z')
+    const b = refill({ tokens: 1, windowStartAt: start }, config, now)
+    assert.equal(b.tokens, 1)
+    assert.equal(b.windowStartAt.toISOString(), start.toISOString())
+  })
+
+  it('refills to full at a new window once the window elapsed', () => {
+    const start = new Date('2026-07-03T10:00:00Z')
+    const now = new Date('2026-07-03T10:01:05Z')
+    const b = refill({ tokens: 0, windowStartAt: start }, config, now)
+    assert.equal(b.tokens, 3)
+    assert.equal(b.windowStartAt.toISOString(), now.toISOString())
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test`
+Expected: FAIL — no `refill` export.
+
+- [ ] **Step 3: Implement**
+
+Create `lib/rate-limit/refill.ts`:
+
+```ts
+import { StaticRateLimitConfig } from './rate-limit-config.js'
+
+export interface Bucket {
+  tokens: number
+  windowStartAt: Date
+}
+
+export function refill (
+  bucket: Bucket | null,
+  config: StaticRateLimitConfig,
+  now: Date
+): Bucket {
+  if (bucket === null) {
+    return { tokens: config.limit, windowStartAt: now }
+  }
+
+  const elapsedMs = now.getTime() - bucket.windowStartAt.getTime()
+
+  if (elapsedMs >= config.windowSeconds * 1000) {
+    return { tokens: config.limit, windowStartAt: now }
+  }
+
+  return bucket
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/rate-limit/refill.ts lib/rate-limit/refill.test.ts
+git commit -m "feat(rate-limit): token-bucket refill math"
+```
+
+---
+
+### Task 3: Strategy interface + static strategy `isBlocked` (pure)
+
+**Files:**
+- Create: `lib/rate-limit/rate-limit.strategy.ts`
+- Create: `lib/rate-limit/strategies/static-rate.strategy.ts`
+- Test: `lib/rate-limit/strategies/static-rate.strategy.test.ts`
+
+**Interfaces:**
+- Consumes: `refill`, `Bucket` (Task 2); config types (Task 1).
+- Produces:
+  - `interface RateLimitBucketRow { key: string, tokens: number | null, windowStartAt: Date | null, resetAt: Date | null, blockedUntil: Date | null }`
+  - `interface RateLimitStrategy { isBlocked(row: RateLimitBucketRow | null, now: Date): boolean }`
+  - `class StaticRateStrategy implements RateLimitStrategy { constructor(config: StaticRateLimitConfig); isBlocked(...): boolean }`
+
+- [ ] **Step 1: Write the strategy interface**
+
+Create `lib/rate-limit/rate-limit.strategy.ts`:
+
+```ts
+export interface RateLimitBucketRow {
+  key: string
+  tokens: number | null
+  windowStartAt: Date | null
+  resetAt: Date | null
+  blockedUntil: Date | null
+}
+
+export interface RateLimitStrategy {
+  /** Fetch-gate read: is this key blocked right now, given its stored row? */
+  isBlocked (row: RateLimitBucketRow | null, now: Date): boolean
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `lib/rate-limit/strategies/static-rate.strategy.test.ts`:
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { StaticRateStrategy } from './static-rate.strategy.js'
+
+const strategy = new StaticRateStrategy({ source: 'static', limit: 3, windowSeconds: 60 })
+const now = new Date('2026-07-03T10:00:30Z')
+const start = new Date('2026-07-03T10:00:00Z')
+
+describe('StaticRateStrategy.isBlocked', () => {
+  it('is not blocked when no row exists (full budget)', () => {
+    assert.equal(strategy.isBlocked(null, now), false)
+  })
+
+  it('is blocked when tokens are exhausted inside the window', () => {
+    const row = { key: 'k', tokens: 0, windowStartAt: start, resetAt: null, blockedUntil: null }
+    assert.equal(strategy.isBlocked(row, now), true)
+  })
+
+  it('is not blocked once the window has elapsed (refills)', () => {
+    const row = { key: 'k', tokens: 0, windowStartAt: start, resetAt: null, blockedUntil: null }
+    const later = new Date('2026-07-03T10:01:05Z')
+    assert.equal(strategy.isBlocked(row, later), false)
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm test`
+Expected: FAIL — no `StaticRateStrategy`.
+
+- [ ] **Step 4: Implement**
+
+Create `lib/rate-limit/strategies/static-rate.strategy.ts`:
+
+```ts
+import { StaticRateLimitConfig } from '../rate-limit-config.js'
+import { refill } from '../refill.js'
+import { RateLimitBucketRow, RateLimitStrategy } from '../rate-limit.strategy.js'
+
+export class StaticRateStrategy implements RateLimitStrategy {
+  constructor (private readonly config: StaticRateLimitConfig) {}
+
+  isBlocked (row: RateLimitBucketRow | null, now: Date): boolean {
+    const bucket = row?.windowStartAt != null && row.tokens != null
+      ? { tokens: row.tokens, windowStartAt: row.windowStartAt }
+      : null
+
+    const refilled = refill(bucket, this.config, now)
+
+    return refilled.tokens <= 0
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/rate-limit/rate-limit.strategy.ts lib/rate-limit/strategies/static-rate.strategy.ts lib/rate-limit/strategies/static-rate.strategy.test.ts
+git commit -m "feat(rate-limit): strategy interface and static isBlocked"
+```
+
+---
+
+### Task 4: `RateLimitStore` interface + Postgres implementation
+
+**Files:**
+- Create: `lib/rate-limit/rate-limit.store.ts`
+- Create: `lib/rate-limit/postgres-rate-limit.store.ts`
+- Test: `lib/rate-limit/postgres-rate-limit.store.test.ts` (integration — flagged)
+
+**Interfaces:**
+- Consumes: `RateLimitBucketRow` (Task 3).
+- Produces:
+  - `abstract class RateLimitStore { ensureSchema(); getMany(keys); tryConsumeToken(key, limit, windowSeconds); setBlockedUntil(key, until); setHeaderState(key, remaining, resetAt) }` with exact signatures below.
+  - `class PostgresRateLimitStore extends RateLimitStore` (uses injected TypeORM `EntityManager`).
+
+- [ ] **Step 1: Write the store interface**
+
+Create `lib/rate-limit/rate-limit.store.ts`:
+
+```ts
+import { RateLimitBucketRow } from './rate-limit.strategy.js'
+
+export abstract class RateLimitStore {
+  abstract ensureSchema (): Promise<void>
+  abstract getMany (keys: string[]): Promise<RateLimitBucketRow[]>
+  /** Atomically refill+decrement one token. Returns true if a token was granted. */
+  abstract tryConsumeToken (key: string, limit: number, windowSeconds: number): Promise<boolean>
+  abstract setBlockedUntil (key: string, until: Date): Promise<void>
+  abstract setHeaderState (key: string, remaining: number, resetAt: Date | null): Promise<void>
+}
+```
+
+- [ ] **Step 2: Implement the Postgres store**
+
+Create `lib/rate-limit/postgres-rate-limit.store.ts`:
+
+```ts
+import { Injectable } from '@nestjs/common'
+import { EntityManager } from 'typeorm'
+import { InjectEntityManager } from '@wisemen/nestjs-typeorm'
+import { RateLimitBucketRow } from './rate-limit.strategy.js'
+import { RateLimitStore } from './rate-limit.store.js'
+
+interface RawRow {
+  key: string
+  tokens: number | null
+  window_start_at: Date | null
+  reset_at: Date | null
+  blocked_until: Date | null
+}
+
+@Injectable()
+export class PostgresRateLimitStore extends RateLimitStore {
+  constructor (
+    @InjectEntityManager() private readonly manager: EntityManager
+  ) {
+    super()
+  }
+
+  async ensureSchema (): Promise<void> {
+    await this.manager.query(`
+      CREATE TABLE IF NOT EXISTS pgboss.rate_limit (
+        key text PRIMARY KEY,
+        tokens integer,
+        window_start_at timestamptz,
+        reset_at timestamptz,
+        blocked_until timestamptz,
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )
+    `)
+  }
+
+  async getMany (keys: string[]): Promise<RateLimitBucketRow[]> {
+    if (keys.length === 0) {
+      return []
+    }
+
+    const rows = await this.manager.query<RawRow[]>(
+      `SELECT key, tokens, window_start_at, reset_at, blocked_until
+       FROM pgboss.rate_limit WHERE key = ANY($1)`,
+      [keys]
+    )
+
+    return rows.map(r => ({
+      key: r.key,
+      tokens: r.tokens,
+      windowStartAt: r.window_start_at,
+      resetAt: r.reset_at,
+      blockedUntil: r.blocked_until
+    }))
+  }
+
+  async tryConsumeToken (key: string, limit: number, windowSeconds: number): Promise<boolean> {
+    // Upsert-then-atomically-decrement in one statement. The window resets to a
+    // full budget when window_start_at is null or older than windowSeconds;
+    // otherwise the counter is ALWAYS decremented (it may drift negative under
+    // contention — that is fine, it self-heals at the next window). The call is
+    // granted iff the resulting count is >= 0: the last token lands on exactly 0
+    // (granted), an over-budget call lands on -1 (denied). This unambiguous
+    // grant test is why we do not clamp at 0.
+    const rows = await this.manager.query<Array<{ tokens: number }>>(
+      `
+      INSERT INTO pgboss.rate_limit (key, tokens, window_start_at, updated_at)
+      VALUES ($1, $2 - 1, now(), now())
+      ON CONFLICT (key) DO UPDATE SET
+        window_start_at = CASE
+          WHEN pgboss.rate_limit.window_start_at IS NULL
+            OR pgboss.rate_limit.window_start_at < now() - ($3 || ' seconds')::interval
+          THEN now() ELSE pgboss.rate_limit.window_start_at END,
+        tokens = CASE
+          WHEN pgboss.rate_limit.window_start_at IS NULL
+            OR pgboss.rate_limit.window_start_at < now() - ($3 || ' seconds')::interval
+          THEN $2 - 1
+          ELSE pgboss.rate_limit.tokens - 1 END,
+        updated_at = now()
+      RETURNING tokens
+      `,
+      [key, limit, String(windowSeconds)]
+    )
+
+    return rows.length > 0 && rows[0].tokens >= 0
+  }
+
+  async setBlockedUntil (key: string, until: Date): Promise<void> {
+    await this.manager.query(
+      `INSERT INTO pgboss.rate_limit (key, blocked_until, updated_at)
+       VALUES ($1, $2, now())
+       ON CONFLICT (key) DO UPDATE SET blocked_until = $2, updated_at = now()`,
+      [key, until]
+    )
+  }
+
+  async setHeaderState (key: string, remaining: number, resetAt: Date | null): Promise<void> {
+    await this.manager.query(
+      `INSERT INTO pgboss.rate_limit (key, tokens, reset_at, updated_at)
+       VALUES ($1, $2, $3, now())
+       ON CONFLICT (key) DO UPDATE SET tokens = $2, reset_at = $3, updated_at = now()`,
+      [key, remaining, resetAt]
+    )
+  }
+}
+```
+
+- [ ] **Step 3: Write the integration test (flagged — needs Postgres)**
+
+Create `lib/rate-limit/postgres-rate-limit.store.test.ts`. This requires a live Postgres with the `pgboss` schema; it is skipped unless `RATE_LIMIT_TEST_DATABASE_URL` is set.
+
+```ts
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { DataSource } from 'typeorm'
+import { PostgresRateLimitStore } from './postgres-rate-limit.store.js'
+
+const url = process.env.RATE_LIMIT_TEST_DATABASE_URL
+
+describe('PostgresRateLimitStore (integration)', { skip: url == null }, () => {
+  let ds: DataSource
+  let store: PostgresRateLimitStore
+
+  before(async () => {
+    ds = new DataSource({ type: 'postgres', url })
+    await ds.initialize()
+    await ds.query('CREATE SCHEMA IF NOT EXISTS pgboss')
+    store = new PostgresRateLimitStore(ds.manager)
+    await store.ensureSchema()
+    await ds.query(`DELETE FROM pgboss.rate_limit WHERE key = 'itest'`)
+  })
+
+  after(async () => {
+    await ds?.destroy()
+  })
+
+  it('grants exactly `limit` tokens then blocks', async () => {
+    const granted: boolean[] = []
+    for (let i = 0; i < 4; i++) {
+      granted.push(await store.tryConsumeToken('itest', 3, 60))
+    }
+    assert.deepEqual(granted, [true, true, true, false])
+  })
+})
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test` (integration test SKIPS without the env var — that is expected and fine).
+Optional full check: `RATE_LIMIT_TEST_DATABASE_URL=postgres://localhost/postgres pnpm test`.
+Expected: build passes, all non-skipped tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/rate-limit/rate-limit.store.ts lib/rate-limit/postgres-rate-limit.store.ts lib/rate-limit/postgres-rate-limit.store.test.ts
+git commit -m "feat(rate-limit): Postgres store with atomic token bucket"
+```
+
+---
+
+### Task 5: `PgbossRateLimitRegistry` — scan providers, map keys
+
+**Files:**
+- Create: `lib/rate-limit/rate-limit.registry.ts`
+- Test: `lib/rate-limit/rate-limit.registry.test.ts`
+
+**Interfaces:**
+- Consumes: `getRateLimitMetadata` (Task 1); config types; `RateLimitStrategy`, `StaticRateStrategy`.
+- Produces:
+  - `class PgbossRateLimitRegistry` with:
+    - `onModuleInit(): void`
+    - `getKeysForClass(className: string): string | undefined` — the limit key a job class is governed by (by class name), or undefined.
+    - `getStrategy(key: string): RateLimitStrategy | undefined`
+    - `getConfig(key: string): RateLimitConfig | undefined`
+    - `getAllKeys(): string[]`
+
+Note: the registry maps by **class name** because that is what the worker thread has at runtime (`job.data.className`). Queue→keys narrowing is not stored; the worker gates on all keys (small set) — simplest correct choice.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/rate-limit/rate-limit.registry.test.ts`. We drive the registry with a fake `ProvidersExplorer` shape so no Nest container is needed.
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { RateLimited } from './rate-limit.decorator.js'
+import { PgbossRateLimitRegistry } from './rate-limit.registry.js'
+import { StaticRateStrategy } from './strategies/static-rate.strategy.js'
+
+@RateLimited('stripe', { source: 'static', limit: 100, windowSeconds: 60 })
+class ChargeJob {}
+class PlainJob {}
+
+function fakeExplorer (classes: Array<new () => unknown>) {
+  return { providers: classes.map(c => ({ providerClass: c, instanceWrapper: {} })) } as never
+}
+
+describe('PgbossRateLimitRegistry', () => {
+  it('maps decorated classes to keys and builds a strategy', () => {
+    const registry = new PgbossRateLimitRegistry(fakeExplorer([ChargeJob, PlainJob]))
+    registry.onModuleInit()
+
+    assert.equal(registry.getKeysForClass('ChargeJob'), 'stripe')
+    assert.equal(registry.getKeysForClass('PlainJob'), undefined)
+    assert.deepEqual(registry.getAllKeys(), ['stripe'])
+    assert.ok(registry.getStrategy('stripe') instanceof StaticRateStrategy)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test`
+Expected: FAIL — no `PgbossRateLimitRegistry`.
+
+- [ ] **Step 3: Implement**
+
+Create `lib/rate-limit/rate-limit.registry.ts`:
+
+```ts
+import { Injectable, Logger } from '@nestjs/common'
+import { ProvidersExplorer } from '../providers/providers-explorer.js'
+import { RateLimitConfig } from './rate-limit-config.js'
+import { getRateLimitMetadata } from './rate-limit.decorator.js'
+import { RateLimitStrategy } from './rate-limit.strategy.js'
+import { StaticRateStrategy } from './strategies/static-rate.strategy.js'
+
+@Injectable()
+export class PgbossRateLimitRegistry {
+  private readonly logger = new Logger(PgbossRateLimitRegistry.name)
+  private readonly classToKey = new Map<string, string>()
+  private readonly keyToConfig = new Map<string, RateLimitConfig>()
+  private readonly keyToStrategy = new Map<string, RateLimitStrategy>()
+
+  constructor (private readonly providerExplorer: ProvidersExplorer) {}
+
+  onModuleInit (): void {
+    for (const provider of this.providerExplorer.providers) {
+      const meta = getRateLimitMetadata(provider.providerClass)
+
+      if (meta === undefined) {
+        continue
+      }
+
+      this.classToKey.set(provider.providerClass.name, meta.key)
+
+      if (!this.keyToStrategy.has(meta.key)) {
+        this.keyToConfig.set(meta.key, meta.config)
+        this.keyToStrategy.set(meta.key, this.buildStrategy(meta.config))
+        this.logger.log(`Registered rate limit '${meta.key}' (${meta.config.source})`)
+      }
+    }
+  }
+
+  getKeysForClass (className: string): string | undefined {
+    return this.classToKey.get(className)
+  }
+
+  getStrategy (key: string): RateLimitStrategy | undefined {
+    return this.keyToStrategy.get(key)
+  }
+
+  getConfig (key: string): RateLimitConfig | undefined {
+    return this.keyToConfig.get(key)
+  }
+
+  getAllKeys (): string[] {
+    return [...this.keyToStrategy.keys()]
+  }
+
+  private buildStrategy (config: RateLimitConfig): RateLimitStrategy {
+    switch (config.source) {
+      case 'static':
+        return new StaticRateStrategy(config)
+      default:
+        // Header/failure strategies are added in Phase 2; until then treat as
+        // never-blocking so a queue is never wedged by an unimplemented mode.
+        return { isBlocked: () => false }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/rate-limit/rate-limit.registry.ts lib/rate-limit/rate-limit.registry.test.ts
+git commit -m "feat(rate-limit): registry scanning @RateLimited providers"
+```
+
+---
+
+### Task 6: `PgbossRateLimiter` — blockedKeys + consume
+
+**Files:**
+- Create: `lib/rate-limit/rate-limiter.ts`
+- Test: `lib/rate-limit/rate-limiter.test.ts`
+
+**Interfaces:**
+- Consumes: `PgbossRateLimitRegistry` (Task 5), `RateLimitStore` (Task 4).
+- Produces:
+  - `class PgbossRateLimiter` with:
+    - `onModuleInit(): Promise<void>` — calls `store.ensureSchema()`
+    - `blockedKeys(): Promise<string[]>` — every registered key currently blocked
+    - `consumeForClass(className: string): Promise<void>` — consume one token for the key governing that job class, if static
+    - `reportForClass(className: string, signal: RateLimitSignal): Promise<void>` — Phase 2 no-op stub for static; real for header/failure
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/rate-limit/rate-limiter.test.ts` with a fake store + a real static strategy via a hand-built registry double.
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PgbossRateLimiter } from './rate-limiter.js'
+import { StaticRateStrategy } from './strategies/static-rate.strategy.js'
+import { RateLimitBucketRow } from './rate-limit.strategy.js'
+import { RateLimitStore } from './rate-limit.store.js'
+
+class FakeStore extends RateLimitStore {
+  rows = new Map<string, RateLimitBucketRow>()
+  consumed: string[] = []
+  grant = true
+  async ensureSchema () {}
+  async getMany (keys: string[]) { return keys.map(k => this.rows.get(k)).filter(Boolean) as RateLimitBucketRow[] }
+  async tryConsumeToken (key: string) { this.consumed.push(key); return this.grant }
+  async setBlockedUntil () {}
+  async setHeaderState () {}
+}
+
+const config = { source: 'static' as const, limit: 3, windowSeconds: 60 }
+function registryDouble () {
+  return {
+    getAllKeys: () => ['stripe'],
+    getKeysForClass: (c: string) => (c === 'ChargeJob' ? 'stripe' : undefined),
+    getStrategy: () => new StaticRateStrategy(config),
+    getConfig: () => config
+  } as never
+}
+
+describe('PgbossRateLimiter', () => {
+  it('reports a key as blocked when its stored row is exhausted', async () => {
+    const store = new FakeStore()
+    store.rows.set('stripe', { key: 'stripe', tokens: 0, windowStartAt: new Date(), resetAt: null, blockedUntil: null })
+    const limiter = new PgbossRateLimiter(registryDouble(), store)
+
+    assert.deepEqual(await limiter.blockedKeys(), ['stripe'])
+  })
+
+  it('does not block when budget remains', async () => {
+    const store = new FakeStore()
+    const limiter = new PgbossRateLimiter(registryDouble(), store)
+    assert.deepEqual(await limiter.blockedKeys(), [])
+  })
+
+  it('consumes a token for the class key', async () => {
+    const store = new FakeStore()
+    const limiter = new PgbossRateLimiter(registryDouble(), store)
+    await limiter.consumeForClass('ChargeJob')
+    assert.deepEqual(store.consumed, ['stripe'])
+  })
+
+  it('ignores classes with no rate limit on consume', async () => {
+    const store = new FakeStore()
+    const limiter = new PgbossRateLimiter(registryDouble(), store)
+    await limiter.consumeForClass('PlainJob')
+    assert.deepEqual(store.consumed, [])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test`
+Expected: FAIL — no `PgbossRateLimiter`.
+
+- [ ] **Step 3: Implement**
+
+Create `lib/rate-limit/rate-limiter.ts`:
+
+```ts
+import { Injectable, Logger } from '@nestjs/common'
+import { RateLimitSignal } from './rate-limit-config.js'
+import { PgbossRateLimitRegistry } from './rate-limit.registry.js'
+import { RateLimitStore } from './rate-limit.store.js'
+
+@Injectable()
+export class PgbossRateLimiter {
+  private readonly logger = new Logger(PgbossRateLimiter.name)
+
+  constructor (
+    private readonly registry: PgbossRateLimitRegistry,
+    private readonly store: RateLimitStore
+  ) {}
+
+  async onModuleInit (): Promise<void> {
+    await this.store.ensureSchema()
+  }
+
+  /** Fetch-gate: which registered keys are blocked right now. Fail-open on error. */
+  async blockedKeys (): Promise<string[]> {
+    const keys = this.registry.getAllKeys()
+
+    if (keys.length === 0) {
+      return []
+    }
+
+    try {
+      const rows = await this.store.getMany(keys)
+      const byKey = new Map(rows.map(r => [r.key, r]))
+      const now = new Date()
+      const blocked: string[] = []
+
+      for (const key of keys) {
+        const strategy = this.registry.getStrategy(key)
+        if (strategy?.isBlocked(byKey.get(key) ?? null, now) === true) {
+          blocked.push(key)
+        }
+      }
+
+      return blocked
+    } catch (error) {
+      this.logger.error('blockedKeys failed; failing open', error as Error)
+      return []
+    }
+  }
+
+  /** Execution: count one usage against the job class's static budget. */
+  async consumeForClass (className: string): Promise<void> {
+    const key = this.registry.getKeysForClass(className)
+    if (key === undefined) {
+      return
+    }
+
+    const config = this.registry.getConfig(key)
+    if (config?.source !== 'static') {
+      return
+    }
+
+    await this.store.tryConsumeToken(key, config.limit, config.windowSeconds)
+  }
+
+  /** Execution feedback for header/failure modes. Static: no-op. (Phase 2.) */
+  async reportForClass (_className: string, _signal: RateLimitSignal): Promise<void> {
+    // Implemented in Phase 2 (Task 12).
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/rate-limit/rate-limiter.ts lib/rate-limit/rate-limiter.test.ts
+git commit -m "feat(rate-limit): limiter blockedKeys and consume"
+```
+
+---
+
+### Task 7: Carry `groupId` through enqueue
+
+**Files:**
+- Modify: `lib/jobs/serialized-job.ts`
+- Modify: `lib/scheduler/pgboss-scheduler.ts:75-97` (`serializeJob`)
+- Test: `lib/scheduler/serialize-group.test.ts`
+
+**Interfaces:**
+- Consumes: `getRateLimitMetadata` (Task 1).
+- Produces: `SerializedJob` gains an optional top-level `groupId?: string`.
+
+- [ ] **Step 1: Write the failing test**
+
+The `serializeJob` method is private. Add a test-only path by extracting the group-resolution into a tiny exported pure helper and testing that. Create `lib/scheduler/resolve-group-id.ts`:
+
+```ts
+import { getRateLimitMetadata } from '../rate-limit/rate-limit.decorator.js'
+
+export function resolveGroupId (jobConstructor: object): string | undefined {
+  return getRateLimitMetadata(jobConstructor)?.key
+}
+```
+
+Create `lib/scheduler/serialize-group.test.ts`:
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { BaseJob } from '../jobs/base-job.js'
+import { RateLimited } from '../rate-limit/rate-limit.decorator.js'
+import { resolveGroupId } from './resolve-group-id.js'
+
+@RateLimited('stripe', { source: 'static', limit: 10, windowSeconds: 60 })
+class ChargeJob extends BaseJob {}
+class PlainJob extends BaseJob {}
+
+describe('resolveGroupId', () => {
+  it('returns the rate-limit key for a decorated job', () => {
+    assert.equal(resolveGroupId(ChargeJob), 'stripe')
+  })
+  it('returns undefined for an undecorated job', () => {
+    assert.equal(resolveGroupId(PlainJob), undefined)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test`
+Expected: FAIL — no `resolve-group-id.js`.
+
+- [ ] **Step 3: Add `groupId` to `SerializedJob`**
+
+Edit `lib/jobs/serialized-job.ts` — add the field to the interface body:
+
+```ts
+export interface SerializedJob<T extends BaseJob = BaseJob>
+  extends JobInsert<SerializedJobData<T>> {
+  name: string
+  groupId?: string
+}
+```
+
+- [ ] **Step 4: Populate it in `serializeJob`**
+
+In `lib/scheduler/pgboss-scheduler.ts`, add the import at the top:
+
+```ts
+import { resolveGroupId } from './resolve-group-id.js'
+```
+
+Then in `serializeJob` (currently returns the object at ~L79-96), add `groupId` to the returned object:
+
+```ts
+    return {
+      name: queue,
+      groupId: resolveGroupId(job.constructor),
+      data: {
+        className,
+        classData: job.data,
+        traceContext: context ?? {}
+      },
+      priority: job.options?.priority,
+      // ...unchanged fields...
+      retentionSeconds: job.options?.retentionSeconds
+    }
+```
+
+(pg-boss's bulk `insert` reads the top-level `"groupId"` column from each job object — see Global Constraints.)
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run: `pnpm test`
+Expected: PASS, build clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/jobs/serialized-job.ts lib/scheduler/resolve-group-id.ts lib/scheduler/pgboss-scheduler.ts lib/scheduler/serialize-group.test.ts
+git commit -m "feat(rate-limit): tag enqueued jobs with rate-limit group id"
+```
+
+---
+
+### Task 8: Gate `fetch` with `ignoreGroups`
+
+**Files:**
+- Modify: `lib/worker/pgboss-worker.ts:20-31` (constructor), `:75-116` (`fetchJobs`)
+- Modify: `lib/worker/pgboss-worker-app.ts:13-30` (pass limiter into workers)
+- Test: `lib/worker/worker-ignore-groups.test.ts`
+
+**Interfaces:**
+- Consumes: `PgbossRateLimiter.blockedKeys()` (Task 6).
+- Produces: `PgBossWorker` constructor gains a trailing `rateLimiter: Pick<PgbossRateLimiter, 'blockedKeys'>` parameter; `fetch` is called with `{ batchSize, ignoreGroups }`.
+
+- [ ] **Step 1: Write the failing test**
+
+We test the fetch options assembly by giving the worker a fake client + fake limiter and asserting `ignoreGroups` is forwarded. Create `lib/worker/worker-ignore-groups.test.ts`:
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PgBossWorker } from './pgboss-worker.js'
+
+describe('PgBossWorker fetch gating', () => {
+  it('passes blockedKeys as ignoreGroups to client.fetch', async () => {
+    const fetchCalls: Array<{ name: string, options: unknown }> = []
+
+    const client = {
+      fetch: async (name: string, options: unknown) => {
+        fetchCalls.push({ name, options })
+        return []
+      }
+    }
+    const rateLimiter = { blockedKeys: async () => ['stripe'] }
+
+    const worker = new PgBossWorker(
+      { queueName: 'system', pollInterval: 1 },
+      { canProceed: () => true },
+      client as never,
+      { } as never,
+      rateLimiter as never
+    )
+
+    // fetchJobs() early-returns unless the worker is "working"; set the flag
+    // directly since we call the private method without start()/threads.
+    ;(worker as unknown as { working: boolean }).working = true
+    await (worker as unknown as { fetchJobs: () => Promise<void> }).fetchJobs()
+
+    assert.equal(fetchCalls.length, 1)
+    assert.equal(fetchCalls[0].name, 'system')
+    assert.deepEqual((fetchCalls[0].options as { ignoreGroups: string[] }).ignoreGroups, ['stripe'])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test`
+Expected: FAIL — constructor arity / `ignoreGroups` not forwarded.
+
+- [ ] **Step 3: Add the limiter to the worker**
+
+In `lib/worker/pgboss-worker.ts`, import the type and extend the constructor:
+
+```ts
+import { PgbossRateLimiter } from '../rate-limit/rate-limiter.js'
+```
+
+Add the parameter (keep existing params, append last):
+
+```ts
+  constructor (
+    config: PgbossWorkerQueueOptions,
+    private bouncer: PgbossBouncer,
+    private client: PgBossClient,
+    private jobRegistry: JobRegistry,
+    private rateLimiter: Pick<PgbossRateLimiter, 'blockedKeys'>
+  ) {
+```
+
+In `fetchJobs`, compute the ignore list **before the `if (this.jobFetchingPromise != null)` de-dup guard** — never between that null-check and the `this.jobFetchingPromise = ...` assignment, because an `await` there would let two concurrent `fetchJobs()` calls both claim the slot and issue duplicate fetches (the method's own comment warns against exactly this). Place it right after the `canProceed()` block:
+
+```ts
+    if (!await this.bouncer.canProceed()) {
+      await new Promise(resolve => setTimeout(resolve, this.pollInterval))
+
+      return
+    }
+
+    const ignoreGroups = await this.rateLimiter.blockedKeys()
+
+    // do not await between this if when null and the assignment of the jobFetchingPromise
+    // to avoid multiple fetches in parallel
+    if (this.jobFetchingPromise != null) {
+      await this.jobFetchingPromise
+
+      return
+    }
+
+    this.jobFetchingPromise = new Promise((resolve, reject) => {
+      void this.client.fetch<RawPgBossJobData>(
+        this.queueName,
+        { batchSize: this.batchSize, ignoreGroups }
+      )
+```
+
+- [ ] **Step 4: Wire it in the worker app**
+
+In `lib/worker/pgboss-worker-app.ts`, inject the limiter and pass it when constructing workers:
+
+```ts
+import { PgbossRateLimiter } from '../rate-limit/rate-limiter.js'
+```
+
+Add `private rateLimiter: PgbossRateLimiter` to the constructor params, and update the `new PgBossWorker(...)` call (L24):
+
+```ts
+        const worker = new PgBossWorker(
+          queueOptions, bouncer, this.client, this.jobRegistry, this.rateLimiter
+        )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/worker/pgboss-worker.ts lib/worker/pgboss-worker-app.ts lib/worker/worker-ignore-groups.test.ts
+git commit -m "feat(rate-limit): gate fetch with ignoreGroups from limiter"
+```
+
+---
+
+### Task 9: Auto-consume on success + module wiring + exports
+
+**Files:**
+- Modify: `lib/worker/pgboss-worker.thread.ts:10-28` (constructor + `run`)
+- Modify: `lib/worker/pgboss-worker.ts:51-57` (pass limiter to threads)
+- Create: `lib/rate-limit/rate-limit.module.ts`
+- Modify: `lib/worker/pgboss-worker.module.ts` (provide rate-limit providers)
+- Modify: `lib/index.ts` (exports)
+- Test: `lib/worker/thread-consume.test.ts`
+
+**Interfaces:**
+- Consumes: `PgbossRateLimiter.consumeForClass` (Task 6).
+- Produces: worker thread consumes one token after a successful handler run.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/worker/thread-consume.test.ts`:
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PgBossWorkerThread } from './pgboss-worker.thread.js'
+
+describe('PgBossWorkerThread rate-limit accounting', () => {
+  it('consumes one token after a successful job', async () => {
+    const consumed: string[] = []
+    const job = { id: '1', name: 'system', data: { className: 'ChargeJob', classData: {} } }
+
+    async function* one () { yield job as never }
+
+    const client = { complete: async () => {}, fail: async () => {} }
+    const registry = { get: async () => ({ run: async () => {} }) }
+    const rateLimiter = { consumeForClass: async (c: string) => { consumed.push(c) }, reportForClass: async () => {} }
+
+    const thread = new PgBossWorkerThread(one(), client as never, registry as never, rateLimiter as never)
+    await thread.run()
+
+    assert.deepEqual(consumed, ['ChargeJob'])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test`
+Expected: FAIL — thread constructor has no limiter / no consume call.
+
+- [ ] **Step 3: Add limiter to the thread and consume on success**
+
+In `lib/worker/pgboss-worker.thread.ts`, import and extend the constructor:
+
+```ts
+import { PgbossRateLimiter } from '../rate-limit/rate-limiter.js'
+```
+
+```ts
+  constructor (
+    private readonly queue: AsyncGenerator<RawPgBossJob, void, unknown>,
+    private readonly client: PgBossClient,
+    private readonly jobRegistry: JobRegistry,
+    private readonly rateLimiter: Pick<PgbossRateLimiter, 'consumeForClass' | 'reportForClass'>
+  ) {}
+```
+
+In `run()`, after a successful `handleJob` + `complete`, consume:
+
+```ts
+      try {
+        const result = await this.handleJob(job)
+
+        await this.client.complete(job.name, job.id, result ?? undefined)
+        await this.rateLimiter.consumeForClass(job.data.className)
+      } catch (error) {
+        captureException(error)
+        await this.client.fail(job.name, job.id, { error }).catch(() => {})
+      }
+```
+
+- [ ] **Step 4: Pass the limiter from worker to threads**
+
+In `lib/worker/pgboss-worker.ts`, `startWorkerThreads` (L51-57) — pass `this.rateLimiter`:
+
+```ts
+      const thread = new PgBossWorkerThread(jobGenerator, this.client, this.jobRegistry, this.rateLimiter)
+```
+
+The worker's `rateLimiter` param type must now include `consumeForClass`/`reportForClass`; widen it:
+
+```ts
+    private rateLimiter: Pick<PgbossRateLimiter, 'blockedKeys' | 'consumeForClass' | 'reportForClass'>
+```
+
+Update Task 8's test double to add `consumeForClass`/`reportForClass` no-ops if the test constructs a thread (it does not — only `fetchJobs` — so no change needed there).
+
+- [ ] **Step 5: Create the module and wire providers**
+
+Create `lib/rate-limit/rate-limit.module.ts`:
+
+```ts
+import { Module } from '@nestjs/common'
+import { ProvidersExplorerModule } from '../providers/providers-explorer.module.js'
+import { PgbossRateLimitRegistry } from './rate-limit.registry.js'
+import { PgbossRateLimiter } from './rate-limiter.js'
+import { RateLimitStore } from './rate-limit.store.js'
+import { PostgresRateLimitStore } from './postgres-rate-limit.store.js'
+
+@Module({
+  imports: [ProvidersExplorerModule],
+  providers: [
+    PgbossRateLimitRegistry,
+    PgbossRateLimiter,
+    { provide: RateLimitStore, useClass: PostgresRateLimitStore }
+  ],
+  exports: [PgbossRateLimiter, PgbossRateLimitRegistry]
+})
+export class PgbossRateLimitModule {}
+```
+
+In `lib/worker/pgboss-worker.module.ts`, import `PgbossRateLimitModule` and ensure `PgbossRateLimiter` is available to `PgbossWorkerApp` (add to that module's `imports`). Match the existing module wiring style in that file.
+
+- [ ] **Step 6: Export the public surface**
+
+In `lib/index.ts`, add:
+
+```ts
+// Rate limiting
+export { RateLimited } from './rate-limit/rate-limit.decorator.js'
+export {
+  RateLimitConfig, StaticRateLimitConfig, HeaderRateLimitConfig,
+  FailureBackoffConfig, RateLimitSignal
+} from './rate-limit/rate-limit-config.js'
+export { PgbossRateLimiter } from './rate-limit/rate-limiter.js'
+export { PgbossRateLimitModule } from './rate-limit/rate-limit.module.js'
+```
+
+- [ ] **Step 7: Run tests + build**
+
+Run: `pnpm test`
+Expected: PASS across the suite; build clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/worker/pgboss-worker.thread.ts lib/worker/pgboss-worker.ts lib/rate-limit/rate-limit.module.ts lib/worker/pgboss-worker.module.ts lib/index.ts lib/worker/thread-consume.test.ts
+git commit -m "feat(rate-limit): auto-consume on success, module wiring, exports"
+```
+
+---
+
+**Phase 1 checkpoint:** Static-rate limiting works end-to-end. A job decorated `@RateLimited('x', { source: 'static', limit, windowSeconds })` is tagged with group `x`, the worker skips fetching group `x` once the bucket is empty, and each successful job consumes a token. Verify with a real consumer before Phase 2 (see Rollout in the spec).
+
+---
+
+## Phase 2 — Header and failure-backoff modes
+
+### Task 10: Header strategy + signal parsing
+
+**Files:**
+- Create: `lib/rate-limit/strategies/header-rate.strategy.ts`
+- Create: `lib/rate-limit/parse-rate-limit-headers.ts`
+- Test: `lib/rate-limit/strategies/header-rate.strategy.test.ts`
+- Test: `lib/rate-limit/parse-rate-limit-headers.test.ts`
+
+**Interfaces:**
+- Consumes: `RateLimitBucketRow`, `RateLimitStrategy`, `HeaderRateLimitConfig`, `RateLimitSignal`.
+- Produces:
+  - `class HeaderRateStrategy implements RateLimitStrategy` — `isBlocked`: blocked when `tokens != null && tokens <= 0 && resetAt != null && now < resetAt`.
+  - `function parseRateLimitHeaders(headers: Record<string, string | undefined>, config: HeaderRateLimitConfig): RateLimitSignal`
+
+- [ ] **Step 1: Write the failing tests**
+
+`lib/rate-limit/strategies/header-rate.strategy.test.ts`:
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { HeaderRateStrategy } from './header-rate.strategy.js'
+
+const strategy = new HeaderRateStrategy({ source: 'headers' })
+const now = new Date('2026-07-03T10:00:00Z')
+
+describe('HeaderRateStrategy.isBlocked', () => {
+  it('not blocked when no state known', () => {
+    assert.equal(strategy.isBlocked(null, now), false)
+  })
+  it('blocked when remaining 0 and reset in the future', () => {
+    const row = { key: 'k', tokens: 0, windowStartAt: null, resetAt: new Date('2026-07-03T10:00:30Z'), blockedUntil: null }
+    assert.equal(strategy.isBlocked(row, now), true)
+  })
+  it('not blocked once reset has passed', () => {
+    const row = { key: 'k', tokens: 0, windowStartAt: null, resetAt: new Date('2026-07-03T09:59:59Z'), blockedUntil: null }
+    assert.equal(strategy.isBlocked(row, now), false)
+  })
+})
+```
+
+`lib/rate-limit/parse-rate-limit-headers.test.ts`:
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseRateLimitHeaders } from './parse-rate-limit-headers.js'
+
+describe('parseRateLimitHeaders', () => {
+  it('reads standard X-RateLimit headers', () => {
+    const sig = parseRateLimitHeaders(
+      { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1751536830' },
+      { source: 'headers' }
+    )
+    assert.equal(sig.remaining, 0)
+    assert.ok(sig.resetAt instanceof Date)
+  })
+
+  it('reads Retry-After seconds on 429', () => {
+    const sig = parseRateLimitHeaders({ 'retry-after': '30' }, { source: 'headers' })
+    assert.equal(sig.retryAfterSeconds, 30)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test`
+Expected: FAIL — modules missing.
+
+- [ ] **Step 3: Implement the parser**
+
+Create `lib/rate-limit/parse-rate-limit-headers.ts`:
+
+```ts
+import { HeaderRateLimitConfig, RateLimitSignal } from './rate-limit-config.js'
+
+export function parseRateLimitHeaders (
+  headers: Record<string, string | undefined>,
+  config: HeaderRateLimitConfig
+): RateLimitSignal {
+  const remainingKey = (config.remainingHeader ?? 'x-ratelimit-remaining').toLowerCase()
+  const resetKey = (config.resetHeader ?? 'x-ratelimit-reset').toLowerCase()
+  const retryAfterKey = (config.retryAfterHeader ?? 'retry-after').toLowerCase()
+
+  const signal: RateLimitSignal = {}
+
+  const remaining = headers[remainingKey]
+  if (remaining !== undefined) {
+    signal.remaining = Number(remaining)
+  }
+
+  const reset = headers[resetKey]
+  if (reset !== undefined) {
+    // Epoch seconds per the common convention.
+    signal.resetAt = new Date(Number(reset) * 1000)
+  }
+
+  const retryAfter = headers[retryAfterKey]
+  if (retryAfter !== undefined) {
+    signal.retryAfterSeconds = Number(retryAfter)
+  }
+
+  return signal
+}
+```
+
+- [ ] **Step 4: Implement the strategy**
+
+Create `lib/rate-limit/strategies/header-rate.strategy.ts`:
+
+```ts
+import { HeaderRateLimitConfig } from '../rate-limit-config.js'
+import { RateLimitBucketRow, RateLimitStrategy } from '../rate-limit.strategy.js'
+
+export class HeaderRateStrategy implements RateLimitStrategy {
+  constructor (private readonly _config: HeaderRateLimitConfig) {}
+
+  isBlocked (row: RateLimitBucketRow | null, now: Date): boolean {
+    if (row?.tokens == null || row.resetAt == null) {
+      return false
+    }
+
+    return row.tokens <= 0 && now < row.resetAt
+  }
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `pnpm test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/rate-limit/strategies/header-rate.strategy.ts lib/rate-limit/parse-rate-limit-headers.ts lib/rate-limit/strategies/header-rate.strategy.test.ts lib/rate-limit/parse-rate-limit-headers.test.ts
+git commit -m "feat(rate-limit): header strategy and header parsing"
+```
+
+---
+
+### Task 11: Failure-backoff strategy
+
+**Files:**
+- Create: `lib/rate-limit/strategies/failure-backoff.strategy.ts`
+- Test: `lib/rate-limit/strategies/failure-backoff.strategy.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `class FailureBackoffStrategy implements RateLimitStrategy` — `isBlocked`: `row?.blockedUntil != null && now < row.blockedUntil`.
+  - `function nextBackoff(config: FailureBackoffConfig, signal: RateLimitSignal, now: Date): Date` — `now + max(retryAfterSeconds, backoffSeconds)` capped at `maxBackoffSeconds`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/rate-limit/strategies/failure-backoff.strategy.test.ts`:
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { FailureBackoffStrategy, nextBackoff } from './failure-backoff.strategy.js'
+
+const config = { source: 'failure' as const, backoffSeconds: 10, maxBackoffSeconds: 60 }
+const strategy = new FailureBackoffStrategy(config)
+const now = new Date('2026-07-03T10:00:00Z')
+
+describe('FailureBackoffStrategy', () => {
+  it('not blocked when no cooldown set', () => {
+    assert.equal(strategy.isBlocked(null, now), false)
+  })
+  it('blocked while blocked_until is in the future', () => {
+    const row = { key: 'k', tokens: null, windowStartAt: null, resetAt: null, blockedUntil: new Date('2026-07-03T10:00:05Z') }
+    assert.equal(strategy.isBlocked(row, now), true)
+  })
+  it('nextBackoff prefers retryAfter and caps at max', () => {
+    assert.equal(nextBackoff(config, { retryAfterSeconds: 120 }, now).toISOString(), '2026-07-03T10:01:00.000Z')
+    assert.equal(nextBackoff(config, {}, now).toISOString(), '2026-07-03T10:00:10.000Z')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement**
+
+Create `lib/rate-limit/strategies/failure-backoff.strategy.ts`:
+
+```ts
+import { FailureBackoffConfig, RateLimitSignal } from '../rate-limit-config.js'
+import { RateLimitBucketRow, RateLimitStrategy } from '../rate-limit.strategy.js'
+
+export function nextBackoff (
+  config: FailureBackoffConfig,
+  signal: RateLimitSignal,
+  now: Date
+): Date {
+  const requested = signal.retryAfterSeconds ?? config.backoffSeconds
+  const capped = config.maxBackoffSeconds != null
+    ? Math.min(requested, config.maxBackoffSeconds)
+    : requested
+
+  return new Date(now.getTime() + capped * 1000)
+}
+
+export class FailureBackoffStrategy implements RateLimitStrategy {
+  constructor (private readonly _config: FailureBackoffConfig) {}
+
+  isBlocked (row: RateLimitBucketRow | null, now: Date): boolean {
+    return row?.blockedUntil != null && now < row.blockedUntil
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/rate-limit/strategies/failure-backoff.strategy.ts lib/rate-limit/strategies/failure-backoff.strategy.test.ts
+git commit -m "feat(rate-limit): failure-backoff strategy"
+```
+
+---
+
+### Task 12: Wire header/failure strategies + `report` feedback
+
+**Files:**
+- Modify: `lib/rate-limit/rate-limit.registry.ts` (`buildStrategy` switch)
+- Modify: `lib/rate-limit/rate-limiter.ts` (`reportForClass`)
+- Create: `lib/rate-limit/rate-limit.error.ts`
+- Modify: `lib/worker/pgboss-worker.thread.ts` (`report` on `RateLimitError`)
+- Test: `lib/rate-limit/rate-limiter-report.test.ts`
+
+**Interfaces:**
+- Consumes: `HeaderRateStrategy` (Task 10), `FailureBackoffStrategy` + `nextBackoff` (Task 11).
+- Produces:
+  - `class RateLimitError extends Error { constructor(signal: RateLimitSignal) }` carrying `.signal`.
+  - `PgbossRateLimiter.reportForClass(className, signal)` persists header/failure state.
+
+- [ ] **Step 1: Complete the strategy switch**
+
+Edit `buildStrategy` in `lib/rate-limit/rate-limit.registry.ts`:
+
+```ts
+  private buildStrategy (config: RateLimitConfig): RateLimitStrategy {
+    switch (config.source) {
+      case 'static':
+        return new StaticRateStrategy(config)
+      case 'headers':
+        return new HeaderRateStrategy(config)
+      case 'failure':
+        return new FailureBackoffStrategy(config)
+    }
+  }
+```
+
+Add the imports for `HeaderRateStrategy` and `FailureBackoffStrategy`.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `lib/rate-limit/rate-limiter-report.test.ts`:
+
+```ts
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PgbossRateLimiter } from './rate-limiter.js'
+import { RateLimitStore } from './rate-limit.store.js'
+import { RateLimitBucketRow } from './rate-limit.strategy.js'
+
+class RecordingStore extends RateLimitStore {
+  blocked: Array<[string, Date]> = []
+  header: Array<[string, number, Date | null]> = []
+  async ensureSchema () {}
+  async getMany () { return [] as RateLimitBucketRow[] }
+  async tryConsumeToken () { return true }
+  async setBlockedUntil (key: string, until: Date) { this.blocked.push([key, until]) }
+  async setHeaderState (key: string, remaining: number, resetAt: Date | null) { this.header.push([key, remaining, resetAt]) }
+}
+
+const failureConfig = { source: 'failure' as const, backoffSeconds: 10 }
+const headerConfig = { source: 'headers' as const }
+
+function registryDouble (key: string, config: unknown) {
+  return {
+    getAllKeys: () => [key],
+    getKeysForClass: () => key,
+    getStrategy: () => ({ isBlocked: () => false }),
+    getConfig: () => config
+  } as never
+}
+
+describe('PgbossRateLimiter.reportForClass', () => {
+  it('sets a cooldown for failure mode on throttle', async () => {
+    const store = new RecordingStore()
+    const limiter = new PgbossRateLimiter(registryDouble('flaky', failureConfig), store)
+    await limiter.reportForClass('Job', { throttled: true, retryAfterSeconds: 5 })
+    assert.equal(store.blocked.length, 1)
+    assert.equal(store.blocked[0][0], 'flaky')
+  })
+
+  it('stores header state for header mode', async () => {
+    const store = new RecordingStore()
+    const limiter = new PgbossRateLimiter(registryDouble('cuopt', headerConfig), store)
+    const resetAt = new Date('2026-07-03T10:00:30Z')
+    await limiter.reportForClass('Job', { remaining: 0, resetAt })
+    assert.deepEqual(store.header[0], ['cuopt', 0, resetAt])
+  })
+})
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `pnpm test`
+Expected: FAIL — `reportForClass` is a no-op.
+
+- [ ] **Step 4: Implement `reportForClass`**
+
+Replace the stub in `lib/rate-limit/rate-limiter.ts`. Add imports for `nextBackoff` and update the method:
+
+```ts
+import { nextBackoff } from './strategies/failure-backoff.strategy.js'
+```
+
+```ts
+  async reportForClass (className: string, signal: RateLimitSignal): Promise<void> {
+    const key = this.registry.getKeysForClass(className)
+    if (key === undefined) {
+      return
+    }
+
+    const config = this.registry.getConfig(key)
+
+    if (config?.source === 'failure' && signal.throttled === true) {
+      await this.store.setBlockedUntil(key, nextBackoff(config, signal, new Date()))
+      return
+    }
+
+    if (config?.source === 'headers' && signal.remaining !== undefined) {
+      await this.store.setHeaderState(key, signal.remaining, signal.resetAt ?? null)
+    }
+  }
+```
+
+- [ ] **Step 5: Add `RateLimitError` and report from the thread**
+
+Create `lib/rate-limit/rate-limit.error.ts`:
+
+```ts
+import { RateLimitSignal } from './rate-limit-config.js'
+
+/** Throw from a handler when the API signalled a rate limit (e.g. a 429). */
+export class RateLimitError extends Error {
+  constructor (readonly signal: RateLimitSignal) {
+    super('Rate limit reached')
+    this.name = 'RateLimitError'
+  }
+}
+```
+
+In `lib/worker/pgboss-worker.thread.ts` `run()`, report on `RateLimitError` before failing (so header/failure state updates even though the job errors):
+
+```ts
+import { RateLimitError } from '../rate-limit/rate-limit.error.js'
+```
+
+```ts
+      } catch (error) {
+        if (error instanceof RateLimitError) {
+          await this.rateLimiter.reportForClass(job.data.className, error.signal).catch(() => {})
+        }
+        captureException(error)
+        await this.client.fail(job.name, job.id, { error }).catch(() => {})
+      }
+```
+
+Export `RateLimitError` from `lib/index.ts`:
+
+```ts
+export { RateLimitError } from './rate-limit/rate-limit.error.js'
+```
+
+- [ ] **Step 6: Run tests + build**
+
+Run: `pnpm test`
+Expected: PASS across the suite; build clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/rate-limit/rate-limit.registry.ts lib/rate-limit/rate-limiter.ts lib/rate-limit/rate-limit.error.ts lib/worker/pgboss-worker.thread.ts lib/index.ts lib/rate-limit/rate-limiter-report.test.ts
+git commit -m "feat(rate-limit): header/failure strategies and report feedback"
+```
+
+---
+
+### Task 13: README documentation
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Document the feature**
+
+Add a "Rate limiting" section to `README.md` covering:
+- `@RateLimited(key, config)` on a job class, with one example per mode:
+  - `{ source: 'static', limit: 100, windowSeconds: 60 }`
+  - `{ source: 'headers' }` + calling `throw new RateLimitError(parseRateLimitHeaders(res.headers, config))` / reporting from the handler
+  - `{ source: 'failure', backoffSeconds: 30 }` + `throw new RateLimitError({ throttled: true })` on a 429
+- How gating works (jobs stay `created`, other groups still drain).
+- The overshoot caveat (bounded by `batchSize × workers`; lower `batchSize` for hot queues).
+- That `PgbossRateLimitModule` must be imported by the worker app module.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(rate-limit): document @RateLimited usage"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** decorator (§5, Task 1); three strategies + reset (§6, Tasks 3/10/11); shared Postgres keyed state + atomicity (§4/§7, Task 4); registry scan (§4, Task 5); limiter blockedKeys/consume/report (§4, Tasks 6/12); enqueue groupId (§7.1, Task 7); fetch ignoreGroups (§7.3, Task 8); execution accounting (§7.4, Tasks 9/12); module + exports (§7.5, Task 9); overshoot decision (§8, README Task 13); backward compat (bouncer untouched — Global Constraints); testing (§9, per-task tests).
+- **Spec §7.2 resolved:** the bouncer interface is left unchanged; the worker consults the limiter directly. Documented in Global Constraints.
+- **Config surface refined from spec §6:** the sketch `{ perMinute: 100 }` is made explicit as `{ source: 'static', limit, windowSeconds }` (discriminated by `source`). A `perMinute`/`perSecond` sugar helper is optional future work, not required.
+- **Type consistency:** `RateLimitBucketRow`, `RateLimitStrategy.isBlocked(row, now)`, `RateLimitStore` method signatures, and `PgbossRateLimiter.{blockedKeys,consumeForClass,reportForClass}` are used identically across all tasks.
+- **Deferred to Phase 2 intentionally:** header/failure strategies return a never-blocking stub from the registry until Task 12 wires them, so Phase 1 is shippable without wedging any queue.

--- a/packages/api/pgboss-nestjs-job/docs/superpowers/specs/2026-07-03-rate-limited-jobs-design.md
+++ b/packages/api/pgboss-nestjs-job/docs/superpowers/specs/2026-07-03-rate-limited-jobs-design.md
@@ -1,0 +1,293 @@
+# Rate-limited jobs for `@wisemen/pgboss-nestjs-job`
+
+**Date:** 2026-07-03
+**Status:** Implemented (revised)
+**Package:** `packages/api/pgboss-nestjs-job`
+
+> **Revision (post-implementation):** the original design put a `@RateLimited(key, config)`
+> decorator on the **job class** and had `PgbossRateLimitRegistry` discover it by
+> scanning DI providers. That is unsound: the decorated job classes are **not**
+> DI providers (only their `@PgBossJobHandler` handlers are), so the registry
+> found nothing and the whole feature was inert. The mechanism was pivoted to:
+> **(a)** the rate-limit key is a job **option** — `super(data, { rateLimited: key })` —
+> serialized to the pg-boss group id and carried on the fetched job (`job.groupId`);
+> **(b)** the strategy/config is declared **centrally** on the worker module
+> (`PgBossWorkerModule.forRoot({ rateLimits })`), which is where the fetch-gate
+> needs the full key set at startup anyway. This removes provider scanning and the
+> `className → key` map entirely. Sections below are updated to the implemented
+> design; the group-gated-fetch enforcement (§3) is unchanged.
+
+> **Revision 2 — execution accounting moved to the transport layer.** The first
+> cut counted usage in the worker thread: consume one token when a job *succeeded*,
+> and report header/failure state only when a handler *threw* `RateLimitError`.
+> That is a loose proxy for real API usage (a job that retries makes 2 calls but
+> consumed 1; a job whose request was sent then failed consumed 0) and header mode
+> learned limits one request too late (only off thrown errors). Accounting now
+> happens **per HTTP request**, via `@wisemen/node-fetch` interceptors registered
+> with `useRateLimiting(client, limiter)`. The worker thread publishes the current
+> job's key into an `AsyncLocalStorage` (`rateLimitStorage`) around handler
+> execution; the interceptors read it (`currentRateLimitKey()`) and call the limiter
+> **hooks** `onRequest` (static: consume per attempt), `onResponse` (headers: record
+> reported state on every response; failure: block + throw `RateLimitError` on 429),
+> and `onError` (failure: block on transport error). The thread no longer does any
+> accounting; `consume`/`report` were replaced by the hooks. The **fetch-gate (§3)
+> and the store/strategies are unchanged.** Trade-off: accounting only applies to
+> calls routed through an instrumented client (documented footgun). This is the
+> "auto HTTP feedback" option noted as future work in §11, now the default.
+
+## 1. Problem
+
+Some jobs call external APIs that are rate limited. Today those jobs just run,
+hit the limit, **fail, and requeue** (the Trixxa pattern) — burning retries,
+producing noise, and never actually respecting the limit. We want a **default,
+reusable** way to make a job queue respect an external rate limit, that:
+
+- works when we **scale to multiple worker instances** (state must be shared,
+  not per-process),
+- does **not** stall unrelated jobs that happen to share a queue,
+- handles three levels of knowledge about the limit:
+  1. **Header mode** — the API tells us (`X-RateLimit-Remaining` / `Retry-After`),
+  2. **Static mode** — we know a configured budget (e.g. 100/min), nothing in the response,
+  3. **Learn-nothing mode** — we know nothing; we only find out by getting a `429`.
+
+## 2. Goals / non-goals
+
+**Goals**
+- A job declares "I'm governed by rate limit X" with a single job option
+  (`{ rateLimited: X }`); the limit's strategy/budget is declared once, centrally,
+  on the worker.
+- Rate-limit state is shared across workers via Postgres (no new infra).
+- When a limit is exhausted, the governed jobs **wait in `created` state** — they
+  are not pulled into `active`, not failed, and don't consume a retry.
+- Other (non-governed, or differently-governed) jobs on the **same queue keep flowing**.
+- All three signal modes are supported behind one interface.
+
+**Non-goals**
+- Guaranteeing zero overshoot on the very first poll after exhaustion (bounded,
+  self-correcting overshoot is acceptable — see §8).
+- A generic HTTP client/interceptor that auto-reports limits (a possible future
+  enhancement, §11 — v1 reports feedback explicitly).
+- Changing how non-rate-limited jobs behave (fully backward compatible).
+
+## 3. Chosen approach — group-gated fetch ("B")
+
+We enforce the limit at the **fetch** boundary using pg-boss **groups**.
+
+- Each governed job is tagged at enqueue with `group: { id: <limitKey> }`.
+- Before each poll, the worker asks the limiter *which keys are exhausted right
+  now* and passes them to pg-boss `fetch` as `ignoreGroups`. pg-boss's fetch SQL
+  excludes those jobs (`... AND (group_id IS NULL OR group_id <> ALL($ignoreGroups))`),
+  so they **stay in `created`** — never pulled, no churn — while other groups on
+  the same queue continue to drain.
+
+This is the "bouncer-per-job" idea done at the right layer: a per-**group** gate
+inside the fetch query rather than a whole-queue on/off switch.
+
+### Why not "A" (queue-per-limit + whole-queue bouncer)
+
+A is simpler (reuses the existing bouncer verbatim, zero framework changes) but
+forces **one dedicated queue per rate-limited API**. Real jobs don't partition
+that way: e.g. `GenerateInvoicePdfJob` is `@PgBossJob(QueueName.SYSTEM)` — it
+shares `SYSTEM` with many job types, dispatched by `className`. Under A we'd have
+to split every rate-limited job into its own queue; under B it stays on `SYSTEM`
+and just carries a group tag. A remains viable as a pure-userland fallback, but B
+is the general default. The **RateLimiter core and the execution-side reporting
+are identical either way**, so that work is not wasted if a team chooses A.
+
+## 4. Architecture
+
+The rate-limit **key** rides with the job (a job option → pg-boss group id); the
+**config** for each key is declared centrally on the worker. The key is read/used
+at **three** points:
+
+```
+   worker rateLimits: { stripe: <strategy/config> }   ← central config (startup)
+   job option:        { rateLimited: 'stripe' }        ← per-job opt-in
+                     │
+   ┌─────────────────┼──────────────────────────┐
+   │ (enqueue)       │ (fetch-gate)              │ (execution)
+   ▼                 ▼                           ▼
+serializeJob     PgbossRateLimiter           worker thread
+ reads job     → worker asks limiter:      →  reads job.groupId, then
+ option →         "which keys blocked?"        after the API call:
+ group id         → fetch({ ignoreGroups })    consume (static) /
+                                               report(headers|429)
+```
+
+- **Opt-in** — `super(data, { rateLimited: key })` on the job. No decorator, no
+  reflection; `serializeJob` copies the option to the group id.
+- **`PgbossRateLimitRegistry`** — constructed from the central `RateLimitConfigMap`
+  (via `PgbossRateLimitModule.forRoot(limits)`), it holds `key → { config, strategy }`.
+  No provider scanning; no `className` map. Available at startup, which is exactly
+  what the fetch-gate needs.
+- **`PgbossRateLimiter`** — shared, Postgres-backed service keyed by limit key.
+  Delegates to one of three **strategies**. Two responsibilities:
+  - **read (fetch-gate):** `blockedKeys() → string[]`
+  - **write (execution):** `consume(key)` and/or `report(key, signal)`, where the
+    key comes from `job.groupId` on the fetched job.
+- **Persistence:** the `pgboss.rate_limit` table (via the same `EntityManager` the
+  scheduler injects), one row per key, updated atomically; schema ensured on worker init.
+
+## 5. Opt-in (job option) + central config
+
+Opt a job in with the `rateLimited` option; declare the strategy centrally:
+
+```ts
+// per-job opt-in — just the key
+@PgBossJob(QueueName.SYSTEM)
+export class ChargeCardJob extends BaseJob<…> {
+  constructor (…) { super(data, { rateLimited: 'stripe' }) }
+}
+
+// central config on the worker (one entry per API)
+PgBossWorkerModule.forRoot({
+  queues: [...],
+  rateLimits: {
+    stripe: { source: 'static', limit: 100, windowSeconds: 60 },  // static
+    cuopt:  { source: 'headers' },                                 // header-driven
+    flaky:  { source: 'failure', backoffSeconds: 30 },            // learn-nothing
+  },
+})
+```
+
+The key is the single source of truth: `serializeJob` reads it from the job (no
+reflection), it is stored as the group id, and the worker resolves the strategy
+from the central `rateLimits` map. Multiple job classes (and multiple queues) may
+share a key; they then share one limiter/bucket. The config belongs to the API,
+so it lives once in `rateLimits` rather than repeated on each job — which also
+avoids the "two classes, same key, different config, second silently ignored"
+hazard the per-class decorator had.
+
+## 6. The three strategies + reset semantics
+
+Only static mode maintains a true "requests remaining" counter. Header mode
+mirrors the API's numbers; learn-nothing tracks only a cooldown.
+
+| Mode | Counter? | State (per key) | `isBlocked` | Reset |
+|---|---|---|---|---|
+| **Static** (`perMinute`/`perSecond`) | ✅ owned | `tokens`, `window_start` | `tokens <= 0` | time-window refill (fixed window or token-bucket) |
+| **Header** (`source: 'headers'`) | ⚠️ mirror | `remaining`, `reset_at` | `remaining <= 0 && now < reset_at` | at `reset_at` (API-provided) |
+| **Learn-nothing** (`onFailure: 'backoff'`) | ❌ none | `blocked_until` | `now < blocked_until` | backoff expiry |
+
+A **strategy** is a pure predicate over the stored row (the fetch-gate read);
+the **limiter** owns the writes (`consume`/`report`), keyed by the limit key:
+
+```ts
+interface RateLimitStrategy {
+  isBlocked (row: RateLimitBucketRow | null, now: Date): boolean   // fetch-gate (read)
+}
+
+class PgbossRateLimiter {
+  blockedKeys (): Promise<string[]>                         // fetch-gate over all keys
+  consume (key: string): Promise<void>                     // static: decrement on call
+  report  (key: string, signal: RateLimitSignal): Promise<void> // header/failure: feedback
+}
+```
+
+`RateLimitSignal` carries what execution observed: HTTP status, `Retry-After`,
+`X-RateLimit-*` headers (or a normalized `{ remaining, resetAt }` / `{ throttled: true }`).
+
+## 7. Enforcement flow / framework touchpoints
+
+All edits live in the library. Files and the change each needs:
+
+1. **`lib/jobs/base-job.ts`** — the options type gains `rateLimited?: string`
+   (`BaseJobOptions`). **`lib/scheduler/pgboss-scheduler.ts`** (`serializeJob`) reads
+   it via `resolveGroupId(job)` (`job.options?.rateLimited`, no reflection) and sets
+   `groupId` on **`lib/jobs/serialized-job.ts`**. pg-boss's bulk `insert` recordset
+   expects a flattened `"groupId"` (verified in pg-boss `plans.js`).
+
+2. **`lib/worker/pgboss-worker.ts`** (`fetchJobs`) — before building the fetch
+   promise, `ignoreGroups = await rateLimiter.blockedKeys()` and pass
+   `this.client.fetch(queueName, { batchSize, ignoreGroups })`. **No `PgBossClient`
+   change** — `FetchOptions` already accepts `ignoreGroups`. Existing `canProceed()`
+   still runs first and composes (whole-queue park vs per-group park). The worker
+   consults the limiter directly — `PgbossBouncer` is **not** extended, so existing
+   bouncers are untouched and no bouncer is required for rate limiting.
+
+3. **`lib/worker/pgboss-worker.thread.ts`** (`run`) — after the handler completes,
+   `if (job.groupId != null) rateLimiter.consume(job.groupId)`; on a thrown
+   `RateLimitError`, `rateLimiter.report(job.groupId, error.signal)`. The key comes
+   straight off the fetched job (`Job.groupId`), so **no `className → key` lookup**.
+   Count at **execution**, not fetch, so a job that errored before the API call
+   doesn't burn quota.
+
+4. **`lib/worker/pgboss-worker.module.ts` / `.module-options.ts`** — add a
+   `rateLimits?: RateLimitConfigMap` option; `forRoot`/`forRootAsync` import
+   `PgbossRateLimitModule.forRoot(rateLimits)`. `PgBossSchedulerModule` does **not**
+   import it — producers only tag the group at enqueue, no limiter needed.
+
+5. **New:** `lib/rate-limit/` — `PgbossRateLimitModule.forRoot(limits)`,
+   `PgbossRateLimitRegistry` (config-map driven), `PgbossRateLimiter` + 3 strategies,
+   `PostgresRateLimitStore` (ensures schema on init), `RateLimitError`,
+   `parseRateLimitHeaders`. Exported from `lib/index.ts`. (No decorator.)
+
+### Multi-worker atomicity
+
+Static consume is a single atomic statement so N workers never over-spend:
+
+```sql
+UPDATE pgboss_rate_limit
+SET tokens = tokens - 1
+WHERE key = $1 AND tokens > 0
+RETURNING tokens;      -- no row / tokens null → blocked
+```
+
+Refill is computed lazily from `window_start`/elapsed on read (no cron needed).
+
+## 8. Edge cases & decisions
+
+- **Overshoot:** the fetch-gate is binary per poll, and pg-boss `fetch` can't cap
+  *count per group* in one call. So a worker may pull up to `batchSize` of an
+  allowed group whose remaining budget was smaller → overshoot bounded by
+  `batchSize × workers` per poll. **Decision:** accept it for v1; header mode
+  self-corrects on the next `report`; static mode can optionally lower `batchSize`
+  for hot queues or reserve-at-fetch later.
+- **Group present but no limiter registered:** treated as not blocked (fail-open,
+  mirroring `AllowBouncer`) — a misconfiguration never wedges the queue.
+- **Backward compatibility:** groups and `@RateLimited` are opt-in; untagged jobs
+  and existing bouncers behave exactly as today.
+- **Shared budget across job types/queues:** the bucket is keyed by the limit key,
+  not the queue — two job classes hitting the same API share one counter.
+- **`report` failure / limiter DB error:** log + fail-open on the read path
+  (don't block work on limiter infra hiccups); execution write errors are
+  swallowed like the existing `fail(...).catch(() => {})`.
+
+## 9. Testing
+
+- **Strategy unit tests:** each of the three — token depletion + window reset
+  (static), header parse + `reset_at` expiry (header), 429 → `blocked_until` +
+  backoff expiry (learn-nothing).
+- **Atomicity:** concurrent `consume` from parallel connections never drives
+  `tokens` below zero (integration test against Postgres).
+- **Fetch-gate:** enqueue mixed-group jobs on one queue; exhaust one key; assert
+  only that group's jobs stay `created` while others drain.
+- **End-to-end:** a governed job that hits a stubbed 429 gets deferred (stays
+  queued, no retry burned) and drains once the cooldown passes.
+- **Backward compat:** existing bouncer + untagged jobs unchanged.
+
+## 10. Rollout
+
+1. Land `lib/rate-limit/` + `serialized-job`/`serializeJob` group support (inert
+   until a job is decorated).
+2. Extend bouncer interface + worker fetch (`blockedGroups`/`ignoreGroups`).
+3. Ship migration for `pgboss_rate_limit`.
+4. Adopt in one real consumer (a Trixxa rate-limited job) as the reference.
+
+## 11. Future (out of scope for v1)
+
+- A shared HTTP interceptor that auto-calls `report()` from responses (removes the
+  explicit report call in handlers).
+- Reserve-at-fetch to eliminate overshoot entirely.
+- Per-tenant keys (`group = 'stripe:tenant42'`) — already supported by the keying
+  model, just needs a documented pattern.
+
+## 12. Alternatives considered
+
+- **Per-job defer** (pull job → try token → reschedule via `startAfter`): precise
+  but pulls every job into `active` just to defer it — churn under backlog, and
+  either burns a retry or loses job identity. Rejected in favour of gating at fetch.
+- **Refuse at enqueue** (producer checks limiter before `send`): matches "don't
+  schedule it" literally but throws away the durable-queue safety net. Rejected.
+- **Approach A** (queue-per-limit): documented in §3; viable userland fallback,
+  not the default.

--- a/packages/api/pgboss-nestjs-job/lib/index.ts
+++ b/packages/api/pgboss-nestjs-job/lib/index.ts
@@ -5,14 +5,14 @@ export { Job } from './persistence/job.entity.js'
 
 // Defining jobs
 export { PgBossWorkerModule } from './worker/pgboss-worker.module.js'
-export { PgBossWorkerModuleOptions } from './worker/pgboss-worker.module-options.js'
+export { PgBossWorkerModuleOptions, PgBossWorkerRateLimitOptions } from './worker/pgboss-worker.module-options.js'
 export { PgbossBouncer } from './worker/pgboss-bouncer.js'
 export { Bouncer } from './worker/pgboss-bouncer.decorator.js'
 
 export { PgBossJob } from './jobs/job.decorator.js'
 export { PgBossJobHandler } from './jobs/job.decorator.js'
 
-export { BaseJob, BaseJobData } from './jobs/base-job.js'
+export { BaseJob, BaseJobData, BaseJobOptions } from './jobs/base-job.js'
 export { JobHandler } from './jobs/job-handler.js'
 
 // Scheduling jobs
@@ -22,3 +22,17 @@ export { PgBossScheduler } from './scheduler/pgboss-scheduler.js'
 // Client
 export { PgBossClientModule } from './client/pgboss-client.module.js'
 export { PgBossClient } from './client/pgboss-client.js'
+
+// Rate limiting
+export {
+  RateLimitConfig, RateLimitConfigMap, StaticRateLimitConfig, HeaderRateLimitConfig,
+  FailureBackoffConfig, RateLimitSignal
+} from './rate-limit/rate-limit-config.js'
+export { PgbossRateLimiter } from './rate-limit/rate-limiter.js'
+export { PgbossRateLimitModule } from './rate-limit/rate-limit.module.js'
+export { RateLimitError } from './rate-limit/rate-limit.error.js'
+export { parseRateLimitHeaders } from './rate-limit/parse-rate-limit-headers.js'
+export { currentRateLimitKey } from './rate-limit/rate-limit.context.js'
+export {
+  createRateLimitInterceptors, useRateLimiting, RateLimitInterceptors
+} from './rate-limit/rate-limit.interceptors.js'

--- a/packages/api/pgboss-nestjs-job/lib/jobs/base-job.ts
+++ b/packages/api/pgboss-nestjs-job/lib/jobs/base-job.ts
@@ -7,12 +7,19 @@ type Serializable = {
 
 export type BaseJobData = Serializable
 
-type JobOptions = Omit<JobInsert, 'id' | 'name' | 'data'>
+export type BaseJobOptions = Omit<JobInsert, 'id' | 'name' | 'data'> & {
+  /**
+   * Opt this job into a rate limit by its key. The key must match one declared
+   * in the worker's `rateLimits` config. The worker gates fetching and counts
+   * usage for jobs carrying this key; it is serialized as the pg-boss group id.
+   */
+  rateLimited?: string
+}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export abstract class BaseJob<T extends BaseJobData = {}> {
   constructor (
     readonly data: T = {} as T,
-    readonly options?: JobOptions
+    readonly options?: BaseJobOptions
   ) {}
 }

--- a/packages/api/pgboss-nestjs-job/lib/jobs/serialized-job.ts
+++ b/packages/api/pgboss-nestjs-job/lib/jobs/serialized-job.ts
@@ -11,4 +11,5 @@ interface SerializedJobData<T extends BaseJob> {
 export interface SerializedJob<T extends BaseJob = BaseJob>
   extends JobInsert<SerializedJobData<T>> {
   name: string
+  groupId?: string
 }

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/parse-rate-limit-headers.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/parse-rate-limit-headers.test.ts
@@ -16,4 +16,24 @@ describe('parseRateLimitHeaders', () => {
     const sig = parseRateLimitHeaders({ 'retry-after': '30' }, { source: 'headers' })
     assert.equal(sig.retryAfterSeconds, 30)
   })
+
+  it('ignores a non-numeric remaining header instead of yielding NaN', () => {
+    const sig = parseRateLimitHeaders({ 'x-ratelimit-remaining': 'unknown' }, { source: 'headers' })
+    assert.equal(sig.remaining, undefined)
+  })
+
+  it('ignores an empty remaining header instead of yielding 0', () => {
+    const sig = parseRateLimitHeaders({ 'x-ratelimit-remaining': '' }, { source: 'headers' })
+    assert.equal(sig.remaining, undefined)
+  })
+
+  it('ignores a non-numeric reset header instead of an Invalid Date', () => {
+    const sig = parseRateLimitHeaders({ 'x-ratelimit-reset': 'later' }, { source: 'headers' })
+    assert.equal(sig.resetAt, undefined)
+  })
+
+  it('ignores a non-numeric Retry-After (e.g. HTTP-date) instead of NaN', () => {
+    const sig = parseRateLimitHeaders({ 'retry-after': 'Wed, 21 Oct 2025 07:28:00 GMT' }, { source: 'headers' })
+    assert.equal(sig.retryAfterSeconds, undefined)
+  })
 })

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/parse-rate-limit-headers.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/parse-rate-limit-headers.test.ts
@@ -1,0 +1,19 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseRateLimitHeaders } from './parse-rate-limit-headers.js'
+
+describe('parseRateLimitHeaders', () => {
+  it('reads standard X-RateLimit headers', () => {
+    const sig = parseRateLimitHeaders(
+      { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1751536830' },
+      { source: 'headers' }
+    )
+    assert.equal(sig.remaining, 0)
+    assert.ok(sig.resetAt instanceof Date)
+  })
+
+  it('reads Retry-After seconds on 429', () => {
+    const sig = parseRateLimitHeaders({ 'retry-after': '30' }, { source: 'headers' })
+    assert.equal(sig.retryAfterSeconds, 30)
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/parse-rate-limit-headers.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/parse-rate-limit-headers.ts
@@ -1,0 +1,30 @@
+import { HeaderRateLimitConfig, RateLimitSignal } from './rate-limit-config.js'
+
+export function parseRateLimitHeaders (
+  headers: Record<string, string | undefined>,
+  config: HeaderRateLimitConfig
+): RateLimitSignal {
+  const remainingKey = (config.remainingHeader ?? 'x-ratelimit-remaining').toLowerCase()
+  const resetKey = (config.resetHeader ?? 'x-ratelimit-reset').toLowerCase()
+  const retryAfterKey = (config.retryAfterHeader ?? 'retry-after').toLowerCase()
+
+  const signal: RateLimitSignal = {}
+
+  const remaining = headers[remainingKey]
+  if (remaining !== undefined) {
+    signal.remaining = Number(remaining)
+  }
+
+  const reset = headers[resetKey]
+  if (reset !== undefined) {
+    // Epoch seconds per the common convention.
+    signal.resetAt = new Date(Number(reset) * 1000)
+  }
+
+  const retryAfter = headers[retryAfterKey]
+  if (retryAfter !== undefined) {
+    signal.retryAfterSeconds = Number(retryAfter)
+  }
+
+  return signal
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/parse-rate-limit-headers.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/parse-rate-limit-headers.ts
@@ -1,5 +1,16 @@
 import { HeaderRateLimitConfig, RateLimitSignal } from './rate-limit-config.js'
 
+/** Parse a header value to a finite number, or undefined if absent/blank/non-numeric. */
+function toFiniteNumber (raw: string | undefined): number | undefined {
+  if (raw === undefined || raw.trim() === '') {
+    return undefined
+  }
+
+  const value = Number(raw)
+
+  return Number.isFinite(value) ? value : undefined
+}
+
 export function parseRateLimitHeaders (
   headers: Record<string, string | undefined>,
   config: HeaderRateLimitConfig
@@ -10,20 +21,20 @@ export function parseRateLimitHeaders (
 
   const signal: RateLimitSignal = {}
 
-  const remaining = headers[remainingKey]
+  const remaining = toFiniteNumber(headers[remainingKey])
   if (remaining !== undefined) {
-    signal.remaining = Number(remaining)
+    signal.remaining = remaining
   }
 
-  const reset = headers[resetKey]
+  const reset = toFiniteNumber(headers[resetKey])
   if (reset !== undefined) {
     // Epoch seconds per the common convention.
-    signal.resetAt = new Date(Number(reset) * 1000)
+    signal.resetAt = new Date(reset * 1000)
   }
 
-  const retryAfter = headers[retryAfterKey]
+  const retryAfter = toFiniteNumber(headers[retryAfterKey])
   if (retryAfter !== undefined) {
-    signal.retryAfterSeconds = Number(retryAfter)
+    signal.retryAfterSeconds = retryAfter
   }
 
   return signal

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/postgres-rate-limit.store.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/postgres-rate-limit.store.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { DataSource } from 'typeorm'
+import { PostgresRateLimitStore } from './postgres-rate-limit.store.js'
+
+const url = process.env.RATE_LIMIT_TEST_DATABASE_URL
+
+describe('PostgresRateLimitStore (integration)', { skip: url == null }, () => {
+  let ds: DataSource
+  let store: PostgresRateLimitStore
+
+  before(async () => {
+    ds = new DataSource({ type: 'postgres', url })
+    await ds.initialize()
+    await ds.query('CREATE SCHEMA IF NOT EXISTS pgboss')
+    store = new PostgresRateLimitStore(ds.manager)
+    await store.ensureSchema()
+    await ds.query(`DELETE FROM pgboss.rate_limit WHERE key = 'itest'`)
+  })
+
+  after(async () => {
+    await ds?.destroy()
+  })
+
+  it('grants exactly `limit` tokens then blocks', async () => {
+    const granted: boolean[] = []
+    for (let i = 0; i < 4; i++) {
+      granted.push(await store.tryConsumeToken('itest', 3, 60))
+    }
+    assert.deepEqual(granted, [true, true, true, false])
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/postgres-rate-limit.store.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/postgres-rate-limit.store.ts
@@ -1,0 +1,107 @@
+import { Injectable } from '@nestjs/common'
+import { EntityManager } from 'typeorm'
+import { InjectEntityManager } from '@wisemen/nestjs-typeorm'
+import { RateLimitBucketRow } from './rate-limit.strategy.js'
+import { RateLimitStore } from './rate-limit.store.js'
+
+// Field names mirror the raw Postgres column names returned by the query below.
+/* eslint-disable @typescript-eslint/naming-convention */
+interface RawRow {
+  key: string
+  tokens: number | null
+  window_start_at: Date | null
+  reset_at: Date | null
+  blocked_until: Date | null
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+@Injectable()
+export class PostgresRateLimitStore extends RateLimitStore {
+  constructor (
+    @InjectEntityManager() private readonly manager: EntityManager
+  ) {
+    super()
+  }
+
+  async ensureSchema (): Promise<void> {
+    await this.manager.query(`
+      CREATE TABLE IF NOT EXISTS pgboss.rate_limit (
+        key text PRIMARY KEY,
+        tokens integer,
+        window_start_at timestamptz,
+        reset_at timestamptz,
+        blocked_until timestamptz,
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )
+    `)
+  }
+
+  async getMany (keys: string[]): Promise<RateLimitBucketRow[]> {
+    if (keys.length === 0) {
+      return []
+    }
+
+    const rows = await this.manager.query<RawRow[]>(
+      `SELECT key, tokens, window_start_at, reset_at, blocked_until
+       FROM pgboss.rate_limit WHERE key = ANY($1)`,
+      [keys]
+    )
+
+    return rows.map(r => ({
+      key: r.key,
+      tokens: r.tokens,
+      windowStartAt: r.window_start_at,
+      resetAt: r.reset_at,
+      blockedUntil: r.blocked_until
+    }))
+  }
+
+  async tryConsumeToken (key: string, limit: number, windowSeconds: number): Promise<boolean> {
+    // Upsert-then-atomically-decrement in one statement. The window resets to a
+    // full budget when window_start_at is null or older than windowSeconds;
+    // otherwise the counter is ALWAYS decremented (it may drift negative under
+    // contention — that is fine, it self-heals at the next window). The call is
+    // granted iff the resulting count is >= 0: the last token lands on exactly 0
+    // (granted), an over-budget call lands on -1 (denied). This unambiguous
+    // grant test is why we do not clamp at 0.
+    const rows = await this.manager.query<Array<{ tokens: number }>>(
+      `
+      INSERT INTO pgboss.rate_limit (key, tokens, window_start_at, updated_at)
+      VALUES ($1, $2 - 1, now(), now())
+      ON CONFLICT (key) DO UPDATE SET
+        window_start_at = CASE
+          WHEN pgboss.rate_limit.window_start_at IS NULL
+            OR pgboss.rate_limit.window_start_at < now() - ($3 || ' seconds')::interval
+          THEN now() ELSE pgboss.rate_limit.window_start_at END,
+        tokens = CASE
+          WHEN pgboss.rate_limit.window_start_at IS NULL
+            OR pgboss.rate_limit.window_start_at < now() - ($3 || ' seconds')::interval
+          THEN $2 - 1
+          ELSE pgboss.rate_limit.tokens - 1 END,
+        updated_at = now()
+      RETURNING tokens
+      `,
+      [key, limit, String(windowSeconds)]
+    )
+
+    return rows.length > 0 && rows[0].tokens >= 0
+  }
+
+  async setBlockedUntil (key: string, until: Date): Promise<void> {
+    await this.manager.query(
+      `INSERT INTO pgboss.rate_limit (key, blocked_until, updated_at)
+       VALUES ($1, $2, now())
+       ON CONFLICT (key) DO UPDATE SET blocked_until = $2, updated_at = now()`,
+      [key, until]
+    )
+  }
+
+  async setHeaderState (key: string, remaining: number, resetAt: Date | null): Promise<void> {
+    await this.manager.query(
+      `INSERT INTO pgboss.rate_limit (key, tokens, reset_at, updated_at)
+       VALUES ($1, $2, $3, now())
+       ON CONFLICT (key) DO UPDATE SET tokens = $2, reset_at = $3, updated_at = now()`,
+      [key, remaining, resetAt]
+    )
+  }
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit-config.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit-config.ts
@@ -1,0 +1,43 @@
+export interface StaticRateLimitConfig {
+  source: 'static'
+  /** Maximum number of requests allowed per window. */
+  limit: number
+  /** Length of the window in seconds. */
+  windowSeconds: number
+}
+
+export interface HeaderRateLimitConfig {
+  source: 'headers'
+  remainingHeader?: string
+  resetHeader?: string
+  retryAfterHeader?: string
+}
+
+export interface FailureBackoffConfig {
+  source: 'failure'
+  backoffSeconds: number
+  maxBackoffSeconds?: number
+}
+
+export type RateLimitConfig =
+  | StaticRateLimitConfig
+  | HeaderRateLimitConfig
+  | FailureBackoffConfig
+
+/**
+ * Central declaration of every rate limit, keyed by its group id. A job opts
+ * into a limit by tagging itself with the matching key
+ * (`super(data, { rateLimited: key })`); the worker resolves the strategy from
+ * this map. The config belongs to the downstream API, so it lives here once —
+ * not repeated on each job class.
+ */
+export type RateLimitConfigMap = Record<string, RateLimitConfig>
+
+/** What execution observed after calling the API. */
+export interface RateLimitSignal {
+  status?: number
+  retryAfterSeconds?: number
+  remaining?: number
+  resetAt?: Date
+  throttled?: boolean
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.context.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.context.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { rateLimitStorage, currentRateLimitKey } from './rate-limit.context.js'
+
+describe('rate-limit context', () => {
+  it('has no key outside a run scope', () => {
+    assert.equal(currentRateLimitKey(), undefined)
+  })
+
+  it('exposes the key inside a run scope', () => {
+    rateLimitStorage.run({ key: 'stripe' }, () => {
+      assert.equal(currentRateLimitKey(), 'stripe')
+    })
+  })
+
+  it('propagates the key across an await', async () => {
+    await rateLimitStorage.run({ key: 'stripe' }, async () => {
+      await Promise.resolve()
+      assert.equal(currentRateLimitKey(), 'stripe')
+    })
+  })
+
+  it('isolates concurrent scopes with different keys', async () => {
+    const seen: Array<string | undefined> = []
+
+    async function record (key: string) {
+      await rateLimitStorage.run({ key }, async () => {
+        await Promise.resolve()
+        seen.push(currentRateLimitKey())
+      })
+    }
+
+    await Promise.all([record('a'), record('b')])
+
+    assert.deepEqual([...seen].sort(), ['a', 'b'])
+    assert.equal(currentRateLimitKey(), undefined)
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.context.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.context.ts
@@ -1,0 +1,18 @@
+import { AsyncLocalStorage } from 'async_hooks'
+
+export interface RateLimitContext {
+  key: string
+}
+
+/**
+ * Carries the current job's rate-limit key across the handler's async call
+ * stack so a shared transport interceptor can attribute each HTTP request to
+ * the right limit without threading the key through handler signatures. The
+ * worker thread sets it around handler execution; interceptors read it.
+ */
+export const rateLimitStorage = new AsyncLocalStorage<RateLimitContext>()
+
+/** The rate-limit key of the job currently executing, if any. */
+export function currentRateLimitKey (): string | undefined {
+  return rateLimitStorage.getStore()?.key
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.error.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.error.ts
@@ -1,0 +1,9 @@
+import { RateLimitSignal } from './rate-limit-config.js'
+
+/** Throw from a handler when the API signalled a rate limit (e.g. a 429). */
+export class RateLimitError extends Error {
+  constructor (readonly signal: RateLimitSignal) {
+    super('Rate limit reached')
+    this.name = 'RateLimitError'
+  }
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.integration.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.integration.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createClient } from '@wisemen/node-fetch'
+import { useRateLimiting } from './rate-limit.interceptors.js'
+import { rateLimitStorage } from './rate-limit.context.js'
+import { RateLimitError } from './rate-limit.error.js'
+
+function setup (fakeFetch: typeof fetch) {
+  const calls: string[] = []
+  const limiter = {
+    onRequest: (k: string) => { calls.push(`req:${k}`); return Promise.resolve() },
+    onResponse: (k: string, status: number) => { calls.push(`res:${k}:${status}`); return Promise.resolve() },
+    onError: (k: string) => { calls.push(`err:${k}`); return Promise.resolve() }
+  }
+  const client = createClient({ fetch: fakeFetch })
+  useRateLimiting(client, limiter)
+
+  return { calls, client }
+}
+
+describe('useRateLimiting (node-fetch integration)', () => {
+  it('accounts request + response for a successful call', async () => {
+    const { calls, client } = setup(() => Promise.resolve(new Response(null, { status: 200 })))
+
+    await rateLimitStorage.run({ key: 'stripe' }, () => client.get('https://api.example.com/x'))
+
+    assert.deepEqual(calls, ['req:stripe', 'res:stripe:200'])
+  })
+
+  it('reports then throws RateLimitError on a 429 (no double-count via error channel)', async () => {
+    const { calls, client } = setup(() => Promise.resolve(new Response(null, { status: 429 })))
+
+    await rateLimitStorage.run({ key: 'flaky' }, async () => {
+      await assert.rejects(
+        () => client.get('https://api.example.com/x'),
+        (e: unknown) => e instanceof RateLimitError
+      )
+    })
+
+    assert.deepEqual(calls, ['req:flaky', 'res:flaky:429'])
+  })
+
+  it('accounts a transport error', async () => {
+    const { calls, client } = setup(() => Promise.reject(new Error('network')))
+
+    await rateLimitStorage.run({ key: 'flaky' }, async () => {
+      await assert.rejects(
+        () => client.get('https://api.example.com/x'),
+        (e: unknown) => e instanceof Error && e.message === 'network'
+      )
+    })
+
+    assert.deepEqual(calls, ['req:flaky', 'err:flaky'])
+  })
+
+  it('leaves requests made outside a job untouched', async () => {
+    const { calls, client } = setup(() => Promise.resolve(new Response(null, { status: 200 })))
+
+    await client.get('https://api.example.com/x')
+
+    assert.deepEqual(calls, [])
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.interceptors.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.interceptors.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createRateLimitInterceptors } from './rate-limit.interceptors.js'
+import { rateLimitStorage } from './rate-limit.context.js'
+import { RateLimitError } from './rate-limit.error.js'
+
+function fakeLimiter () {
+  const calls: string[] = []
+  const limiter = {
+    onRequest: (k: string) => { calls.push(`req:${k}`); return Promise.resolve() },
+    onResponse: (k: string, status: number) => { calls.push(`res:${k}:${status}`); return Promise.resolve() },
+    onError: (k: string) => { calls.push(`err:${k}`); return Promise.resolve() }
+  }
+
+  return { calls, limiter }
+}
+
+describe('createRateLimitInterceptors', () => {
+  it('request: calls onRequest with the current key and returns the request unchanged', async () => {
+    const { calls, limiter } = fakeLimiter()
+    const { request } = createRateLimitInterceptors(limiter)
+    const req = new Request('https://api.example.com/x')
+
+    const out = await rateLimitStorage.run({ key: 'stripe' }, () => request(req))
+
+    assert.equal(out, req)
+    assert.deepEqual(calls, ['req:stripe'])
+  })
+
+  it('request: no-op outside a job scope', async () => {
+    const { calls, limiter } = fakeLimiter()
+    const { request } = createRateLimitInterceptors(limiter)
+
+    await request(new Request('https://api.example.com/x'))
+
+    assert.deepEqual(calls, [])
+  })
+
+  it('response: reports and returns the response for a non-429', async () => {
+    const { calls, limiter } = fakeLimiter()
+    const { response } = createRateLimitInterceptors(limiter)
+    const res = new Response(null, { status: 200, headers: { 'x-ratelimit-remaining': '5' } })
+
+    const out = await rateLimitStorage.run({ key: 'gh' }, () => response(res, new Request('https://x')))
+
+    assert.equal(out, res)
+    assert.deepEqual(calls, ['res:gh:200'])
+  })
+
+  it('response: reports then throws RateLimitError on a 429', async () => {
+    const { calls, limiter } = fakeLimiter()
+    const { response } = createRateLimitInterceptors(limiter)
+    const res = new Response(null, { status: 429, headers: { 'retry-after': '30' } })
+
+    await rateLimitStorage.run({ key: 'flaky' }, async () => {
+      await assert.rejects(() => response(res, new Request('https://x')), (e: unknown) => e instanceof RateLimitError)
+    })
+
+    assert.deepEqual(calls, ['res:flaky:429'])
+  })
+
+  it('error: reports a generic transport error but ignores our own RateLimitError', async () => {
+    const { calls, limiter } = fakeLimiter()
+    const { error } = createRateLimitInterceptors(limiter)
+
+    await rateLimitStorage.run({ key: 'flaky' }, async () => {
+      await error(new Error('network'), undefined, new Request('https://x'))
+      await error(new RateLimitError({ throttled: true }), undefined, new Request('https://x'))
+    })
+
+    assert.deepEqual(calls, ['err:flaky'])
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.interceptors.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.interceptors.ts
@@ -1,0 +1,69 @@
+import type { FetchClient } from '@wisemen/node-fetch'
+import { RateLimitSignal } from './rate-limit-config.js'
+import { RateLimitError } from './rate-limit.error.js'
+import { currentRateLimitKey } from './rate-limit.context.js'
+import type { PgbossRateLimiter } from './rate-limiter.js'
+
+type LimiterHooks = Pick<PgbossRateLimiter, 'onRequest' | 'onResponse' | 'onError'>
+
+/**
+ * `@wisemen/node-fetch` interceptors that do rate-limit accounting for the job
+ * currently executing (resolved from async context — see `rate-limit.context`).
+ * Register them on a client with {@link useRateLimiting}. Requests made outside
+ * a rate-limited job are left untouched.
+ */
+export interface RateLimitInterceptors {
+  request: (req: Request) => Promise<Request>
+  response: (res: Response, req?: Request) => Promise<Response>
+  error: (err: unknown, res?: Response, req?: Request) => Promise<unknown>
+}
+
+export function createRateLimitInterceptors (limiter: LimiterHooks): RateLimitInterceptors {
+  return {
+    request: async (req) => {
+      const key = currentRateLimitKey()
+      if (key != null) {
+        await limiter.onRequest(key)
+      }
+
+      return req
+    },
+    response: async (res) => {
+      const key = currentRateLimitKey()
+      if (key != null) {
+        const headers = Object.fromEntries(res.headers.entries()) as Record<string, string | undefined>
+        await limiter.onResponse(key, res.status, headers)
+
+        if (res.status === 429) {
+          const signal: RateLimitSignal = { status: 429, throttled: true }
+          if (headers['retry-after'] !== undefined) {
+            signal.retryAfterSeconds = Number(headers['retry-after'])
+          }
+
+          throw new RateLimitError(signal)
+        }
+      }
+
+      return res
+    },
+    error: async (err) => {
+      const key = currentRateLimitKey()
+      // The 429 branch above throws a RateLimitError; if the client routes that
+      // into the error channel, it must not double-count as a transport error.
+      if (key != null && !(err instanceof RateLimitError)) {
+        await limiter.onError(key)
+      }
+
+      return err
+    }
+  }
+}
+
+/** Register rate-limit accounting on a `@wisemen/node-fetch` client. */
+export function useRateLimiting (client: FetchClient, limiter: LimiterHooks): void {
+  const { request, response, error } = createRateLimitInterceptors(limiter)
+
+  client.interceptors.request.use(request)
+  client.interceptors.response.use(response)
+  client.interceptors.error.use(error)
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.module.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.module.ts
@@ -1,0 +1,28 @@
+import { DynamicModule, Module } from '@nestjs/common'
+import { RateLimitConfigMap } from './rate-limit-config.js'
+import { PgbossRateLimitRegistry } from './rate-limit.registry.js'
+import { PgbossRateLimiter } from './rate-limiter.js'
+import { RateLimitStore } from './rate-limit.store.js'
+import { PostgresRateLimitStore } from './postgres-rate-limit.store.js'
+import { RATE_LIMIT_LIMITS } from './rate-limit.tokens.js'
+
+@Module({})
+export class PgbossRateLimitModule {
+  /**
+   * @param limits central map of rate-limit key -> config. A job opts into a
+   * limit with `super(data, { rateLimited: key })`. Defaults to `{}` so a worker
+   * with no rate limits still resolves an (inert) limiter.
+   */
+  static forRoot (limits: RateLimitConfigMap = {}): DynamicModule {
+    return {
+      module: PgbossRateLimitModule,
+      providers: [
+        { provide: RATE_LIMIT_LIMITS, useValue: limits },
+        PgbossRateLimitRegistry,
+        PgbossRateLimiter,
+        { provide: RateLimitStore, useClass: PostgresRateLimitStore }
+      ],
+      exports: [PgbossRateLimiter]
+    }
+  }
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.registry.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.registry.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PgbossRateLimitRegistry } from './rate-limit.registry.js'
+import { StaticRateStrategy } from './strategies/static-rate.strategy.js'
+
+describe('PgbossRateLimitRegistry', () => {
+  it('builds config and a strategy per key from the central limits map', () => {
+    const registry = new PgbossRateLimitRegistry({
+      stripe: { source: 'static', limit: 100, windowSeconds: 60 }
+    })
+
+    assert.deepEqual(registry.getAllKeys(), ['stripe'])
+    assert.deepEqual(registry.getConfig('stripe'), { source: 'static', limit: 100, windowSeconds: 60 })
+    assert.ok(registry.getStrategy('stripe') instanceof StaticRateStrategy)
+  })
+
+  it('returns undefined for unknown keys and empty for no limits', () => {
+    const registry = new PgbossRateLimitRegistry({})
+
+    assert.equal(registry.getConfig('nope'), undefined)
+    assert.equal(registry.getStrategy('nope'), undefined)
+    assert.deepEqual(registry.getAllKeys(), [])
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.registry.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.registry.ts
@@ -1,0 +1,50 @@
+import { Inject, Injectable, Logger } from '@nestjs/common'
+import { RateLimitConfig, RateLimitConfigMap } from './rate-limit-config.js'
+import { RateLimitStrategy } from './rate-limit.strategy.js'
+import { RATE_LIMIT_LIMITS } from './rate-limit.tokens.js'
+import { FailureBackoffStrategy } from './strategies/failure-backoff.strategy.js'
+import { HeaderRateStrategy } from './strategies/header-rate.strategy.js'
+import { StaticRateStrategy } from './strategies/static-rate.strategy.js'
+
+/**
+ * Holds the central rate-limit config supplied via `PgbossRateLimitModule.forRoot`
+ * and builds one strategy per key. Keyed entirely by rate-limit key — jobs carry
+ * that key as their group id, so no job-class discovery is needed.
+ */
+@Injectable()
+export class PgbossRateLimitRegistry {
+  private readonly logger = new Logger(PgbossRateLimitRegistry.name)
+  private readonly keyToConfig = new Map<string, RateLimitConfig>()
+  private readonly keyToStrategy = new Map<string, RateLimitStrategy>()
+
+  constructor (@Inject(RATE_LIMIT_LIMITS) limits: RateLimitConfigMap) {
+    for (const [key, config] of Object.entries(limits)) {
+      this.keyToConfig.set(key, config)
+      this.keyToStrategy.set(key, this.buildStrategy(config))
+      this.logger.log(`Registered rate limit '${key}' (${config.source})`)
+    }
+  }
+
+  getStrategy (key: string): RateLimitStrategy | undefined {
+    return this.keyToStrategy.get(key)
+  }
+
+  getConfig (key: string): RateLimitConfig | undefined {
+    return this.keyToConfig.get(key)
+  }
+
+  getAllKeys (): string[] {
+    return [...this.keyToStrategy.keys()]
+  }
+
+  private buildStrategy (config: RateLimitConfig): RateLimitStrategy {
+    switch (config.source) {
+      case 'static':
+        return new StaticRateStrategy(config)
+      case 'headers':
+        return new HeaderRateStrategy(config)
+      case 'failure':
+        return new FailureBackoffStrategy(config)
+    }
+  }
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.store.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.store.ts
@@ -1,0 +1,10 @@
+import { RateLimitBucketRow } from './rate-limit.strategy.js'
+
+export abstract class RateLimitStore {
+  abstract ensureSchema (): Promise<void>
+  abstract getMany (keys: string[]): Promise<RateLimitBucketRow[]>
+  /** Atomically refill+decrement one token. Returns true if a token was granted. */
+  abstract tryConsumeToken (key: string, limit: number, windowSeconds: number): Promise<boolean>
+  abstract setBlockedUntil (key: string, until: Date): Promise<void>
+  abstract setHeaderState (key: string, remaining: number, resetAt: Date | null): Promise<void>
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.strategy.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.strategy.ts
@@ -1,0 +1,12 @@
+export interface RateLimitBucketRow {
+  key: string
+  tokens: number | null
+  windowStartAt: Date | null
+  resetAt: Date | null
+  blockedUntil: Date | null
+}
+
+export interface RateLimitStrategy {
+  /** Fetch-gate read: is this key blocked right now, given its stored row? */
+  isBlocked (row: RateLimitBucketRow | null, now: Date): boolean
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.tokens.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limit.tokens.ts
@@ -1,0 +1,2 @@
+/** DI token holding the central `RateLimitConfigMap` supplied via `forRoot`. */
+export const RATE_LIMIT_LIMITS = Symbol('wisemen.pgboss-rate-limit.limits')

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter-hooks.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter-hooks.test.ts
@@ -79,9 +79,32 @@ describe('PgbossRateLimiter.onResponse', () => {
     assert.deepEqual(store.blocked, [])
   })
 
-  it('does nothing for a static key', async () => {
+  it('blocks a static key on a 429 without recording header state', async () => {
     const store = new RecordingStore()
-    await limiter(store).onResponse('stripe', 429, { 'x-ratelimit-remaining': '0' })
+    await limiter(store).onResponse('stripe', 429, {})
+    assert.deepEqual(store.header, [])
+    assert.equal(store.blocked.length, 1)
+    assert.equal(store.blocked[0][0], 'stripe')
+  })
+
+  it('blocks a headers key on a 429', async () => {
+    const store = new RecordingStore()
+    await limiter(store).onResponse('gh', 429, {})
+    assert.equal(store.blocked.length, 1)
+    assert.equal(store.blocked[0][0], 'gh')
+  })
+
+  it('honors Retry-After for a static 429 block, else a default cooldown', async () => {
+    const store = new RecordingStore()
+    const before = Date.now()
+    await limiter(store).onResponse('stripe', 429, { 'retry-after': '30' })
+    const until = store.blocked[0][1].getTime()
+    assert.ok(until >= before + 29_000 && until <= before + 31_000, `expected ~30s, got ${until - before}ms`)
+  })
+
+  it('does nothing for a static key on a success', async () => {
+    const store = new RecordingStore()
+    await limiter(store).onResponse('stripe', 200, { 'x-ratelimit-remaining': '0' })
     assert.deepEqual(store.header, [])
     assert.deepEqual(store.blocked, [])
   })

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter-hooks.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter-hooks.test.ts
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PgbossRateLimiter } from './rate-limiter.js'
+import { RateLimitStore } from './rate-limit.store.js'
+import { RateLimitBucketRow } from './rate-limit.strategy.js'
+import { RateLimitConfig } from './rate-limit-config.js'
+
+class RecordingStore extends RateLimitStore {
+  consumed: Array<[string, number, number]> = []
+  blocked: Array<[string, Date]> = []
+  header: Array<[string, number, Date | null]> = []
+  async ensureSchema () {}
+  getMany () { return Promise.resolve([] as RateLimitBucketRow[]) }
+  tryConsumeToken (key: string, limit: number, windowSeconds: number) { this.consumed.push([key, limit, windowSeconds]); return Promise.resolve(true) }
+  setBlockedUntil (key: string, until: Date) { this.blocked.push([key, until]); return Promise.resolve() }
+  setHeaderState (key: string, remaining: number, resetAt: Date | null) { this.header.push([key, remaining, resetAt]); return Promise.resolve() }
+}
+
+function registryDouble (configs: Record<string, RateLimitConfig>) {
+  return {
+    getAllKeys: () => Object.keys(configs),
+    getStrategy: () => ({ isBlocked: () => false }),
+    getConfig: (k: string) => configs[k]
+  } as never
+}
+
+const configs: Record<string, RateLimitConfig> = {
+  stripe: { source: 'static', limit: 100, windowSeconds: 60 },
+  gh: { source: 'headers' },
+  flaky: { source: 'failure', backoffSeconds: 10 }
+}
+
+function limiter (store: RateLimitStore) {
+  return new PgbossRateLimiter(registryDouble(configs), store)
+}
+
+describe('PgbossRateLimiter.onRequest', () => {
+  it('consumes a token for a static key', async () => {
+    const store = new RecordingStore()
+    await limiter(store).onRequest('stripe')
+    assert.deepEqual(store.consumed, [['stripe', 100, 60]])
+  })
+
+  it('does nothing for header, failure, or unknown keys', async () => {
+    const store = new RecordingStore()
+    const l = limiter(store)
+    await l.onRequest('gh')
+    await l.onRequest('flaky')
+    await l.onRequest('nope')
+    assert.deepEqual(store.consumed, [])
+  })
+})
+
+describe('PgbossRateLimiter.onResponse', () => {
+  it('records header state when remaining is present', async () => {
+    const store = new RecordingStore()
+    await limiter(store).onResponse('gh', 200, { 'x-ratelimit-remaining': '5' })
+    assert.equal(store.header.length, 1)
+    assert.equal(store.header[0][0], 'gh')
+    assert.equal(store.header[0][1], 5)
+  })
+
+  it('does not record header state when remaining is absent', async () => {
+    const store = new RecordingStore()
+    await limiter(store).onResponse('gh', 200, {})
+    assert.deepEqual(store.header, [])
+  })
+
+  it('blocks a failure key on a 429', async () => {
+    const store = new RecordingStore()
+    await limiter(store).onResponse('flaky', 429, {})
+    assert.equal(store.blocked.length, 1)
+    assert.equal(store.blocked[0][0], 'flaky')
+  })
+
+  it('does not block a failure key on a 200', async () => {
+    const store = new RecordingStore()
+    await limiter(store).onResponse('flaky', 200, {})
+    assert.deepEqual(store.blocked, [])
+  })
+
+  it('does nothing for a static key', async () => {
+    const store = new RecordingStore()
+    await limiter(store).onResponse('stripe', 429, { 'x-ratelimit-remaining': '0' })
+    assert.deepEqual(store.header, [])
+    assert.deepEqual(store.blocked, [])
+  })
+})
+
+describe('PgbossRateLimiter.onError', () => {
+  it('blocks a failure key', async () => {
+    const store = new RecordingStore()
+    await limiter(store).onError('flaky')
+    assert.equal(store.blocked.length, 1)
+    assert.equal(store.blocked[0][0], 'flaky')
+  })
+
+  it('does nothing for non-failure keys', async () => {
+    const store = new RecordingStore()
+    const l = limiter(store)
+    await l.onError('stripe')
+    await l.onError('gh')
+    assert.deepEqual(store.blocked, [])
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PgbossRateLimiter } from './rate-limiter.js'
+import { StaticRateStrategy } from './strategies/static-rate.strategy.js'
+import { RateLimitBucketRow } from './rate-limit.strategy.js'
+import { RateLimitStore } from './rate-limit.store.js'
+
+class FakeStore extends RateLimitStore {
+  rows = new Map<string, RateLimitBucketRow>()
+  async ensureSchema () {}
+  getMany (keys: string[]) { return Promise.resolve(keys.map(k => this.rows.get(k)).filter(Boolean) as RateLimitBucketRow[]) }
+  tryConsumeToken () { return Promise.resolve(true) }
+  async setBlockedUntil () {}
+  async setHeaderState () {}
+}
+
+const config = { source: 'static' as const, limit: 3, windowSeconds: 60 }
+function registryDouble () {
+  return {
+    getAllKeys: () => ['stripe'],
+    getStrategy: () => new StaticRateStrategy(config),
+    getConfig: (k: string) => (k === 'stripe' ? config : undefined)
+  } as never
+}
+
+describe('PgbossRateLimiter.blockedKeys', () => {
+  it('reports a key as blocked when its stored row is exhausted', async () => {
+    const store = new FakeStore()
+    store.rows.set('stripe', { key: 'stripe', tokens: 0, windowStartAt: new Date(), resetAt: null, blockedUntil: null })
+    const limiter = new PgbossRateLimiter(registryDouble(), store)
+
+    assert.deepEqual(await limiter.blockedKeys(), ['stripe'])
+  })
+
+  it('does not block when budget remains', async () => {
+    const store = new FakeStore()
+    const limiter = new PgbossRateLimiter(registryDouble(), store)
+    assert.deepEqual(await limiter.blockedKeys(), [])
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter.test.ts
@@ -37,4 +37,16 @@ describe('PgbossRateLimiter.blockedKeys', () => {
     const limiter = new PgbossRateLimiter(registryDouble(), store)
     assert.deepEqual(await limiter.blockedKeys(), [])
   })
+
+  it('blocks any key whose blockedUntil is in the future, even when its strategy would allow it', async () => {
+    const store = new FakeStore()
+    // tokens remain (static strategy alone would NOT block), but a 429 set a cooldown.
+    store.rows.set('stripe', {
+      key: 'stripe', tokens: 3, windowStartAt: new Date(), resetAt: null,
+      blockedUntil: new Date(Date.now() + 60_000)
+    })
+    const limiter = new PgbossRateLimiter(registryDouble(), store)
+
+    assert.deepEqual(await limiter.blockedKeys(), ['stripe'])
+  })
 })

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter.ts
@@ -1,0 +1,103 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { RateLimitSignal } from './rate-limit-config.js'
+import { parseRateLimitHeaders } from './parse-rate-limit-headers.js'
+import { PgbossRateLimitRegistry } from './rate-limit.registry.js'
+import { RateLimitStore } from './rate-limit.store.js'
+import { nextBackoff } from './strategies/failure-backoff.strategy.js'
+
+@Injectable()
+export class PgbossRateLimiter {
+  private readonly logger = new Logger(PgbossRateLimiter.name)
+
+  constructor (
+    private readonly registry: PgbossRateLimitRegistry,
+    private readonly store: RateLimitStore
+  ) {}
+
+  async onModuleInit (): Promise<void> {
+    await this.store.ensureSchema()
+  }
+
+  /** Fetch-gate: which registered keys are blocked right now. Fail-open on error. */
+  async blockedKeys (): Promise<string[]> {
+    const keys = this.registry.getAllKeys()
+
+    if (keys.length === 0) {
+      return []
+    }
+
+    try {
+      const rows = await this.store.getMany(keys)
+      const byKey = new Map(rows.map(r => [r.key, r]))
+      const now = new Date()
+      const blocked: string[] = []
+
+      for (const key of keys) {
+        const strategy = this.registry.getStrategy(key)
+        if (strategy?.isBlocked(byKey.get(key) ?? null, now) === true) {
+          blocked.push(key)
+        }
+      }
+
+      return blocked
+    } catch (error) {
+      this.logger.error('blockedKeys failed; failing open', error as Error)
+      return []
+    }
+  }
+
+  /**
+   * Transport hook — a request is about to be sent. Static mode counts one
+   * attempt against the shared budget (per-request, so retries and failed
+   * requests are counted too). Header/failure modes learn from the response, so
+   * this is a no-op for them.
+   */
+  async onRequest (key: string): Promise<void> {
+    const config = this.registry.getConfig(key)
+    if (config?.source !== 'static') {
+      return
+    }
+
+    await this.store.tryConsumeToken(key, config.limit, config.windowSeconds)
+  }
+
+  /**
+   * Transport hook — a response arrived. Header mode records the API's reported
+   * remaining/reset; failure mode blocks on a 429 (honoring `Retry-After`).
+   * Static mode already counted at request time, so it is a no-op.
+   */
+  async onResponse (key: string, status: number, headers: Record<string, string | undefined>): Promise<void> {
+    const config = this.registry.getConfig(key)
+
+    if (config?.source === 'headers') {
+      const signal = parseRateLimitHeaders(headers, config)
+      if (signal.remaining !== undefined) {
+        await this.store.setHeaderState(key, signal.remaining, signal.resetAt ?? null)
+      }
+
+      return
+    }
+
+    if (config?.source === 'failure' && status === 429) {
+      const signal: RateLimitSignal = { throttled: true, status }
+      if (headers['retry-after'] !== undefined) {
+        signal.retryAfterSeconds = Number(headers['retry-after'])
+      }
+
+      await this.store.setBlockedUntil(key, nextBackoff(config, signal, new Date()))
+    }
+  }
+
+  /**
+   * Transport hook — the request threw (network error / abort). Failure mode
+   * treats that as a throttle and backs off; other modes ignore it.
+   */
+  async onError (key: string): Promise<void> {
+    const config = this.registry.getConfig(key)
+    if (config?.source !== 'failure') {
+      return
+    }
+
+    await this.store.setBlockedUntil(key, nextBackoff(config, { throttled: true }, new Date()))
+  }
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/rate-limiter.ts
@@ -1,9 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common'
-import { RateLimitSignal } from './rate-limit-config.js'
+import { RateLimitConfig, RateLimitSignal } from './rate-limit-config.js'
 import { parseRateLimitHeaders } from './parse-rate-limit-headers.js'
 import { PgbossRateLimitRegistry } from './rate-limit.registry.js'
 import { RateLimitStore } from './rate-limit.store.js'
 import { nextBackoff } from './strategies/failure-backoff.strategy.js'
+
+/** Cooldown applied to a 429 with no `Retry-After`, for modes without their own backoff config. */
+const DEFAULT_THROTTLE_COOLDOWN_SECONDS = 60
 
 @Injectable()
 export class PgbossRateLimiter {
@@ -33,8 +36,12 @@ export class PgbossRateLimiter {
       const blocked: string[] = []
 
       for (const key of keys) {
+        const row = byKey.get(key) ?? null
         const strategy = this.registry.getStrategy(key)
-        if (strategy?.isBlocked(byKey.get(key) ?? null, now) === true) {
+        // A `blockedUntil` cooldown (set by a 429) gates every mode; the
+        // per-mode strategy handles proactive gating (token bucket / headers).
+        const onCooldown = row?.blockedUntil != null && now < row.blockedUntil
+        if (onCooldown || strategy?.isBlocked(row, now) === true) {
           blocked.push(key)
         }
       }
@@ -63,29 +70,46 @@ export class PgbossRateLimiter {
 
   /**
    * Transport hook — a response arrived. Header mode records the API's reported
-   * remaining/reset; failure mode blocks on a 429 (honoring `Retry-After`).
-   * Static mode already counted at request time, so it is a no-op.
+   * remaining/reset (proactive gating). A 429 blocks the key for *every* mode so
+   * its jobs wait before retrying (failure mode uses its configured backoff;
+   * static/headers use `Retry-After` or a default cooldown).
    */
   async onResponse (key: string, status: number, headers: Record<string, string | undefined>): Promise<void> {
     const config = this.registry.getConfig(key)
+    if (config === undefined) {
+      return
+    }
 
-    if (config?.source === 'headers') {
+    if (config.source === 'headers') {
       const signal = parseRateLimitHeaders(headers, config)
       if (signal.remaining !== undefined) {
         await this.store.setHeaderState(key, signal.remaining, signal.resetAt ?? null)
       }
-
-      return
     }
 
-    if (config?.source === 'failure' && status === 429) {
-      const signal: RateLimitSignal = { throttled: true, status }
-      if (headers['retry-after'] !== undefined) {
-        signal.retryAfterSeconds = Number(headers['retry-after'])
+    if (status === 429) {
+      await this.store.setBlockedUntil(key, this.throttleUntil(config, headers))
+    }
+  }
+
+  /** When a 429 clears: `Retry-After` if given; failure mode falls back to its backoff, others to the default. */
+  private throttleUntil (config: RateLimitConfig, headers: Record<string, string | undefined>): Date {
+    const now = new Date()
+    const retryAfter = Number(headers['retry-after'])
+    const hasRetryAfter = Number.isFinite(retryAfter) && retryAfter > 0
+
+    if (config.source === 'failure') {
+      const signal: RateLimitSignal = { throttled: true, status: 429 }
+      if (hasRetryAfter) {
+        signal.retryAfterSeconds = retryAfter
       }
 
-      await this.store.setBlockedUntil(key, nextBackoff(config, signal, new Date()))
+      return nextBackoff(config, signal, now)
     }
+
+    const seconds = hasRetryAfter ? retryAfter : DEFAULT_THROTTLE_COOLDOWN_SECONDS
+
+    return new Date(now.getTime() + seconds * 1000)
   }
 
   /**

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/refill.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/refill.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { refill } from './refill.js'
+
+const config = { source: 'static' as const, limit: 3, windowSeconds: 60 }
+
+describe('refill', () => {
+  it('creates a full bucket when none exists', () => {
+    const now = new Date('2026-07-03T10:00:00Z')
+    const b = refill(null, config, now)
+    assert.equal(b.tokens, 3)
+    assert.equal(b.windowStartAt.toISOString(), now.toISOString())
+  })
+
+  it('keeps the bucket unchanged inside the window', () => {
+    const start = new Date('2026-07-03T10:00:00Z')
+    const now = new Date('2026-07-03T10:00:30Z')
+    const b = refill({ tokens: 1, windowStartAt: start }, config, now)
+    assert.equal(b.tokens, 1)
+    assert.equal(b.windowStartAt.toISOString(), start.toISOString())
+  })
+
+  it('refills to full at a new window once the window elapsed', () => {
+    const start = new Date('2026-07-03T10:00:00Z')
+    const now = new Date('2026-07-03T10:01:05Z')
+    const b = refill({ tokens: 0, windowStartAt: start }, config, now)
+    assert.equal(b.tokens, 3)
+    assert.equal(b.windowStartAt.toISOString(), now.toISOString())
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/refill.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/refill.ts
@@ -1,0 +1,24 @@
+import { StaticRateLimitConfig } from './rate-limit-config.js'
+
+export interface Bucket {
+  tokens: number
+  windowStartAt: Date
+}
+
+export function refill (
+  bucket: Bucket | null,
+  config: StaticRateLimitConfig,
+  now: Date
+): Bucket {
+  if (bucket === null) {
+    return { tokens: config.limit, windowStartAt: now }
+  }
+
+  const elapsedMs = now.getTime() - bucket.windowStartAt.getTime()
+
+  if (elapsedMs >= config.windowSeconds * 1000) {
+    return { tokens: config.limit, windowStartAt: now }
+  }
+
+  return bucket
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/failure-backoff.strategy.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/failure-backoff.strategy.test.ts
@@ -18,4 +18,10 @@ describe('FailureBackoffStrategy', () => {
     assert.equal(nextBackoff(config, { retryAfterSeconds: 120 }, now).toISOString(), '2026-07-03T10:01:00.000Z')
     assert.equal(nextBackoff(config, {}, now).toISOString(), '2026-07-03T10:00:10.000Z')
   })
+  it('falls back to backoffSeconds when retryAfter is NaN', () => {
+    assert.equal(nextBackoff(config, { retryAfterSeconds: NaN }, now).toISOString(), '2026-07-03T10:00:10.000Z')
+  })
+  it('falls back to backoffSeconds when retryAfter is 0', () => {
+    assert.equal(nextBackoff(config, { retryAfterSeconds: 0 }, now).toISOString(), '2026-07-03T10:00:10.000Z')
+  })
 })

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/failure-backoff.strategy.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/failure-backoff.strategy.test.ts
@@ -1,0 +1,21 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { FailureBackoffStrategy, nextBackoff } from './failure-backoff.strategy.js'
+
+const config = { source: 'failure' as const, backoffSeconds: 10, maxBackoffSeconds: 60 }
+const strategy = new FailureBackoffStrategy(config)
+const now = new Date('2026-07-03T10:00:00Z')
+
+describe('FailureBackoffStrategy', () => {
+  it('not blocked when no cooldown set', () => {
+    assert.equal(strategy.isBlocked(null, now), false)
+  })
+  it('blocked while blocked_until is in the future', () => {
+    const row = { key: 'k', tokens: null, windowStartAt: null, resetAt: null, blockedUntil: new Date('2026-07-03T10:00:05Z') }
+    assert.equal(strategy.isBlocked(row, now), true)
+  })
+  it('nextBackoff prefers retryAfter and caps at max', () => {
+    assert.equal(nextBackoff(config, { retryAfterSeconds: 120 }, now).toISOString(), '2026-07-03T10:01:00.000Z')
+    assert.equal(nextBackoff(config, {}, now).toISOString(), '2026-07-03T10:00:10.000Z')
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/failure-backoff.strategy.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/failure-backoff.strategy.ts
@@ -1,0 +1,23 @@
+import { FailureBackoffConfig, RateLimitSignal } from '../rate-limit-config.js'
+import { RateLimitBucketRow, RateLimitStrategy } from '../rate-limit.strategy.js'
+
+export function nextBackoff (
+  config: FailureBackoffConfig,
+  signal: RateLimitSignal,
+  now: Date
+): Date {
+  const requested = signal.retryAfterSeconds ?? config.backoffSeconds
+  const capped = config.maxBackoffSeconds != null
+    ? Math.min(requested, config.maxBackoffSeconds)
+    : requested
+
+  return new Date(now.getTime() + capped * 1000)
+}
+
+export class FailureBackoffStrategy implements RateLimitStrategy {
+  constructor (private readonly _config: FailureBackoffConfig) {}
+
+  isBlocked (row: RateLimitBucketRow | null, now: Date): boolean {
+    return row?.blockedUntil != null && now < row.blockedUntil
+  }
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/failure-backoff.strategy.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/failure-backoff.strategy.ts
@@ -6,7 +6,10 @@ export function nextBackoff (
   signal: RateLimitSignal,
   now: Date
 ): Date {
-  const requested = signal.retryAfterSeconds ?? config.backoffSeconds
+  const retryAfter = signal.retryAfterSeconds
+  const requested = retryAfter !== undefined && Number.isFinite(retryAfter) && retryAfter > 0
+    ? retryAfter
+    : config.backoffSeconds
   const capped = config.maxBackoffSeconds != null
     ? Math.min(requested, config.maxBackoffSeconds)
     : requested

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/header-rate.strategy.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/header-rate.strategy.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { HeaderRateStrategy } from './header-rate.strategy.js'
+
+const strategy = new HeaderRateStrategy({ source: 'headers' })
+const now = new Date('2026-07-03T10:00:00Z')
+
+describe('HeaderRateStrategy.isBlocked', () => {
+  it('not blocked when no state known', () => {
+    assert.equal(strategy.isBlocked(null, now), false)
+  })
+  it('blocked when remaining 0 and reset in the future', () => {
+    const row = { key: 'k', tokens: 0, windowStartAt: null, resetAt: new Date('2026-07-03T10:00:30Z'), blockedUntil: null }
+    assert.equal(strategy.isBlocked(row, now), true)
+  })
+  it('not blocked once reset has passed', () => {
+    const row = { key: 'k', tokens: 0, windowStartAt: null, resetAt: new Date('2026-07-03T09:59:59Z'), blockedUntil: null }
+    assert.equal(strategy.isBlocked(row, now), false)
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/header-rate.strategy.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/header-rate.strategy.ts
@@ -1,0 +1,14 @@
+import { HeaderRateLimitConfig } from '../rate-limit-config.js'
+import { RateLimitBucketRow, RateLimitStrategy } from '../rate-limit.strategy.js'
+
+export class HeaderRateStrategy implements RateLimitStrategy {
+  constructor (private readonly _config: HeaderRateLimitConfig) {}
+
+  isBlocked (row: RateLimitBucketRow | null, now: Date): boolean {
+    if (row?.tokens == null || row.resetAt == null) {
+      return false
+    }
+
+    return row.tokens <= 0 && now < row.resetAt
+  }
+}

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/static-rate.strategy.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/static-rate.strategy.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { StaticRateStrategy } from './static-rate.strategy.js'
+
+const strategy = new StaticRateStrategy({ source: 'static', limit: 3, windowSeconds: 60 })
+const now = new Date('2026-07-03T10:00:30Z')
+const start = new Date('2026-07-03T10:00:00Z')
+
+describe('StaticRateStrategy.isBlocked', () => {
+  it('is not blocked when no row exists (full budget)', () => {
+    assert.equal(strategy.isBlocked(null, now), false)
+  })
+
+  it('is blocked when tokens are exhausted inside the window', () => {
+    const row = { key: 'k', tokens: 0, windowStartAt: start, resetAt: null, blockedUntil: null }
+    assert.equal(strategy.isBlocked(row, now), true)
+  })
+
+  it('is not blocked once the window has elapsed (refills)', () => {
+    const row = { key: 'k', tokens: 0, windowStartAt: start, resetAt: null, blockedUntil: null }
+    const later = new Date('2026-07-03T10:01:05Z')
+    assert.equal(strategy.isBlocked(row, later), false)
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/static-rate.strategy.ts
+++ b/packages/api/pgboss-nestjs-job/lib/rate-limit/strategies/static-rate.strategy.ts
@@ -1,0 +1,17 @@
+import { StaticRateLimitConfig } from '../rate-limit-config.js'
+import { refill } from '../refill.js'
+import { RateLimitBucketRow, RateLimitStrategy } from '../rate-limit.strategy.js'
+
+export class StaticRateStrategy implements RateLimitStrategy {
+  constructor (private readonly config: StaticRateLimitConfig) {}
+
+  isBlocked (row: RateLimitBucketRow | null, now: Date): boolean {
+    const bucket = row?.windowStartAt != null && row.tokens != null
+      ? { tokens: row.tokens, windowStartAt: row.windowStartAt }
+      : null
+
+    const refilled = refill(bucket, this.config, now)
+
+    return refilled.tokens <= 0
+  }
+}

--- a/packages/api/pgboss-nestjs-job/lib/scheduler/pgboss-scheduler.ts
+++ b/packages/api/pgboss-nestjs-job/lib/scheduler/pgboss-scheduler.ts
@@ -12,6 +12,7 @@ import { BaseJob } from '../jobs/base-job.js'
 import { PGBOSS_JOB_HANDLER, PGBOSS_QUEUE_NAME } from '../jobs/job.decorator.js'
 import { SerializedJob } from '../jobs/serialized-job.js'
 import { TraceContextCarrier } from '../jobs/trace-context-carrier.js'
+import { resolveGroupId } from './resolve-group-id.js'
 
 @Injectable()
 export class PgBossScheduler {
@@ -78,6 +79,7 @@ export class PgBossScheduler {
 
     return {
       name: queue,
+      groupId: resolveGroupId(job),
       data: {
         className,
         classData: job.data,

--- a/packages/api/pgboss-nestjs-job/lib/scheduler/resolve-group-id.ts
+++ b/packages/api/pgboss-nestjs-job/lib/scheduler/resolve-group-id.ts
@@ -1,0 +1,6 @@
+import { BaseJob } from '../jobs/base-job.js'
+
+/** The rate-limit key a job opted into, used as its pg-boss group id. */
+export function resolveGroupId (job: BaseJob): string | undefined {
+  return job.options?.rateLimited
+}

--- a/packages/api/pgboss-nestjs-job/lib/scheduler/serialize-group.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/scheduler/serialize-group.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { BaseJob } from '../jobs/base-job.js'
+import { resolveGroupId } from './resolve-group-id.js'
+
+class ChargeJob extends BaseJob {
+  constructor () {
+    super({}, { rateLimited: 'stripe' })
+  }
+}
+
+class PlainJob extends BaseJob {}
+
+describe('resolveGroupId', () => {
+  it('returns the rate-limit key a job opted into', () => {
+    assert.equal(resolveGroupId(new ChargeJob()), 'stripe')
+  })
+
+  it('returns undefined for a job with no rate limit', () => {
+    assert.equal(resolveGroupId(new PlainJob()), undefined)
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker-app.ts
+++ b/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker-app.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
 import { PgBossClient } from '../client/pgboss-client.js'
 import { JobRegistry } from '../jobs/job.registry.js'
+import { PgbossRateLimiter } from '../rate-limit/rate-limiter.js'
 import { PgBossWorker } from './pgboss-worker.js'
 import { MODULE_OPTIONS_TOKEN, PgbossWorkerModuleOptions } from './pgboss-worker.module-definition.js'
 import { PgbossBouncerRegistry } from './pgboss-bouncer.registry.js'
@@ -14,6 +15,7 @@ export class PgbossWorkerApp implements OnModuleInit, OnModuleDestroy {
     private client: PgBossClient,
     private bouncerRegistry: PgbossBouncerRegistry,
     private jobRegistry: JobRegistry,
+    private rateLimiter: PgbossRateLimiter,
     @Inject(MODULE_OPTIONS_TOKEN) private options: PgbossWorkerModuleOptions
   ) { }
 
@@ -21,7 +23,9 @@ export class PgbossWorkerApp implements OnModuleInit, OnModuleDestroy {
     try {
       for (const queueOptions of this.options.queues) {
         const bouncer = await this.bouncerRegistry.getBouncer(queueOptions.queueName)
-        const worker = new PgBossWorker(queueOptions, bouncer, this.client, this.jobRegistry)
+        const worker = new PgBossWorker(
+          queueOptions, bouncer, this.client, this.jobRegistry, this.rateLimiter
+        )
 
         await this.client.createQueue(queueOptions.queueName, { policy: 'stately' })
         worker.start()

--- a/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker.module-options.ts
+++ b/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker.module-options.ts
@@ -1,4 +1,5 @@
 import { PgBossClientModuleOptions } from '../client/pgboss-client.module-options.js'
+import { RateLimitConfigMap } from '../rate-limit/rate-limit-config.js'
 
 export interface PgbossWorkerQueueOptions {
   queueName: string
@@ -10,4 +11,15 @@ export interface PgbossWorkerQueueOptions {
 
 export interface PgBossWorkerModuleOptions extends PgBossClientModuleOptions {
   queues: PgbossWorkerQueueOptions[]
+}
+
+/**
+ * Central rate-limit declarations, keyed by rate-limit key. Jobs opt in with
+ * `super(data, { rateLimited: key })`. Passed directly to `forRoot`/`forRootAsync`
+ * (not returned from `useFactory`), so it is deliberately NOT part of
+ * `PgBossWorkerModuleOptions` — that keeps it out of the async factory's return
+ * type, where it would be silently ignored.
+ */
+export interface PgBossWorkerRateLimitOptions {
+  rateLimits?: RateLimitConfigMap
 }

--- a/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker.module.ts
+++ b/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker.module.ts
@@ -3,7 +3,9 @@ import { DynamicModule, Module } from '@nestjs/common'
 import { JobModule } from '../jobs/job.module.js'
 import { PgBossClientModule } from '../client/pgboss-client.module.js'
 import { ProvidersExplorerModule } from '../providers/providers-explorer.module.js'
+import { PgbossRateLimitModule } from '../rate-limit/rate-limit.module.js'
 import { ConfigurableModuleClass, PgbossWorkerModuleAsyncOptions, PgbossWorkerModuleOptions } from './pgboss-worker.module-definition.js'
+import { PgBossWorkerRateLimitOptions } from './pgboss-worker.module-options.js'
 import { PgbossBouncerRegistry } from './pgboss-bouncer.registry.js'
 import { PgbossWorkerApp } from './pgboss-worker-app.js'
 
@@ -12,7 +14,9 @@ import { PgbossWorkerApp } from './pgboss-worker-app.js'
   providers: [PgbossBouncerRegistry, PgbossWorkerApp]
 })
 export class PgBossWorkerModule extends ConfigurableModuleClass {
-  static override forRoot (options: PgbossWorkerModuleOptions): DynamicModule {
+  static override forRoot (
+    options: PgbossWorkerModuleOptions & PgBossWorkerRateLimitOptions
+  ): DynamicModule {
     const module = super.forRoot(options)
     const imports = [...module.imports ?? []]
 
@@ -22,13 +26,18 @@ export class PgBossWorkerModule extends ConfigurableModuleClass {
     })
 
     imports.push(clientModule)
+    imports.push(PgbossRateLimitModule.forRoot(options.rateLimits))
 
     return { ...module, imports }
   }
 
-  static override forRootAsync (options: PgbossWorkerModuleAsyncOptions): DynamicModule {
+  static override forRootAsync (
+    options: PgbossWorkerModuleAsyncOptions & PgBossWorkerRateLimitOptions
+  ): DynamicModule {
     const module = super.forRootAsync(options)
     const imports = module.imports ?? []
+
+    imports.push(PgbossRateLimitModule.forRoot(options.rateLimits))
 
     const clientModule = PgBossClientModule.forRootAsync({
       inject: options.inject,

--- a/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker.thread.ts
+++ b/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker.thread.ts
@@ -5,6 +5,7 @@ import { propagation, context, SpanStatusCode, Context, trace } from '@opentelem
 import { PgBossClient } from '../client/pgboss-client.js'
 import { JobRegistry } from '../jobs/job.registry.js'
 import { TraceContextCarrier } from '../jobs/trace-context-carrier.js'
+import { rateLimitStorage } from '../rate-limit/rate-limit.context.js'
 import { RawPgBossJob } from './pgboss-worker.constants.js'
 
 export class PgBossWorkerThread {
@@ -17,11 +18,16 @@ export class PgBossWorkerThread {
   async run (): Promise<void> {
     for await (const job of this.queue) {
       try {
-        const result = await this.handleJob(job)
+        // Publish the job's rate-limit key into async context so a transport
+        // interceptor can attribute the handler's API calls to it. Rate-limit
+        // accounting (consume/report) happens there, not here.
+        const result = job.groupId != null
+          ? await rateLimitStorage.run({ key: job.groupId }, () => this.handleJob(job))
+          : await this.handleJob(job)
 
         await this.client.complete(job.name, job.id, result ?? undefined)
       } catch (error) {
-        captureException(error) 
+        captureException(error)
         await this.client.fail(job.name, job.id, { error }).catch(() => {})
       }
     }

--- a/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker.thread.ts
+++ b/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker.thread.ts
@@ -6,7 +6,17 @@ import { PgBossClient } from '../client/pgboss-client.js'
 import { JobRegistry } from '../jobs/job.registry.js'
 import { TraceContextCarrier } from '../jobs/trace-context-carrier.js'
 import { rateLimitStorage } from '../rate-limit/rate-limit.context.js'
+import { RateLimitError } from '../rate-limit/rate-limit.error.js'
 import { RawPgBossJob } from './pgboss-worker.constants.js'
+
+/**
+ * A `RateLimitError` is an expected, self-healing throttle signal (the transport
+ * interceptor throws it on a 429), not a defect — it should fail+retry the job
+ * but must not be reported to Sentry, or sustained throttling floods it.
+ */
+export function isReportableError (error: unknown): boolean {
+  return !(error instanceof RateLimitError)
+}
 
 export class PgBossWorkerThread {
   constructor (
@@ -27,7 +37,10 @@ export class PgBossWorkerThread {
 
         await this.client.complete(job.name, job.id, result ?? undefined)
       } catch (error) {
-        captureException(error)
+        if (isReportableError(error)) {
+          captureException(error)
+        }
+
         await this.client.fail(job.name, job.id, { error }).catch(() => {})
       }
     }

--- a/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker.ts
+++ b/packages/api/pgboss-nestjs-job/lib/worker/pgboss-worker.ts
@@ -1,6 +1,7 @@
 import { captureError } from 'rxjs/internal/util/errorContext'
 import { PgBossClient } from '../client/pgboss-client.js'
 import { JobRegistry } from '../jobs/job.registry.js'
+import { PgbossRateLimiter } from '../rate-limit/rate-limiter.js'
 import { PgBossWorkerThread } from './pgboss-worker.thread.js'
 import { PgbossBouncer } from './pgboss-bouncer.js'
 import { PgbossWorkerQueueOptions } from './pgboss-worker.module-options.js'
@@ -21,7 +22,8 @@ export class PgBossWorker {
     config: PgbossWorkerQueueOptions,
     private bouncer: PgbossBouncer,
     private client: PgBossClient,
-    private jobRegistry: JobRegistry
+    private jobRegistry: JobRegistry,
+    private rateLimiter: Pick<PgbossRateLimiter, 'blockedKeys'>
   ) {
     this.queueName = config.queueName
     this.concurrency = config?.concurrency ?? 1
@@ -83,6 +85,8 @@ export class PgBossWorker {
       return
     }
 
+    const ignoreGroups = await this.rateLimiter.blockedKeys()
+
     // do not await between this if when null and the assignment of the jobFetchingPromise
     // to avoid multiple fetches in parallel
     if (this.jobFetchingPromise != null) {
@@ -94,7 +98,7 @@ export class PgBossWorker {
     this.jobFetchingPromise = new Promise((resolve, reject) => {
       void this.client.fetch<RawPgBossJobData>(
         this.queueName,
-        { batchSize: this.batchSize }
+        { batchSize: this.batchSize, ignoreGroups }
       )
         .then(async (jobs) => {
           if (jobs == null || jobs.length === 0) {

--- a/packages/api/pgboss-nestjs-job/lib/worker/thread-context.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/worker/thread-context.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PgBossWorkerThread } from './pgboss-worker.thread.js'
+import { currentRateLimitKey } from '../rate-limit/rate-limit.context.js'
+
+function threadFor (job: object, onRun: () => void) {
+  function* one () { yield job as never }
+  const client = { complete: () => Promise.resolve(), fail: () => Promise.resolve() }
+  const registry = { get: () => Promise.resolve({ run: () => { onRun(); return Promise.resolve() } }) }
+
+  return new PgBossWorkerThread(one() as never, client as never, registry as never)
+}
+
+describe('PgBossWorkerThread rate-limit context', () => {
+  it('exposes the job group as the rate-limit key while the handler runs', async () => {
+    let seen: string | undefined = 'unset'
+    const job = { id: '1', name: 'system', groupId: 'stripe', data: { className: 'ChargeJob', classData: {} } }
+
+    await threadFor(job, () => { seen = currentRateLimitKey() }).run()
+
+    assert.equal(seen, 'stripe')
+  })
+
+  it('has no rate-limit key for a job without a group', async () => {
+    let seen: string | undefined = 'unset'
+    const job = { id: '1', name: 'system', data: { className: 'PlainJob', classData: {} } }
+
+    await threadFor(job, () => { seen = currentRateLimitKey() }).run()
+
+    assert.equal(seen, undefined)
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/worker/thread-error-reporting.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/worker/thread-error-reporting.test.ts
@@ -1,0 +1,15 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { isReportableError } from './pgboss-worker.thread.js'
+import { RateLimitError } from '../rate-limit/rate-limit.error.js'
+
+describe('isReportableError', () => {
+  it('does not report a RateLimitError (expected, self-healing throttle)', () => {
+    assert.equal(isReportableError(new RateLimitError({ throttled: true })), false)
+  })
+
+  it('reports genuine errors', () => {
+    assert.equal(isReportableError(new Error('boom')), true)
+    assert.equal(isReportableError('nope'), true)
+  })
+})

--- a/packages/api/pgboss-nestjs-job/lib/worker/worker-ignore-groups.test.ts
+++ b/packages/api/pgboss-nestjs-job/lib/worker/worker-ignore-groups.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PgBossWorker } from './pgboss-worker.js'
+
+describe('PgBossWorker fetch gating', () => {
+  it('passes blockedKeys as ignoreGroups to client.fetch', async () => {
+    const fetchCalls: Array<{ name: string, options: unknown }> = []
+
+    const client = {
+      fetch: (name: string, options: unknown) => {
+        fetchCalls.push({ name, options })
+
+        return Promise.resolve([])
+      }
+    }
+    const rateLimiter = { blockedKeys: () => ['stripe'] }
+
+    const worker = new PgBossWorker(
+      { queueName: 'system', pollInterval: 1 },
+      { canProceed: () => true },
+      client as never,
+      { } as never,
+      rateLimiter as never
+    )
+
+    // fetchJobs() early-returns unless the worker is "working"; set the flag
+    // directly since we call the private method without start()/threads.
+    ;(worker as unknown as { working: boolean }).working = true
+    await (worker as unknown as { fetchJobs: () => Promise<void> }).fetchJobs()
+
+    assert.equal(fetchCalls.length, 1)
+    assert.equal(fetchCalls[0].name, 'system')
+    assert.deepEqual((fetchCalls[0].options as { ignoreGroups: string[] }).ignoreGroups, ['stripe'])
+  })
+})

--- a/packages/api/pgboss-nestjs-job/package.json
+++ b/packages/api/pgboss-nestjs-job/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf ./dist",
     "build": "tsc",
     "pretest": "pnpm build",
-    "test": "node --test ./dist/**/*.test.js",
+    "test": "node --test './dist/**/*.test.js'",
     "prerelease": "npm run build",
     "release": "pnpx release-it"
   },
@@ -38,13 +38,20 @@
     "@nestjs/core": "catalog:backend-peer",
     "@opentelemetry/api": "catalog:backend-peer",
     "@sentry/nestjs": "catalog:backend-peer",
+    "@wisemen/node-fetch": "workspace:*",
     "colors": "catalog:backend-peer",
     "rxjs": "catalog:backend-peer",
     "typeorm": "catalog:backend-peer",
     "class-transformer": "catalog:backend-peer"
   },
+  "peerDependenciesMeta": {
+    "@wisemen/node-fetch": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@wisemen/eslint-config-nestjs": "workspace:*",
+    "@wisemen/node-fetch": "workspace:*",
     "eslint": "catalog:lint-api",
     "oxlint": "catalog:lint-api",
     "oxlint-tsgolint": "catalog:lint-api",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2104,6 +2104,9 @@ importers:
       '@wisemen/eslint-config-nestjs':
         specifier: workspace:*
         version: link:../eslint-config-nestjs
+      '@wisemen/node-fetch':
+        specifier: workspace:*
+        version: link:../node-fetch
       eslint:
         specifier: catalog:lint-api
         version: 10.2.1(jiti@2.6.1)
@@ -10774,6 +10777,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@8.1.1:
@@ -14232,8 +14236,8 @@ packages:
   vue-component-type-helpers@3.3.0:
     resolution: {integrity: sha512-vwR8DDsBysI9NWXa0okPFpCcW+BUC3sPTuLBNo1faMzw4QWMFd+3/lFYFu29ZN0q+8UReXWJHEYesC9dcXYCLg==}
 
-  vue-component-type-helpers@3.3.5:
-    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
+  vue-component-type-helpers@3.3.6:
+    resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -19268,7 +19272,7 @@ snapshots:
       storybook: 10.3.0(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.27(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.5
+      vue-component-type-helpers: 3.3.6
 
   '@stylistic/eslint-plugin@5.10.0(eslint@10.2.1(jiti@2.6.1))':
     dependencies:
@@ -26641,7 +26645,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.0: {}
 
-  vue-component-type-helpers@3.3.5: {}
+  vue-component-type-helpers@3.3.6: {}
 
   vue-demi@0.14.10(vue@3.5.27(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
## What

Adds rate-limit handling for external APIs to `@wisemen/pgboss-nestjs-job`, so jobs that call a rate-limited API **wait instead of failing and requeuing**.

> **Stacked PR.** Base is `feature/tbn-1289-fetch-package-with-interceptors` (the `@wisemen/node-fetch` PR #1320), which this depends on for the fetch interceptors. Merge that first, then re-target this onto `main`.

## How it works

Two halves:

**1. Blocking (fetch-gate).** A job opts into a limit with `super(data, { rateLimited: key })` — serialized to the pg-boss group id. Each limit's strategy/config is declared centrally on the worker:

```ts
PgBossWorkerModule.forRoot({
  queues: [...],
  rateLimits: { "my-api": { source: "static", limit: 100, windowSeconds: 60 } },
})
```

Before each poll the worker asks the limiter which keys are blocked and passes them to `fetch` as `ignoreGroups`, so those jobs stay in `created` while other groups on the same queue keep flowing. State lives in Postgres (`pgboss.rate_limit`), shared across all workers.

**2. Accounting (per HTTP request).** Usage counting / header reading / 429 handling happen at the HTTP call via `@wisemen/node-fetch` interceptors:

```ts
const api = createClient({ baseUrl: "https://api.example.com" });
useRateLimiting(api, rateLimiter); // register once
// ...then use `api` for the job's calls
```

The worker publishes the current job's key into `AsyncLocalStorage` around handler execution; the interceptors read it and drive the limiter hooks — `onRequest` (static: consume per attempt), `onResponse` (headers: record reported remaining/reset on every response; failure: block + throw `RateLimitError` on 429), `onError` (failure: block on transport error). Requests made outside a rate-limited job are untouched.

Three strategies: **static** token bucket, **header-driven**, **failure-backoff**. `@wisemen/node-fetch` is an optional peer dependency.

## Notes for reviewers

- Accounting only applies to calls routed through a `useRateLimiting` client — a rate-limited job calling bare `fetch` is not counted (documented in the README).
- Static consume is per **request attempt** (retries and failed-but-sent requests count), so `limit` means requests, not successful jobs.
- Fetch-gate gating is binary per poll → a burst can overshoot by up to `batchSize × workers` (documented "Overshoot caveat").

## Testing

45 tests (node:test), all green; clean `tsc`; 0 lint errors. Covers the ALS context, the three limiter hooks per mode, the interceptors (unit + real-`@wisemen/node-fetch` integration incl. the 429-throw path), and the fetch-gate. The Postgres atomic-bucket test is gated behind `RATE_LIMIT_TEST_DATABASE_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
