### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/extract-nestjs-provider-explorer.md
+++ b/.bumpy/extract-nestjs-provider-explorer.md
@@ -1,9 +1,0 @@
----
-"@wisemen/nestjs-provider-explorer": minor
-"@wisemen/nestjs-domain-events": patch
-"@wisemen/nestjs-typesense": patch
-"@wisemen/nestjs-nats": patch
-"@wisemen/pgboss-nestjs-job": patch
----
-
-Added a shared NestJS provider explorer package and migrated existing packages to use it.

--- a/.bumpy/rusty-silver-cat.md
+++ b/.bumpy/rusty-silver-cat.md
@@ -1,5 +1,0 @@
----
-"@wisemen/scoped-filter": patch
----
-
-Fix ValidateWhen in PlainDateFilter

--- a/packages/api/nestjs-domain-events/CHANGELOG.md
+++ b/packages/api/nestjs-domain-events/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 0.0.6
+<sub>2026-07-13</sub>
+
+- [#1417](https://github.com/wisemen-digital/wisemen-core/pull/1417)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - Added a shared NestJS provider explorer package and migrated existing packages to use it.
+
 ## 0.0.5
 <sub>2026-07-10</sub>
 

--- a/packages/api/nestjs-domain-events/package.json
+++ b/packages/api/nestjs-domain-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-domain-events",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/nestjs-nats/CHANGELOG.md
+++ b/packages/api/nestjs-nats/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 1.1.1
+<sub>2026-07-13</sub>
+
+- [#1417](https://github.com/wisemen-digital/wisemen-core/pull/1417)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - Added a shared NestJS provider explorer package and migrated existing packages to use it.
+
 ## 1.1.0
 <sub>2026-07-08</sub>
 

--- a/packages/api/nestjs-nats/package.json
+++ b/packages/api/nestjs-nats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-nats",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/nestjs-provider-explorer/CHANGELOG.md
+++ b/packages/api/nestjs-provider-explorer/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+<sub>2026-07-13</sub>
+
+- [#1417](https://github.com/wisemen-digital/wisemen-core/pull/1417)  *(minor)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - Added a shared NestJS provider explorer package and migrated existing packages to use it.

--- a/packages/api/nestjs-provider-explorer/package.json
+++ b/packages/api/nestjs-provider-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-provider-explorer",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/nestjs-tests/CHANGELOG.md
+++ b/packages/api/nestjs-tests/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 0.0.6
+<sub>2026-07-13</sub>
+
+- *(patch)* Updated dependency `@wisemen/nestjs-domain-events` v0.0.6
+
 ## 0.0.5
 <sub>2026-07-10</sub>
 

--- a/packages/api/nestjs-tests/package.json
+++ b/packages/api/nestjs-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-tests",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/nestjs-typesense/CHANGELOG.md
+++ b/packages/api/nestjs-typesense/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 0.0.2
+<sub>2026-07-13</sub>
+
+- [#1417](https://github.com/wisemen-digital/wisemen-core/pull/1417)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - Added a shared NestJS provider explorer package and migrated existing packages to use it.
+
 ## 0.0.1
 <sub>2026-07-10</sub>
 

--- a/packages/api/nestjs-typesense/package.json
+++ b/packages/api/nestjs-typesense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-typesense",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/pgboss-nestjs-job/CHANGELOG.md
+++ b/packages/api/pgboss-nestjs-job/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @wisemen/pgboss-nestjs-job
 
+
+## 4.0.10
+<sub>2026-07-13</sub>
+
+- [#1417](https://github.com/wisemen-digital/wisemen-core/pull/1417)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - Added a shared NestJS provider explorer package and migrated existing packages to use it.
+
 ## 4.0.9
 
 ### Patch Changes

--- a/packages/api/pgboss-nestjs-job/package.json
+++ b/packages/api/pgboss-nestjs-job/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/pgboss-nestjs-job",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/scoped-filter/CHANGELOG.md
+++ b/packages/api/scoped-filter/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 
 
+
+## 1.0.1
+<sub>2026-07-13</sub>
+
+- [#1415](https://github.com/wisemen-digital/wisemen-core/pull/1415)  *(patch)* Thanks [@YuHangHuu](https://github.com/YuHangHuu)! - Fix ValidateWhen in PlainDateFilter
+
 ## 1.0.0
 <sub>2026-06-30</sub>
 

--- a/packages/api/scoped-filter/package.json
+++ b/packages/api/scoped-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/scoped-filter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/nestjs-provider-explorer` 0.0.1 → **0.1.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-afd174eade72e655c2080a6d18a43cf03c0506baa9669c76255f554043c90c33)</sub>

- Added a shared NestJS provider explorer package and migrated existing packages to use it. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-e8493d54d06d1b220fe90d5ac73d3a9f4ab3680f6709c1d90440dd651f53f594))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/nestjs-domain-events` 0.0.5 → **0.0.6** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-c13956048755a12253c50ccf078b5db141005cb67e3dc3df58dbe8fa966480b4)</sub>

- Added a shared NestJS provider explorer package and migrated existing packages to use it. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-e8493d54d06d1b220fe90d5ac73d3a9f4ab3680f6709c1d90440dd651f53f594))

#### `@wisemen/nestjs-nats` 1.1.0 → **1.1.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-81a951dd5868500cf33991ba2bcacfdd310d9cb41f91b73a9dd2b766ce9228ae)</sub>

- Added a shared NestJS provider explorer package and migrated existing packages to use it. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-e8493d54d06d1b220fe90d5ac73d3a9f4ab3680f6709c1d90440dd651f53f594))

#### `@wisemen/nestjs-tests` 0.0.5 → **0.0.6** _(dep)_ <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-cd49adf6cb6497c7b30da8022479f43cbf78b5bde6f0907ee35be7084266e144)</sub>

- Updated dependencies

#### `@wisemen/nestjs-typesense` 0.0.1 → **0.0.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-aa4abb471301e1e3d1c7ea06efd39502731c66b4601521aeba598e48e427ece9)</sub>

- Added a shared NestJS provider explorer package and migrated existing packages to use it. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-e8493d54d06d1b220fe90d5ac73d3a9f4ab3680f6709c1d90440dd651f53f594))

#### `@wisemen/pgboss-nestjs-job` 4.0.9 → **4.0.10** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-402cfe2ecee6f2fa684004d60597b335584d2f142cd7c1b379a61e4c48d94226)</sub>

- Added a shared NestJS provider explorer package and migrated existing packages to use it. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-e8493d54d06d1b220fe90d5ac73d3a9f4ab3680f6709c1d90440dd651f53f594))

#### `@wisemen/scoped-filter` 1.0.0 → **1.0.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-e237bf1a849d4de86c426bf169d71c2e8790161bedaecc1e3b0a19f07e934fee)</sub>

- Fix ValidateWhen in PlainDateFilter ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1416/changes#diff-2da4def8cadc2d7cbe371b8ac1e99b4866ff666fb18b1276e2556537ba122ddf))
