### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/soft-rusty-deer.md
+++ b/.bumpy/soft-rusty-deer.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Invert check for missing type in `mainSidebarNavigationLink`

--- a/.bumpy/soft-shy-ibis.md
+++ b/.bumpy/soft-shy-ibis.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Hide the overlfow-x in the main sidebar

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -20,6 +20,13 @@
 
 
 
+
+## 1.14.1
+<sub>2026-07-14</sub>
+
+- [#1431](https://github.com/wisemen-digital/wisemen-core/pull/1431)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Hide the overlfow-x in the main sidebar
+- [#1431](https://github.com/wisemen-digital/wisemen-core/pull/1431)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Invert check for missing type in `mainSidebarNavigationLink`
+
 ## 1.14.0
 <sub>2026-07-14</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/vue-core-design-system` 1.14.0 → **1.14.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1432/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Hide the overlfow-x in the main sidebar ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1432/changes#diff-1aeffead661e054846139450d22a32704512015117f1f00602d8991be611fb3d))
- Invert check for missing type in `mainSidebarNavigationLink` ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1432/changes#diff-79e87853352b275783c4fb9efa54eee7d93212d86f0fe66ab7e3b9154e58580c))
