### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/bright-bold-kite.md
+++ b/.bumpy/bright-bold-kite.md
@@ -1,8 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fix `FormDialog` and `DialogChin` issues:
-- Pressing Esc on a dirty `FormDialog` now shows the unsaved-changes confirmation chin instead of discarding changes immediately; pressing Esc again closes the dialog and discards the changes
-- Fixed a height jump/chop in the dialog chin's open animation, most noticeable when it opened at the same time as a form field's error message
-- Closing a `FormDialog` with unsaved changes no longer marks every form field as touched, so validation errors no longer appear on fields the user never interacted with

--- a/.bumpy/bright-tidy-elk.md
+++ b/.bumpy/bright-tidy-elk.md
@@ -1,7 +1,0 @@
----
-"@wisemen/vue-core-design-system": minor
----
-
-UIDropdownMenu, UIContextMenu: Content can now grow past its min-width to fit larger items. While open,
-it remembers the widest size it has rendered at so it never shrinks back
-down and shifts the layout; this resets each time the menu is reopened. This requires `is-adaptive-content-width: true`

--- a/.bumpy/happy-kind-trout.md
+++ b/.bumpy/happy-kind-trout.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-actions": patch
----
-
-Reduce debounce from 200ms to 80ms for menus

--- a/.bumpy/happy-rich-clam.md
+++ b/.bumpy/happy-rich-clam.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fix dropdown/context menus not keeping an item highlighted while navigating via keyboard. Items loaded in asynchronously, or a list filtered down to zero results and then cleared, could end up with nothing highlighted. The first item is now kept highlighted for as long as the menu stays open and the user is driving it via keyboard, including once a search/filter kicks in on a menu that was opened with the mouse.

--- a/.bumpy/rare-kind-ant.md
+++ b/.bumpy/rare-kind-ant.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Remove unsude component from sidebar

--- a/packages/web/actions/CHANGELOG.md
+++ b/packages/web/actions/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 
 
+
+## 0.2.2
+<sub>2026-07-14</sub>
+
+- [#1423](https://github.com/wisemen-digital/wisemen-core/pull/1423)  *(patch)* Thanks [@wouterlms](https://github.com/wouterlms)! - Reduce debounce from 200ms to 80ms for menus
+
 ## 0.2.1
 <sub>2026-06-30</sub>
 

--- a/packages/web/actions/package.json
+++ b/packages/web/actions/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -19,6 +19,20 @@
 
 
 
+
+## 1.14.0
+<sub>2026-07-14</sub>
+
+- [#1418](https://github.com/wisemen-digital/wisemen-core/pull/1418)  *(minor)* Thanks [@wouterlms](https://github.com/wouterlms)! - UIDropdownMenu, UIContextMenu: Content can now grow past its min-width to fit larger items. While open,
+  it remembers the widest size it has rendered at so it never shrinks back
+  down and shifts the layout; this resets each time the menu is reopened. This requires `is-adaptive-content-width: true`
+- [#1409](https://github.com/wisemen-digital/wisemen-core/pull/1409)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Fix `FormDialog` and `DialogChin` issues:
+  - Pressing Esc on a dirty `FormDialog` now shows the unsaved-changes confirmation chin instead of discarding changes immediately; pressing Esc again closes the dialog and discards the changes
+  - Fixed a height jump/chop in the dialog chin's open animation, most noticeable when it opened at the same time as a form field's error message
+  - Closing a `FormDialog` with unsaved changes no longer marks every form field as touched, so validation errors no longer appear on fields the user never interacted with
+- [#1413](https://github.com/wisemen-digital/wisemen-core/pull/1413)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Remove unsude component from sidebar
+- [#1419](https://github.com/wisemen-digital/wisemen-core/pull/1419)  *(patch)* Thanks [@wouterlms](https://github.com/wouterlms)! - Fix dropdown/context menus not keeping an item highlighted while navigating via keyboard. Items loaded in asynchronously, or a list filtered down to zero results and then cleared, could end up with nothing highlighted. The first item is now kept highlighted for as long as the menu stays open and the user is driving it via keyboard, including once a search/filter kicks in on a menu that was opened with the mouse.
+
 ## 1.13.0
 <sub>2026-07-08</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/vue-core-design-system` 1.13.0 → **1.14.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1425/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Fix `FormDialog` and `DialogChin` issues: ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1425/changes#diff-0ea448bc75f118bde3f8519fc53cacd786cf1505e243748e501dbab9e397fc7a))
  - Pressing Esc on a dirty `FormDialog` now shows the unsaved-changes confirmation chin instead of discarding changes immediately; pressing Esc again closes the dialog and discards the changes
  - Fixed a height jump/chop in the dialog chin's open animation, most noticeable when it opened at the same time as a form field's error message
  - Closing a `FormDialog` with unsaved changes no longer marks every form field as touched, so validation errors no longer appear on fields the user never interacted with
- Remove unsude component from sidebar ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1425/changes#diff-ef577de4054ef08f4ab1b2989d7e862e74e07a1a2552e21807f4c6ea4e46a6a7))
- UIDropdownMenu, UIContextMenu: Content can now grow past its min-width to fit larger items. While open, ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1425/changes#diff-c5ede6ca807240036fcd716e848c86f3ee9f95fcf2408d39efd2bb85e6053fe4))
  it remembers the widest size it has rendered at so it never shrinks back
  down and shifts the layout; this resets each time the menu is reopened. This requires `is-adaptive-content-width: true`
- Fix dropdown/context menus not keeping an item highlighted while navigating via keyboard. Items loaded in asynchronously, or a list filtered down to zero results and then cleared, could end up with nothing highlighted. The first item is now kept highlighted for as long as the menu stays open and the user is driving it via keyboard, including once a search/filter kicks in on a menu that was opened with the mouse. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1425/changes#diff-71f843a497402b286989f7adbbd21a4bf7463119c3f1f6eadfb26ccc0bd9dcb1))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/vue-core-actions` 0.2.1 → **0.2.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1425/changes#diff-0b28015ba399cc69eba7feeccfe81fa9b615fd065c19bcc086aac0f5f570ed9e)</sub>

- Reduce debounce from 200ms to 80ms for menus ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1425/changes#diff-fa328436e167744d1262b3dd6f0ba4356ed5768632d944f9caa35765d784264f))
