### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/dark-vast-mist.md
+++ b/.bumpy/dark-vast-mist.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-tests": patch
----
-
-feat: support `readonly` in stubbed datasource

--- a/packages/api/nestjs-tests/CHANGELOG.md
+++ b/packages/api/nestjs-tests/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 
 
+
+## 0.0.7
+<sub>2026-07-15</sub>
+
+- [#1437](https://github.com/wisemen-digital/wisemen-core/pull/1437)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - feat: support `readonly` in stubbed datasource
+
 ## 0.0.6
 <sub>2026-07-13</sub>
 

--- a/packages/api/nestjs-tests/package.json
+++ b/packages/api/nestjs-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-tests",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/nestjs-tests` 0.0.6 → **0.0.7** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1438/changes#diff-cd49adf6cb6497c7b30da8022479f43cbf78b5bde6f0907ee35be7084266e144)</sub>

- feat: support `readonly` in stubbed datasource ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1438/changes#diff-b83e0c46484c7565df5740f0d858b5e868199c0747fdeaa05060543dee971aec))
