### PR TITLE
fix(date-wise): fix dayOfMonth on plaindate() and formatting

### DIFF
--- a/.bumpy/deep-rare-rose.md
+++ b/.bumpy/deep-rare-rose.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/datewise": patch
+---
+
+Bugfixes on plaindate.dayOfMonth() and format timestamp.toPlainDate()

--- a/packages/api/datewise/lib/plain-date/dayjs-plain-date.ts
+++ b/packages/api/datewise/lib/plain-date/dayjs-plain-date.ts
@@ -117,7 +117,7 @@ export class DayjsPlainDate implements PlainDate {
   }
 
   dayOfMonth (): number {
-    return this.date.get('day')
+    return this.date.date()
   }
 
   weekOfYear (): number {

--- a/packages/api/datewise/lib/plain-date/tests/plain-date.accessors.unit.test.ts
+++ b/packages/api/datewise/lib/plain-date/tests/plain-date.accessors.unit.test.ts
@@ -1,7 +1,7 @@
 import { before, describe, it } from 'node:test'
 import { expect } from 'expect'
 import { initDayjs } from '../../common/init-dayjs.js'
-import { factory } from '../plain-date.factory.js'
+import { factory, today } from '../plain-date.factory.js'
 import { DayjsPlainDate } from '../dayjs-plain-date.js'
 import { FutureInfinityDate } from '../future-infinity-date.js'
 import { PastInfinityDate } from '../past-infinity-date.js'
@@ -22,7 +22,6 @@ describe('PlainDate accessors', () => {
 
       expect(day.day()).toBe(0) // wrapped around to sunday
     })
-
   })
 
   describe('isoWeek', () => {
@@ -31,7 +30,6 @@ describe('PlainDate accessors', () => {
       expect(factory('2025-12-28').isoWeek()).toBe(52)
       expect(factory('2025-12-29').isoWeek()).toBe(1)
     })
-
   })
 
   describe('isoWeekParity', () => {
@@ -44,7 +42,6 @@ describe('PlainDate accessors', () => {
       expect(factory('2025-01-06').isoWeekParity()).toBe(IsoWeekParity.EVEN) // week 2
       expect(factory('2025-01-20').isoWeekParity()).toBe(IsoWeekParity.EVEN) // week 4
     })
-
   })
 
   describe('isoWeekday', () => {
@@ -58,7 +55,6 @@ describe('PlainDate accessors', () => {
 
       expect(day.isoWeekday()).toBe(7) // wrapped around to sunday
     })
-
   })
 
   describe('until', () => {
@@ -304,6 +300,14 @@ describe('PlainDate accessors', () => {
 
       expect(date1.until(date2).days).toBe(0)
       expect(date1.since(date2).days).toBe(0)
+    })
+  })
+
+  describe('dayOfMonth', () => {
+    it('returns the day of the month', () => {
+      const now = today().startOf('month').add(9, 'day')
+      const dayOfMonth = now.dayOfMonth()
+      expect(dayOfMonth).toBe(10)
     })
   })
 })

--- a/packages/api/datewise/lib/timestamp/dayjs-timestamp.ts
+++ b/packages/api/datewise/lib/timestamp/dayjs-timestamp.ts
@@ -221,7 +221,7 @@ export class DayjsTimestamp implements Timestamp {
   }
 
   toPlainDate (): PlainDate {
-    return plainDate(this)
+    return plainDate(this.format('YYYY-MM-DD'))
   }
 
   toPlainTime (): PlainTime {


### PR DESCRIPTION
- this.date.get('day') returns day of the week instead of day of the month
- format the timestamp to date only to avoid 1 day off issues with timezones if code is run near midnight. If it passes as timestamp it will call new Date() which interprets the timestamp to the local time. On the server this will no issue but on local machines it will cause tests to fail randomly.  ex

2026-07-11T23:00Z

new Date('2026-07-11T23:00Z') -> 2026-07-12:01:00+2:00 thus plaindate is off by one day