### PR TITLE
fix(custom-fields): fix nullable column and SKILL

### DIFF
--- a/.bumpy/smooth-witty-crab.md
+++ b/.bumpy/smooth-witty-crab.md
@@ -1,0 +1,8 @@
+---
+"@wisemen/nestjs-custom-fields": patch
+---
+
+Fix column options of @CustomFieldValueColumn() to allow null. 
+Extend CustomFieldDefinitionsRepository method to insert an array of entity types to avoid multiple database roundtrips.
+Add a customFieldValue() factory for tests.
+Update SKILL.MD with changes.

--- a/packages/api/nestjs-custom-fields/README.md
+++ b/packages/api/nestjs-custom-fields/README.md
@@ -17,7 +17,7 @@ Definition uniqueness is scoped by `entityType`. For non-tenant definitions,
 ## Step 1: Register The Exported Entity And Create The Table
 
 This package already exports the effective `CustomFieldDefinition` TypeORM
-entity. Add it to your datasource entities yourself so TypeORM knows about the
+entity. Add it to all TypeORM datasources yourself so TypeORM knows about the
 table metadata. After that, generate and run a migration so the table and the
 exported entity's partial unique indexes are created in your database.
 

--- a/packages/api/nestjs-custom-fields/lib/factory/custom-field-value.factory.ts
+++ b/packages/api/nestjs-custom-fields/lib/factory/custom-field-value.factory.ts
@@ -1,0 +1,15 @@
+import type { CustomFieldDefinitionUuid } from '#src/custom-field-definition.uuid.js'
+import type { CustomFieldValueByType } from '#src/custom-field-value.js'
+import { CustomFieldType } from '#src/enum/custom-field-type.enum.js'
+
+export function customFieldValue<T extends CustomFieldType>(
+  type: T,
+  definitionUuid: CustomFieldDefinitionUuid,
+  value: CustomFieldValueByType<T>['value']
+): CustomFieldValueByType<T> {
+  return {
+    definitionUuid,
+    type,
+    value
+  }
+}

--- a/packages/api/nestjs-custom-fields/lib/factory/custom-field-value.factory.unit.test.ts
+++ b/packages/api/nestjs-custom-fields/lib/factory/custom-field-value.factory.unit.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test'
+import { expect } from 'expect'
+import type { CustomFieldDefinitionUuid } from '#src/custom-field-definition.uuid.js'
+import { CustomFieldType } from '#src/enum/custom-field-type.enum.js'
+import { generateUuid } from '#src/custom-field-definition.uuid.js'
+import { customFieldValue } from '#src/factory/custom-field-value.factory.js'
+
+describe('customFieldValue', () => {
+  it('creates a typed custom field value', () => {
+    const definitionUuid = generateUuid<CustomFieldDefinitionUuid>()
+
+    expect(customFieldValue(CustomFieldType.TEXT, definitionUuid, 'hello')).toEqual({
+      definitionUuid,
+      type: CustomFieldType.TEXT,
+      value: 'hello'
+    })
+  })
+
+  it('supports values whose runtime shape depends on the field type', () => {
+    const definitionUuid = generateUuid<CustomFieldDefinitionUuid>()
+
+    expect(customFieldValue(CustomFieldType.MULTI_SELECT, definitionUuid, ['low', 'high'])).toEqual({
+      definitionUuid,
+      type: CustomFieldType.MULTI_SELECT,
+      value: ['low', 'high']
+    })
+  })
+})

--- a/packages/api/nestjs-custom-fields/lib/index.ts
+++ b/packages/api/nestjs-custom-fields/lib/index.ts
@@ -21,6 +21,7 @@ export {
 } from './dto/custom-field-value.dto.js'
 export { CustomFieldDefinitionError } from './errors/custom-field-definition.error.js'
 export { customFieldDefinition } from './factory/custom-field-definition.factory.js'
