### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/bold-thin-crane.md
+++ b/.bumpy/bold-thin-crane.md
@@ -1,7 +1,0 @@
----
-"@wisemen/payload-core-translate": patch
----
-
-- Added ignored fields, to ignore fields for manually edited status
-- Improved root array fields by sanitizing the array id's
-- Improved logic for tagging a document as manually edited

--- a/.bumpy/icy-thin-finch.md
+++ b/.bumpy/icy-thin-finch.md
@@ -1,5 +1,0 @@
----
-"@wisemen/payload-core-settings": patch
----
-
-Removed seeders from package, they are better in the template itself

--- a/packages/payload/settings/CHANGELOG.md
+++ b/packages/payload/settings/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## 0.0.2
+<sub>2026-07-07</sub>
+
+- [#1375](https://github.com/wisemen-digital/wisemen-core/pull/1375)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Removed seeders from package, they are better in the template itself
+
 ## 0.0.1
 <sub>2026-07-06</sub>
 

--- a/packages/payload/settings/package.json
+++ b/packages/payload/settings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wisemen/payload-core-settings",
   "type": "module",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": false,
   "imports": {
     "#*": "./src/*"

--- a/packages/payload/translate/CHANGELOG.md
+++ b/packages/payload/translate/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+
+## 0.0.2
+<sub>2026-07-07</sub>
+
+- [#1377](https://github.com/wisemen-digital/wisemen-core/pull/1377)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - - Added ignored fields, to ignore fields for manually edited status
+  - Improved root array fields by sanitizing the array id's
+  - Improved logic for tagging a document as manually edited
+
 ## 0.0.1
 <sub>2026-07-03</sub>
 

--- a/packages/payload/translate/package.json
+++ b/packages/payload/translate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wisemen/payload-core-translate",
   "type": "module",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": false,
   "imports": {
     "#*": "./src/*"


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/payload-core-settings` 0.0.1 → **0.0.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1376/changes#diff-3f444f030f12d589970d48090572c34959d9ac2b7471d16c100691de8d0f3ce5)</sub>

- Removed seeders from package, they are better in the template itself ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1376/changes#diff-488c7a21bd1f008d4f0ba21a1f23d76b3be4db713db9e1e6676998cf0e4a388d))

#### `@wisemen/payload-core-translate` 0.0.1 → **0.0.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1376/changes#diff-a54dcc7b88d4691b865d70b05800c6ffeb2fadb2034d69d9e3bdcbcde47da224)</sub>

- - Added ignored fields, to ignore fields for manually edited status ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1376/changes#diff-ab2bcd7715d3a4a77ccea43ec1d4880fc27720e699da7beb29ef2099b7a84132))
  - Improved root array fields by sanitizing the array id's
  - Improved logic for tagging a document as manually edited
