### PR TITLE
feat: Make cli compatible for ngen

### DIFF
--- a/packages/api/nestjs-gen/skills/builder-generator/SKILL.md
+++ b/packages/api/nestjs-gen/skills/builder-generator/SKILL.md
@@ -36,6 +36,21 @@ Naming your source files with the matching suffix (`*.entity.ts`,
 filename clean — the suffix is only stripped from the input basename, so a
 non-matching file produces an odd double-extension output name.
 
+## Non-interactive (agent) usage
+
+No terminal/TTY needed — this generator has no conditional or dynamic-choice
+prompts, so plop's own bypass mechanism (built into `ngen`, no extra flags or
+tooling) can supply every answer up front by name:
+
+```sh
+pnpx @wisemen/ngen builder --inputPath=src/app/book/entities/book.entity.ts --outputPath= --type=entity
+```
+
+`inputPath` and `type` have no default and must be supplied; `outputPath` also
+has no default, so pass it explicitly as empty (`--outputPath=`) for the
+"write next to input file" behavior. `type` accepts the list's value, name, or
+index (`entity`/`command`/`query`/`interface`).
+
 ## Output shape
 
 ```ts

--- a/packages/api/nestjs-gen/skills/cronjob-generator/SKILL.md
+++ b/packages/api/nestjs-gen/skills/cronjob-generator/SKILL.md
@@ -20,6 +20,19 @@ expected to come from the target project's own `CronjobType` enum +
 Both `subdir` and `name` are required in practice — leaving either blank
 produces a malformed path.
 
+## Non-interactive (agent) usage
+
+No terminal/TTY needed — this generator has no conditional or dynamic-choice
+prompts, so plop's own bypass mechanism (built into `ngen`, no extra flags or
+tooling) can supply every answer up front by name:
+
+```sh
+pnpx @wisemen/ngen cronjob --dir=src/app/ --subdir=reports --name=sync-invoices
+```
+
+`dir` falls back to its default if omitted; `subdir` and `name` have no
+default and must be supplied.
+
 ## What gets generated
 
 Both files land at `<dir>/<subdir>/use-cases/<kebab-name>/`:

--- a/packages/api/nestjs-gen/skills/job-generator/SKILL.md
+++ b/packages/api/nestjs-gen/skills/job-generator/SKILL.md
@@ -20,6 +20,24 @@ an existing queue defined in the project's `QueueName` enum.
    isn't found, this prompt has zero choices and effectively blocks the
    generator. Add the queue to `QueueName` first if it's missing.
 
+## Non-interactive (agent) usage
+
+No terminal/TTY needed. All four prompts, including the dynamic `queue`
+list, can be bypassed non-interactively via plop's own bypass mechanism
+(built into `ngen`, no extra flags or tooling), by name:
+
+```sh
+pnpx @wisemen/ngen job --dir=src/app/ --subdir=reports --name=send-invoice --queue=reports
+```
+
+`dir` falls back to its default if omitted; `subdir`, `name`, and `queue`
+have no default and must be supplied. `queue` accepts the enum member's
+value, name, or index. (`queue`'s `choices` are computed dynamically from
+the target project's `QueueName` enum — this repo patches `node-plop` via
+`patches/node-plop.patch` to resolve dynamic `choices` before bypass
+matching; upstream `node-plop@0.32.3` does not support this and throws
+`prompt.choices.find is not a function` instead.)
+
 ## What gets generated
 
 All under `<dir>/<subdir>/use-cases/<kebab-name>/`:

--- a/packages/api/nestjs-gen/skills/module-generator/SKILL.md
+++ b/packages/api/nestjs-gen/skills/module-generator/SKILL.md
@@ -34,6 +34,35 @@ in the expected shape.
 8. If `Event` is checked: `Domain event name:` — e.g. `Archived` → emits an
    `ArchivedEvent`.
 
+## Non-interactive (agent) usage
+
+No terminal/TTY needed, including for the `custom` flow. Every prompt, static
+or conditional, can be bypassed via plop's own bypass mechanism (built into
+`ngen`, no extra flags or tooling), by name. This generator's name is
+`module / useCase` (with spaces) — quote it as a single CLI argument:
+
+```sh
+pnpx @wisemen/ngen "module / useCase" --dir=src/app/ --subdir=/ --module=book --createEntity=yes --type=create,index,detail,update,delete
+```
+
+`dir`/`subdir`/`createEntity` fall back to their defaults if omitted;
+`module` and `type` have no default and must be supplied. `type` is a
+checkbox — pass a comma-separated list of values.
+
+For the `custom` flow, include `custom` and (if relevant) `custom_addons` /
+`domain_event_name` — they only apply when `type` includes `"custom"` /
+`custom_addons` includes `"domain_event"`, so omit them otherwise:
+
+```sh
+pnpx @wisemen/ngen "module / useCase" --dir=src/app/ --subdir=/ --module=book --createEntity=yes --type=custom --custom=archive --custom_addons=response,command,domain_event --domain_event_name=Archived
+```
+
+(Conditional prompts like `custom` are only bypassable here because this repo
+patches `node-plop` via `patches/node-plop.patch` to evaluate each prompt's
+`when` against the answers gathered so far, instead of hard-refusing any
+conditional prompt outright — upstream `node-plop@0.32.3` throws `You can not
+bypass conditional prompts: custom` instead, with no workaround.)
+
 ## What always gets generated
 
 - A `Permission` enum + `Permissions()`/`Public()` decorator (created once,

--- a/packages/api/nestjs-gen/skills/translations-generator/SKILL.md
+++ b/packages/api/nestjs-gen/skills/translations-generator/SKILL.md
@@ -23,6 +23,24 @@ throws; if it has no language subfolders, the checkbox has zero choices.
 2. `Select the languages...` — checkbox, choices = subfolder names under
    `src/modules/localization/resources/`, all pre-checked.
 
+## Non-interactive (agent) usage
+
+No terminal/TTY needed. Both prompts, including the dynamic `languages`
+checkbox, can be bypassed non-interactively via plop's own bypass mechanism
+(built into `ngen`, no extra flags or tooling), by name:
+
+```sh
+pnpx @wisemen/ngen translations --type=permissions --languages=en,nl-BE
+```
+
+`type` falls back to its default (`permissions`) if omitted. `languages`
+accepts a comma-separated list of language folder names; passing `--languages=`
+(empty) generates none. (`languages`' `choices` are computed dynamically from
+`src/modules/localization/resources/`'s subfolders — this repo patches
+`node-plop` via `patches/node-plop.patch` to resolve dynamic `choices` before
+bypass matching; upstream `node-plop@0.32.3` does not support this and throws
+`prompt.choices.some is not a function` instead.)
+
 ## What each type does
 
 | Type | Target file | Source enum | Leaf fields |

--- a/packages/api/nestjs-gen/skills/typesense-generator/SKILL.md
+++ b/packages/api/nestjs-gen/skills/typesense-generator/SKILL.md
@@ -24,6 +24,20 @@ Requires the target entity to already exist at
 
 All files land under `<dir>/<subdir>/<entity>/typesense/`.
 
+## Non-interactive (agent) usage
+
+No terminal/TTY needed — this generator has no conditional or dynamic-choice
+prompts, so plop's own bypass mechanism (built into `ngen`, no extra flags or
+tooling) can supply every answer up front by name:
+
+```sh
+pnpx @wisemen/ngen typesense --dir=src/app/ --subdir=/ --name=book --includeSubscriber=no
+```
+
+Confirm-type prompts (`includeSubscriber`) accept `yes`/`no`/`y`/`n`/`true`/`false`.
+Any prompt you omit falls back to its default (`dir`, `subdir`,
+`includeSubscriber`); `name` has no default and must be supplied.
+
 ## What gets generated
 
 | File | Class | Notes |

--- a/packages/api/nestjs-gen/templates/use-case/custom/custom-controller.hbs
+++ b/packages/api/nestjs-gen/templates/use-case/custom/custom-controller.hbs
@@ -12,7 +12,7 @@ export class {{pascalCase useCaseName}}Controller {
 
   @Version('1')
   @Permissions(Permission.{{constantCase permissionName}})
-  async {{camelCase useCaseName}} (): Promise<void> {
+  public async {{camelCase useCaseName}} (): Promise<void> {
     return this.useCase.execute()
   }
 }

--- a/patches/node-plop.patch
+++ b/patches/node-plop.patch
@@ -1,0 +1,88 @@
+diff --git a/src/prompt-bypass.js b/src/prompt-bypass.js
+index 8310a97d1ad6f7a593163c702a083753a89c3242..0d2ea3334d3b84f149691313d094fbb5f91323be 100644
+--- a/src/prompt-bypass.js
++++ b/src/prompt-bypass.js
+@@ -54,10 +54,20 @@ const flag = {
+   isPrompt: (v) => /^_+$/.test(v),
+ };
+ 
++// resolve a prompt's `choices`, calling it (and awaiting the result) when
++// it's a dynamic function instead of a static array
++async function resolveChoices(prompt, answers) {
++  if (typeof prompt.choices === "function") {
++    return (await prompt.choices(answers)) ?? [];
++  }
++  return prompt.choices ?? [];
++}
++
+ // generic list bypass function. used for all types of lists.
+ // accepts value, index, or key as matching criteria
+-const listTypeBypass = (v, prompt) => {
+-  const choice = prompt.choices.find((c, idx) => choiceMatchesValue(c, idx, v));
++const listTypeBypass = async (v, prompt, answers) => {
++  const choices = await resolveChoices(prompt, answers);
++  const choice = choices.find((c, idx) => choiceMatchesValue(c, idx, v));
+   if (choice != null) {
+     return getChoiceValue(choice);
+   }
+@@ -79,24 +89,22 @@ const typeBypass = {
+     }
+     throw Error("invalid input");
+   },
+-  checkbox(v, prompt) {
++  async checkbox(v, prompt, answers) {
+     if (v === "") {
+       return [];
+     }
+ 
++    const choices = await resolveChoices(prompt, answers);
+     const valList = v.split(",");
+     const valuesNoMatch = valList.filter(
+-      (val) =>
+-        !prompt.choices.some((c, idx) => choiceMatchesValue(c, idx, val)),
++      (val) => !choices.some((c, idx) => choiceMatchesValue(c, idx, val)),
+     );
+     if (valuesNoMatch.length) {
+       throw Error(`no match for "${valuesNoMatch.join('", "')}"`);
+     }
+ 
+     return valList.map((val) =>
+-      getChoiceValue(
+-        prompt.choices.find((c, idx) => choiceMatchesValue(c, idx, val)),
+-      ),
++      getChoiceValue(choices.find((c, idx) => choiceMatchesValue(c, idx, val))),
+     );
+   },
+   list: listTypeBypass,
+@@ -150,13 +158,16 @@ export default async function (prompts, bypassArr, plop) {
+       continue;
+     }
+ 
+-    // if this prompt is dynamic, throw error because we can't know if
+-    // the pompt bypass values given line up with the path this user
+-    // has taken through the prompt tree.
++    // if this prompt is conditional, resolve `when` against the answers
++    // gathered so far (built up in-order, same as inquirer would) instead of
++    // refusing outright — if it doesn't apply, there's nothing to bypass;
++    // if it does apply, the bypass value below is used like any other.
+     if (typeof p.when === "function") {
+-      bypassFailures.push(`You can not bypass conditional prompts: ${p.name}`);
+-      bypassedPromptValues.push(false);
+-      continue;
++      const shouldAsk = await p.when(answers);
++      if (!shouldAsk) {
++        bypassedPromptValues.push(true);
++        continue;
++      }
+     }
+ 
+     try {
+@@ -167,7 +178,7 @@ export default async function (prompts, bypassArr, plop) {
+       // get the real answer data out of the bypass function and attach it
+       // to the answer data object
+       const bypassIsFunc = typeof bypass === "function";
+-      const value = bypassIsFunc ? bypass.call(null, val, p) : val;
++      const value = bypassIsFunc ? await bypass.call(null, val, p, answers) : val;
+ 
+       // if inquirer prompt has a filter function - call it
+       const answer = p.filter ? p.filter(value, answers) : value;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,6 +840,9 @@ overrides:
 
 packageExtensionsChecksum: sha256-9usZlOdVj0YeLr51rHuCnoJXtCquR9TSkl07aBT4UE0=
 
+patchedDependencies:
+  node-plop: e5204bc75fb37e07ce203c6bc6c017165201f3b433483df79faa1ede18e2a9fa
+
 importers:
 
   .:
@@ -15788,7 +15791,7 @@ snapshots:
       eslint-plugin-regexp: 3.1.0(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-toml: 1.3.1(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-unicorn: 63.0.0(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-vue: 10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.7.0)))(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.7.0)))
       eslint-plugin-yml: 3.3.1(eslint@9.39.4(jiti@2.7.0))
       eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.27)(eslint@9.39.4(jiti@2.7.0))
@@ -15842,6 +15845,59 @@ snapshots:
       eslint-plugin-toml: 1.3.1(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-unicorn: 63.0.0(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-vue: 10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.7.0)))(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.7.0)))
+      eslint-plugin-yml: 3.3.1(eslint@9.39.4(jiti@2.7.0))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.27)(eslint@9.39.4(jiti@2.7.0))
+      globals: 17.5.0
+      local-pkg: 1.1.2
+      parse-gitignore: 2.0.0
+      toml-eslint-parser: 1.0.3
+      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@2.7.0))
+      yaml-eslint-parser: 2.0.0
+    optionalDependencies:
+      eslint-plugin-format: 1.3.1(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-vuejs-accessibility: 2.4.1(eslint@9.39.4(jiti@2.7.0))
+    transitivePeerDependencies:
+      - '@eslint/json'
+      - '@typescript-eslint/rule-tester'
+      - '@typescript-eslint/typescript-estree'
+      - '@typescript-eslint/utils'
+      - '@vue/compiler-sfc'
+      - oxlint
+      - supports-color
+      - typescript
+      - vitest
+
+  '@antfu/eslint-config@7.7.0(eslint-plugin-format@1.3.1(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-vuejs-accessibility@2.4.1(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(oxlint@1.59.0(oxlint-tsgolint@0.20.0))(typescript@5.9.3)(vitest@4.1.0)':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@clack/prompts': 1.5.1
+      '@e18e/eslint-plugin': 0.2.0(eslint@9.39.4(jiti@2.7.0))(oxlint@1.59.0(oxlint-tsgolint@0.20.0))
+      '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint/markdown': 7.5.1
+      '@stylistic/eslint-plugin': 5.10.0(eslint@9.39.4(jiti@2.7.0))
+      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@vitest/eslint-plugin': 1.6.9(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.0)
+      ansis: 4.2.0
+      cac: 7.0.0
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-config-flat-gitignore: 2.3.0(eslint@9.39.4(jiti@2.7.0))
+      eslint-flat-config-utils: 3.1.0
+      eslint-merge-processors: 2.0.0(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-antfu: 3.2.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-command: 3.5.2(@typescript-eslint/rule-tester@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.59.0(typescript@5.9.3))(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import-lite: 0.5.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-jsdoc: 62.9.0(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-jsonc: 3.1.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-no-only-tests: 3.3.0
+      eslint-plugin-perfectionist: 5.8.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-pnpm: 1.6.0(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-regexp: 3.1.0(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-toml: 1.3.1(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-unicorn: 63.0.0(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-vue: 10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.7.0)))(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.7.0)))
       eslint-plugin-yml: 3.3.1(eslint@9.39.4(jiti@2.7.0))
       eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.27)(eslint@9.39.4(jiti@2.7.0))
@@ -22180,7 +22236,7 @@ snapshots:
 
   '@wisemen/eslint-config-vue@2.1.3(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(jsonc-eslint-parser@3.1.0)(oxlint@1.59.0(oxlint-tsgolint@0.20.0))(tailwindcss@4.1.18)(typescript@5.9.3)(vitest@4.1.0)(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.7.0)))(yaml-eslint-parser@2.0.0)':
     dependencies:
-      '@antfu/eslint-config': 7.7.0(@typescript-eslint/rule-tester@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.59.0(typescript@5.9.3))(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.27)(eslint-plugin-format@1.3.1(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-vuejs-accessibility@2.4.1(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(oxlint@1.59.0(oxlint-tsgolint@0.20.0))(typescript@5.9.3)(vitest@4.1.0)
+      '@antfu/eslint-config': 7.7.0(eslint-plugin-format@1.3.1(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-vuejs-accessibility@2.4.1(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(oxlint@1.59.0(oxlint-tsgolint@0.20.0))(typescript@5.9.3)(vitest@4.1.0)
       '@eslint/eslintrc': 3.3.3
       '@intlify/eslint-plugin-vue-i18n': 4.1.1(eslint@9.39.4(jiti@2.7.0))(jsonc-eslint-parser@3.1.0)(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.7.0)))(yaml-eslint-parser@2.0.0)
       '@typescript-eslint/parser': 8.53.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -22294,7 +22350,7 @@ snapshots:
 
   '@wisemen/eslint-config-vue@2.1.3(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(jsonc-eslint-parser@3.1.0)(oxlint@1.59.0(oxlint-tsgolint@0.20.0))(tailwindcss@4.1.18)(typescript@5.9.3)(vitest@4.1.0)(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.7.0)))(yaml-eslint-parser@2.0.0)':
     dependencies:
-      '@antfu/eslint-config': 7.7.0(@typescript-eslint/rule-tester@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.59.0(typescript@5.9.3))(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.27)(eslint-plugin-format@1.3.1(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-vuejs-accessibility@2.4.1(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(oxlint@1.59.0(oxlint-tsgolint@0.20.0))(typescript@5.9.3)(vitest@4.1.0)
+      '@antfu/eslint-config': 7.7.0(eslint-plugin-format@1.3.1(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-vuejs-accessibility@2.4.1(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(oxlint@1.59.0(oxlint-tsgolint@0.20.0))(typescript@5.9.3)(vitest@4.1.0)
       '@eslint/eslintrc': 3.3.3
       '@intlify/eslint-plugin-vue-i18n': 4.1.1(eslint@9.39.4(jiti@2.7.0))(jsonc-eslint-parser@3.1.0)(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.7.0)))(yaml-eslint-parser@2.0.0)
       '@typescript-eslint/parser': 8.53.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -26191,7 +26247,7 @@ snapshots:
 
   node-mock-http@1.0.4: {}
 
-  node-plop@0.32.3(@types/node@24.8.1):
+  node-plop@0.32.3(patch_hash=e5204bc75fb37e07ce203c6bc6c017165201f3b433483df79faa1ede18e2a9fa)(@types/node@24.8.1):
     dependencies:
       '@types/inquirer': 9.0.10
       '@types/picomatch': 4.0.3
@@ -26765,7 +26821,7 @@ snapshots:
       interpret: 3.1.1
       liftoff: 5.0.1
       nanospinner: 1.2.2
-      node-plop: 0.32.3(@types/node@24.8.1)
+      node-plop: 0.32.3(patch_hash=e5204bc75fb37e07ce203c6bc6c017165201f3b433483df79faa1ede18e2a9fa)(@types/node@24.8.1)
       picocolors: 1.1.1
       v8flags: 4.0.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -427,3 +427,6 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - '@hey-api/openapi-ts@0.97.3'
+
+patchedDependencies:
+  node-plop: patches/node-plop.patch


### PR DESCRIPTION
Problem
@wisemen/ngen's CLI (built on Plop) only worked through live inquirer prompts. Anything without a TTY — an agent, a CI job, a script — would either hang waiting for input or crash (ERR_USE_AFTER_CLOSE) the moment stdin wasn't a real terminal, with no supported way to supply answers up front.

What was investigated
Plop already ships a bypass mechanism (plop <generator> --flag=value ...) that resolves prompt answers by name instead of asking interactively. Testing it against every generator in this plopfile found it already covers most cases — but two bugs in node-plop@0.32.3 blocked full coverage:

Dynamic choices never resolved. Prompts whose choices is a function (job's queue, translations' languages) crashed bypass matching with prompt.choices.find/some is not a function — the bypass code called array methods on the function itself instead of calling it first.
Any conditional (when) prompt was refused outright, regardless of whether it would actually apply — blocking the module / useCase generator's custom use-case flow entirely (You can not bypass conditional prompts: custom).
Fix
patches/node-plop.patch (applied via pnpm patch / patchedDependencies in pnpm-workspace.yaml, no fork needed): resolves dynamic choices before bypass matching, and evaluates each conditional prompt's when against answers gathered so far instead of blanket-refusing it. ngen's own code (main.ts) is untouched — the fix lives entirely at the dependency level.
templates/use-case/custom/custom-controller.hbs: added an explicit public modifier to the generated controller method. Unrelated bug found while testing the custom flow — three ts-morph manipulators (addControllerHttpMethod/addControllerResponse/addControllerCommand) require the literal public keyword to locate the method, which this template lacked, so the custom flow threw regardless of interactive/non-interactive use.
All 6 skills/*/SKILL.md updated with a "Non-interactive (agent) usage" section per generator, giving the exact working bypass command — every example was run against the built CLI and verified to exit 0.