### PR TITLE
feat(tbn-1365): handle service messages in parallel

### DIFF
--- a/.bumpy/copper-soft-wind.md
+++ b/.bumpy/copper-soft-wind.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/nestjs-nats": patch
+---
+
+feat: handle service messages in parallel

--- a/packages/api/nestjs-nats/lib/services/nats-service-endpoint.ts
+++ b/packages/api/nestjs-nats/lib/services/nats-service-endpoint.ts
@@ -57,8 +57,7 @@ export class NatsServiceEndpoint {
 
   async listen (): Promise<void> {
     for await (const message of this.stream) {
-      // Handle messages one by one
-      await this.handleMessage(message)
+      void this.handleMessage(message)
     }
   }
 


### PR DESCRIPTION
### Description
Nats service endpoints are similar to API endpoints, therefore there is no need to handle them 1 by 1.
Optionally later on we could add rate limiters like we do on the API.