### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/bold-old-sage.md
+++ b/.bumpy/bold-old-sage.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-domain-events": patch
----
-
-fix: allow nullable tenantUuid on domain event

--- a/packages/api/nestjs-domain-events/CHANGELOG.md
+++ b/packages/api/nestjs-domain-events/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+
+## 0.0.4
+<sub>2026-07-10</sub>
+
+- [#1400](https://github.com/wisemen-digital/wisemen-core/pull/1400)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - fix: allow nullable tenantUuid on domain event
+
 ## 0.0.3
 <sub>2026-07-10</sub>
 

--- a/packages/api/nestjs-domain-events/package.json
+++ b/packages/api/nestjs-domain-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-domain-events",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/nestjs-tests/CHANGELOG.md
+++ b/packages/api/nestjs-tests/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+
+## 0.0.4
+<sub>2026-07-10</sub>
+
+- *(patch)* Updated dependency `@wisemen/nestjs-domain-events` v0.0.4
+
 ## 0.0.3
 <sub>2026-07-10</sub>
 

--- a/packages/api/nestjs-tests/package.json
+++ b/packages/api/nestjs-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-tests",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/nestjs-domain-events` 0.0.3 → **0.0.4** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1401/changes#diff-c13956048755a12253c50ccf078b5db141005cb67e3dc3df58dbe8fa966480b4)</sub>

- fix: allow nullable tenantUuid on domain event ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1401/changes#diff-4441bcce664620e8ad7d995a6d60bc2de045596ecfc6c24b8c99fc444fbedba7))

#### `@wisemen/nestjs-tests` 0.0.3 → **0.0.4** _(dep)_ <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1401/changes#diff-cd49adf6cb6497c7b30da8022479f43cbf78b5bde6f0907ee35be7084266e144)</sub>

- Updated dependencies