+export { customFieldValue } from './factory/custom-field-value.factory.js'
 export { CustomFieldDefinitionResponse } from './responses/custom-field-definition.response.js'
 export { CustomFieldDefinitionData as CustomFieldDefinitionFields } from './custom-field-definition.js'
 export { CustomFieldType, CustomFieldTypeApiProperty, CustomFieldTypeColumn } from './enum/custom-field-type.enum.js'

--- a/packages/api/nestjs-custom-fields/lib/repositories/custom-field-definitions.repository.ts
+++ b/packages/api/nestjs-custom-fields/lib/repositories/custom-field-definitions.repository.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common'
-import { Repository } from 'typeorm'
+import { Any, Repository } from 'typeorm'
 import { CustomFieldDefinition } from '#src/typeorm/custom-field-definition.entity.js'
 import { InjectRepository } from '@wisemen/nestjs-typeorm'
 
 export interface CustomFieldDefinitionsOptions {
   tenantUuid?: string
-  entityType?: string
+  entityType?: string | string[]
 }
 
 @Injectable()
@@ -16,11 +16,17 @@ export class CustomFieldDefinitionsRepository {
   ) { }
 
   async findDefinitions(
-    options? : CustomFieldDefinitionsOptions
+    options?: CustomFieldDefinitionsOptions
   ): Promise<CustomFieldDefinition[]> {
+    const entityType = options?.entityType
+    const isArray = Array.isArray(entityType)
+    if (isArray && entityType.length === 0) {
+      return []
+    }
+
     return this.repository.find({
       where: {
-        entityType: options?.entityType,
+        entityType: isArray ? Any(entityType) : entityType,
         tenantUuid: options?.tenantUuid
       },
       order: {

--- a/packages/api/nestjs-custom-fields/lib/typeorm/custom-field-value.column.ts
+++ b/packages/api/nestjs-custom-fields/lib/typeorm/custom-field-value.column.ts
@@ -13,7 +13,7 @@ interface CustomFieldValueColumnTransformers {
   timestampTransformer: TimestampTransformer
 }
 
-export function CustomFieldValueColumn(options?: Omit<ColumnOptions, 'type' | 'transformer' | 'nullable'>): PropertyDecorator {
+export function CustomFieldValueColumn(options?: Omit<ColumnOptions, 'type' | 'transformer'>): PropertyDecorator {
   return Column({
     ...options,
     type: 'jsonb',
@@ -34,8 +34,12 @@ class CustomFieldValueTransformer implements ValueTransformer {
   }
 
   from(
-    value: CustomFieldColumnValue | CustomFieldColumnValue[]
-  ): CustomFieldValue | CustomFieldValue[] {
+    value: CustomFieldColumnValue | CustomFieldColumnValue[] | null | undefined
+  ): CustomFieldValue | CustomFieldValue[] | null | undefined {
+    if (value == null) {
+      return value
+    }
+
     if (Array.isArray(value)) {
       return value.map(v => this.parseCustomFieldValue(v))
     }
@@ -44,8 +48,12 @@ class CustomFieldValueTransformer implements ValueTransformer {
   }
 
   to(
-    value: CustomFieldValue | CustomFieldValue[]
-  ): CustomFieldColumnValue | CustomFieldColumnValue[] {
+    value: CustomFieldValue | CustomFieldValue[] | null | undefined
+  ): CustomFieldColumnValue | CustomFieldColumnValue[] | null | undefined {
+    if (value == null) {
+      return value
+    }
+
     if (Array.isArray(value)) {
       return value.map(v => this.getSerializeValue(v))
     }

--- a/packages/api/nestjs-custom-fields/skills/getting-started/SKILL.md
+++ b/packages/api/nestjs-custom-fields/skills/getting-started/SKILL.md
@@ -20,7 +20,7 @@ Definition uniqueness is scoped by `entityType`. For non-tenant definitions,
 ## Step 1: Register The Exported Entity And Create The Table
 
 This package already exports the effective `CustomFieldDefinition` TypeORM
-entity. Add it to your datasource entities yourself so TypeORM knows about the
+entity. Add it to all TypeORM datasources yourself so TypeORM knows about the
 table metadata. After that, generate and run a migration so the table and the
 exported entity's partial unique indexes are created in your database.
 
@@ -64,7 +64,8 @@ import {
 } from '@wisemen/nestjs-custom-fields'
 
 enum CustomFieldEntityType {
-  TICKET = 'ticket'
+  TICKET = 'ticket',
+  COMMENT = 'comment'
 }
 
 export class Playground extends JobContainer {
@@ -186,6 +187,49 @@ const parsed = dto.parse()
 // }
 ```
 
+## Creating Definitions And Values In Tests
+
+Use `customFieldDefinition(...)` to create definitions in tests. This keeps
+test fixtures on the same normalized and validated path as production
+definitions. The factory generates the definition UUID, so use `definition.uuid`
+when creating its values.
+
+```ts
+import { LocalizedString } from '@wisemen/localized-string'
+import {
+  CustomFieldType,
+  customFieldDefinition,
+  customFieldValue,
+  type CustomFieldValue
+} from '@wisemen/nestjs-custom-fields'
+
+const definition = customFieldDefinition(CustomFieldType.TEXT, {
+  tenantUuid: null,
+  entityType: 'ticket',
+  key: 'summary',
+  label: new LocalizedString([{ locale: 'en', value: 'Summary' }]),
+  description: null,
+  isRequired: false
+})
+
+const value: CustomFieldValue = customFieldValue(
+  CustomFieldType.TEXT,
+  definition.uuid,
+  'hello'
+)
+```
+
+For request-boundary tests, instantiate the relevant
+`CustomFieldValueDto` subclass and call `.parse()` to create the domain value.
+`CustomFieldValueDto.from(value)` is the inverse operation: it maps an existing
+domain value to a response DTO and does not create a value.
+
+There is no public builder for definitions or values. Use the two factories for
+standard fixtures, and keep more specialized test builders local to the
+consuming project. `customFieldValue(...)` only constructs the typed value; use
+`validateCustomFieldValue(...)` or `validateCustomFieldValues(...)` to validate
+it against its definition.
+
 ## Step 5: Retrieve Definitions For Validation
 
 When you process submitted values, retrieve the matching definitions through
@@ -222,15 +266,27 @@ async update(...): Promise<void> {
 ```
 On repository lookups, `tenantUuid` is optional. Omit it to work with
 non-tenant definitions, or set it to retrieve tenant-specific definitions in a
-multi-tenant setup.
+multi-tenant setup. `entityType` is also optional and accepts either one entity
+type or an array of entity types.
+
+```ts
+const definitions = await repository.findDefinitions({
+  entityType: [CustomFieldEntityType.TICKET, CustomFieldEntityType.COMMENT],
+  tenantUuid
+})
+```
+
+Use a multi-entity lookup when a use case validates or returns definitions for
+several entity types together. The tenant filter still applies to every
+requested entity type, and results remain ordered by definition `key`.
 
 After DTO parsing, validate the resolved values against the definitions that
 apply for that entity and tenant. This is the runtime check that enforces the
 definition rules.
 
 The runtime order matters: call `.parse()` on the DTOs first, then run
-`validateCustomFieldValues(...)` against the definitions for that
-`entityType` and tenant scope.
+`validateCustomFieldValues(...)` against the definitions for the relevant
+entity type or entity types and tenant scope.
 
 ```ts
 import { Injectable } from '@nestjs/common'


### PR DESCRIPTION
- Fix column options of @CustomFieldValueColumn() to allow null. 
- Extend CustomFieldDefinitionsRepository method to insert an array of entity types to avoid multiple database roundtrips.
- Add a customFieldValue() factory for tests.
- Update SKILL.MD with changes for the changes and add extra testing section.