### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/add-auth-login-controls.md
+++ b/.bumpy/add-auth-login-controls.md
@@ -1,5 +1,0 @@
----
-"@wisemen/payload-core-auth": minor
----
-
-Added support for blocking logins with a custom error, disabling first-user creation, naming Zitadel authentication strategies, and provisioning users after selected operations.

--- a/.bumpy/rich-tall-reef.md
+++ b/.bumpy/rich-tall-reef.md
@@ -1,5 +1,0 @@
----
-"@wisemen/scoped-filter": patch
----
-
-Add missing @Type() in NumberFilter

--- a/packages/api/scoped-filter/CHANGELOG.md
+++ b/packages/api/scoped-filter/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 1.0.2
+<sub>2026-07-14</sub>
+
+- [#1426](https://github.com/wisemen-digital/wisemen-core/pull/1426)  *(patch)* Thanks [@YuHangHuu](https://github.com/YuHangHuu)! - Add missing @Type() in NumberFilter
+
 ## 1.0.1
 <sub>2026-07-13</sub>
 

--- a/packages/api/scoped-filter/package.json
+++ b/packages/api/scoped-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/scoped-filter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/payload/auth/CHANGELOG.md
+++ b/packages/payload/auth/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 0.1.0
+<sub>2026-07-14</sub>
+
+- [#1420](https://github.com/wisemen-digital/wisemen-core/pull/1420)  *(minor)* Thanks [@Robbe95](https://github.com/Robbe95)! - Added support for blocking logins with a custom error, disabling first-user creation, naming Zitadel authentication strategies, and provisioning users after selected operations.
+
 ## 0.0.3
 <sub>2026-07-13</sub>
 

--- a/packages/payload/auth/package.json
+++ b/packages/payload/auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wisemen/payload-core-auth",
   "type": "module",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "private": false,
   "imports": {
     "#*": "./src/*"


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/payload-core-auth` 0.0.3 → **0.1.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1428/changes#diff-619e8be260db96f79e37d386f4ece52dee63e19017843bc42d3d3502d2ae63fb)</sub>

- Added support for blocking logins with a custom error, disabling first-user creation, naming Zitadel authentication strategies, and provisioning users after selected operations. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1428/changes#diff-85198c88df59e100cfc26c21c969eea43d1d2597f14f7ae65276de5beb3ce72b))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/scoped-filter` 1.0.1 → **1.0.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1428/changes#diff-e237bf1a849d4de86c426bf169d71c2e8790161bedaecc1e3b0a19f07e934fee)</sub>

- Add missing @Type() in NumberFilter ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1428/changes#diff-dd39f15e3da720aad545b6c61da03444db159dc52231be4d6f0b2d08cbe34ded))
