### PR TITLE
feat(web-e2e): add @wisemen/web-e2e Playwright testing toolkit

### DIFF
--- a/.bumpy/web-e2e-initial.md
+++ b/.bumpy/web-e2e-initial.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/web-e2e": minor
+---
+
+Add `@wisemen/web-e2e`: a Playwright end-to-end testing toolkit providing a fixture factory (`createTest`), semantic page objects (form, table, dialog, pagination, toast, state, tabs, breadcrumbs, search/filter, bulk actions, multi-step forms, map), MSW mocking helpers (`CrudHandlerFactory` and JSON:API error-response builders), a fluent `BuilderBase`, OIDC auth setup, and a Playwright `defineConfig` helper.

--- a/packages/web/e2e/README.md
+++ b/packages/web/e2e/README.md
@@ -1,0 +1,170 @@
+# @wisemen/web-e2e
+
+Playwright end-to-end testing toolkit for Wisemen web apps. It provides a ready-to-extend test fixture, semantic page objects, MSW mocking helpers, fluent DTO/error builders, and a Playwright config helper — so every app writes E2E tests the same way instead of re-inventing utilities.
+
+## What's included
+
+- **Fixture factory** — `createTest()` wires up MSW (`playwright-msw`), a role-based permission context, WebSocket mocking, Istanbul coverage collection, accessibility scanning, and console-error monitoring.
+- **Page objects** — `FormTestUtil`, `TableTestUtil`, `DialogTestUtil`, `TestUtil`, `PaginationTestUtil`, `ToastTestUtil`, `StateTestUtil`, `BreadcrumbTestUtil`, `TabTestUtil`, `SearchFilterUtil`, `BulkActionsUtil`, `MultiStepFormUtil`, `MapTestUtil`.
+- **Mocking** — `CrudHandlerFactory` for standard REST endpoints and error-response builders (`BadRequestBuilder`, `UnauthorizedBuilder`, `ForbiddenBuilder`, `NotFoundBuilder`, `ConflictBuilder`, `ServerErrorBuilder`) that emit the JSON:API error shape used across Wisemen APIs.
+- **Builders** — `BuilderBase` for fluent, defaulted test-data builders.
+- **Auth** — `createAuthSetup()` for OIDC storage-state setup.
+- **Config** — `defineConfig()` (via `@wisemen/web-e2e/config`) wrapping Playwright's config with sensible defaults.
+
+## Installation
+
+```bash
+pnpm add -D @wisemen/web-e2e @playwright/test msw playwright-msw @axe-core/playwright
+```
+
+`@playwright/test`, `msw`, `playwright-msw`, and `@axe-core/playwright` are peer dependencies — install them in the consuming app.
+
+## Quick start
+
+### 1. `playwright.config.ts`
+
+```ts
+import { defineConfig } from '@wisemen/web-e2e/config'
+
+export default defineConfig({
+  port: 4000,
+  testMatch: 'src/modules/**/tests/*.e2e.spec.ts',
+  auth: {
+    enabled: true,
+    storageStatePath: 'tests/.auth/user.json',
+  },
+  testing: {
+    accessibility: true,
+    consoleMonitoring: true,
+  },
+  retries: process.env.CI != null ? 2 : 0,
+})
+```
+
+### 2. `tests/fixture/base.fixture.ts`
+
+Create a project-local fixture that extends the package with your app's handlers and permission type:
+
+```ts
+import { createTest } from '@wisemen/web-e2e'
+
+import type { PermissionType } from '@/composables/permission-guard/permissionGuard.composable'
+import { authHandlers } from '@/mocks/handlers/auth.mock'
+
+export const test = createTest<PermissionType>({
+  defaultPermissions: ['resource.read'],
+  handlers: [...authHandlers],
+  websocketUrlPattern: 'wss://api.base.url/websockets*',
+})
+
+export { expect } from '@wisemen/web-e2e'
+```
+
+### 3. A test
+
+```ts
+import { expect, test } from '@tests/fixture/base.fixture'
+import { FormTestUtil, TableTestUtil, TestUtil } from '@wisemen/web-e2e'
+
+import { UserDtoBuilder } from '@/modules/user/models/userDto.builder'
+import { MockHandlerFactory } from '@tests/utils/mockHandler.factory'
+
+test.describe('User create', () => {
+  test.use({ userPermissions: ['user.read', 'user.create'] })
+
+  test('creates a user', async ({ page, worker }) => {
+    const user = new UserDtoBuilder().withName('Jane').build()
+
+    await worker.use(
+      MockHandlerFactory.user.getIndex([]),
+      MockHandlerFactory.user.create(user),
+    )
+
+    await page.goto('/admin/users')
+    await page.getByRole('button', { name: 'Create' }).click()
+
+    const dialog = new TestUtil(page).getActiveDialog()
+    const form = new FormTestUtil(page, dialog.locator('form'))
+
+    await form.getTextFieldByLabel('Name').fill('Jane')
+    await form.submit()
+
+    await expect(page.getByRole('alert')).toContainText('created')
+  })
+})
+```
+
+## Mocking
+
+### `CrudHandlerFactory`
+
+```ts
+import { CrudHandlerFactory } from '@wisemen/web-e2e'
+
+const users = new CrudHandlerFactory<UserDto>({ endpoint: 'users' })
+
+await worker.use(
+  users.getIndex([user1, user2]), // GET    */api/v1/users (paginated)
+  users.getDetail(user1),         // GET    */api/v1/users/:uuid
+  users.create({ uuid }),         // POST   */api/v1/users        -> 201
+  users.update(updatedUser),      // PATCH  */api/v1/users/:uuid
+  users.delete(),                 // DELETE */api/v1/users/*       -> 204
+)
+```
+
+### Error responses
+
+Builders emit `{ errors: [{ code, detail, status, source?: { pointer } }] }`:
+
+```ts
+import { BadRequestBuilder, ForbiddenBuilder } from '@wisemen/web-e2e'
+import { http } from 'msw'
+
+await worker.use(
+  http.post('*/api/v1/users', () =>
+    new BadRequestBuilder()
+      .withFieldError('email', 'Email already exists')
+      .build()),
+)
+
+await worker.use(
+  http.get('*/api/v1/users', () =>
+    new ForbiddenBuilder().withMessage('You do not have permission').build()),
+)
+```
+
+## Test data — `BuilderBase`
+
+```ts
+import { BuilderBase } from '@wisemen/web-e2e'
+
+export class UserDtoBuilder extends BuilderBase<UserDto> {
+  constructor(initial?: Partial<UserDto>) {
+    super({
+      uuid: BuilderBase.randomUuid(),
+      name: 'John Doe',
+      email: 'john@example.com',
+      ...initial,
+    })
+  }
+
+  withName(name: string): this {
+    this.value.name = name
+
+    return this
+  }
+}
+```
+
+## Locator strategy
+
+Page objects use semantic, role-based locators (`getByRole`, `getByLabel`). Write accessible markup and prefer role/label/text selectors over CSS, `data-testid`, or XPath.
+
+## Building
+
+```bash
+pnpm build       # bundle with tsdown (esm) -> dist/
+pnpm type-check
+pnpm lint
+pnpm test
+```

--- a/packages/web/e2e/eslint.config.ts
+++ b/packages/web/e2e/eslint.config.ts
@@ -1,0 +1,7 @@
+import { packageConfig } from '@wisemen/eslint-config-vue'
+
+export default [
+  ...(await packageConfig({
+    tailwindDisabled: true,
+  })),
+]

--- a/packages/web/e2e/package.json
+++ b/packages/web/e2e/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@wisemen/web-e2e",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "version": "0.0.0",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wisemen-digital/wisemen-core",
+    "directory": "packages/web/e2e"
+  },
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    },
+    "./config": {
+      "types": "./dist/config/index.d.mts",
+      "import": "./dist/config/index.mjs"
+    }
+  },
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "typings": "./dist/index.d.mts",
+  "keywords": [
+    "playwright",
+    "e2e",
+    "testing",
+    "msw",
+    "page-objects"
+  ],
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "pub:release": "pnpm publish --access public",
+    "pub:beta": "pnpm publish --no-git-checks --access public --tag beta",
+    "pub:next": "pnpm publish --no-git-checks --access public --tag next",
+    "cleanup": "rimraf dist/ node_modules/ .turbo/",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest --run",
+    "type-check": "pnpm tsc"
+  },
+  "peerDependencies": {
+    "@axe-core/playwright": "catalog:peer",
+    "@playwright/test": "catalog:peer",
+    "msw": "catalog:peer",
+    "playwright-msw": "catalog:peer"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "catalog:test",
+    "@playwright/test": "catalog:test",
+    "@types/node": "catalog:types",
+    "@wisemen/eslint-config-vue": "workspace:*",
+    "eslint": "catalog:lint-web",
+    "msw": "catalog:test",
+    "playwright-msw": "catalog:test",
+    "tsdown": "catalog:build",
+    "typescript": "catalog:build",
+    "vitest": "catalog:test"
+  }
+}

--- a/packages/web/e2e/src/auth/createAuthSetup.ts
+++ b/packages/web/e2e/src/auth/createAuthSetup.ts
@@ -1,0 +1,93 @@
+import type { Page } from '@playwright/test'
+
+import { FormTestUtil } from '@/page-objects/form.page-object'
+
+export interface AuthSetupOptions {
+  /** OIDC authorize URL pattern to intercept (e.g., 'https://test-oidc.example.com/oauth/v2/authorize**') */
+  authorizeUrlPattern: string
+  /** Callback URL base (e.g., 'http://localhost:4000/auth/callback') */
+  callbackUrl: string
+  /** Login page URL (default: '/auth/login') */
+  loginUrl?: string
+  /**
+   * Custom login steps. Called after navigating to the login page.
+   * The FormTestUtil is scoped to the page's form.
+   */
+  performLogin: (page: Page, form: FormTestUtil) => Promise<void>
+  /** Path to save storage state (e.g., 'tests/.auth/user.json') */
+  storageStatePath: string
+  /**
+   * Optional assertion after auth completes.
+   * Called after storage state is saved.
+   */
+  verifyAuth?: (page: Page) => Promise<void>
+}
+
+/**
+ * Creates a reusable authentication function for Playwright e2e tests.
+ *
+ * The factory handles the OIDC redirect interception and storage state saving,
+ * while you provide the app-specific login steps (filling forms, submitting, etc.)
+ *
+ * @example
+ * ```ts
+ * const authenticate = createAuthSetup({
+ *   authorizeUrlPattern: 'https://test-oidc.example.com/oauth/v2/authorize**',
+ *   callbackUrl: 'http://localhost:4000/auth/callback',
+ *   storageStatePath: 'tests/.auth/user.json',
+ *   performLogin: async (page, form) => {
+ *     const username = form.getTextFieldByLabel('Username')
+ *     await username.fill('test@example.com')
+ *     await form.submit()
+ *   },
+ * })
+ *
+ * test('authenticate', async ({ page }) => {
+ *   await authenticate(page)
+ * })
+ * ```
+ */
+export function createAuthSetup(options: AuthSetupOptions): (page: Page) => Promise<void> {
+  const {
+    authorizeUrlPattern,
+    callbackUrl,
+    loginUrl = '/auth/login',
+    performLogin,
+    storageStatePath,
+    verifyAuth,
+  } = options
+
+  return async (page: Page): Promise<void> => {
+    // 1. Intercept OIDC authorize endpoint and redirect with a mock authorization code
+    await page.route(authorizeUrlPattern, async (route) => {
+      const url = new URL(route.request().url())
+      const state = url.searchParams.get('state')
+
+      await route.fulfill({
+        body: '',
+        headers: {
+          location: `${callbackUrl}?code=${crypto.randomUUID()}&state=${state}`,
+        },
+        status: 302,
+      })
+    })
+
+    // 2. Navigate to the login page
+    await page.goto(loginUrl)
+
+    // 3. Run the app-specific login steps
+    const form = new FormTestUtil(page)
+
+    await performLogin(page, form)
+
+    // 4. Save the browser's storage state (cookies, localStorage, etc.)
+    await page.context().storageState({
+      path: storageStatePath,
+    })
+
+    // 5. Optionally verify the auth was successful
+    if (verifyAuth != null) {
+      await verifyAuth(page)
+    }
+  }
+}

--- a/packages/web/e2e/src/builders/builderBase.test.ts
+++ b/packages/web/e2e/src/builders/builderBase.test.ts
@@ -1,0 +1,98 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+import { BuilderBase } from '@/builders/builderBase'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+interface Widget {
+  uuid: string
+  name: string
+  tags: string[]
+}
+
+class WidgetBuilder extends BuilderBase<Widget> {
+  constructor(initial?: Partial<Widget>) {
+    super({
+      uuid: BuilderBase.randomUuid(),
+      name: 'Default',
+      tags: [],
+      ...initial,
+    })
+  }
+
+  withName(name: string): this {
+    this.value.name = name
+
+    return this
+  }
+
+  withTags(tags: string[]): this {
+    this.value.tags = tags
+
+    return this
+  }
+}
+
+describe('builderBase', () => {
+  it('builds an object with the seeded defaults', () => {
+    const widget = new WidgetBuilder().build()
+
+    expect(widget.name).toBe('Default')
+    expect(widget.tags).toEqual([])
+    expect(widget.uuid).toMatch(UUID_REGEX)
+  })
+
+  it('applies chained with* overrides', () => {
+    const widget = new WidgetBuilder()
+      .withName('Renamed')
+      .withTags([
+        'a',
+        'b',
+      ])
+      .build()
+
+    expect(widget.name).toBe('Renamed')
+    expect(widget.tags).toEqual([
+      'a',
+      'b',
+    ])
+  })
+
+  it('returns a deep clone so later mutation does not leak into built objects', () => {
+    const builder = new WidgetBuilder().withTags([
+      'a',
+    ])
+    const first = builder.build()
+
+    builder.withTags([
+      'a',
+      'b',
+    ])
+
+    const second = builder.build()
+
+    expect(first.tags).toEqual([
+      'a',
+    ])
+    expect(second.tags).toEqual([
+      'a',
+      'b',
+    ])
+  })
+
+  it('honours the initial partial passed to the constructor', () => {
+    const widget = new WidgetBuilder({
+      name: 'Seeded',
+    }).build()
+
+    expect(widget.name).toBe('Seeded')
+  })
+
+  it('generates unique uuids', () => {
+    expect(BuilderBase.randomUuid()).not.toBe(BuilderBase.randomUuid())
+  })
+})

--- a/packages/web/e2e/src/builders/builderBase.ts
+++ b/packages/web/e2e/src/builders/builderBase.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from 'node:crypto'
+
+/**
+ * Abstract fluent builder base for constructing test data objects.
+ *
+ * Subclasses seed the initial value in their constructor and expose
+ * chainable `with*` methods that mutate `this.value` and return `this`.
+ *
+ * @example
+ * ```ts
+ * class UserDtoBuilder extends BuilderBase<UserDto> {
+ *   constructor(initial?: Partial<UserDto>) {
+ *     super({ uuid: BuilderBase.randomUuid(), name: 'John', ...initial })
+ *   }
+ *   withName(name: string): this { this.value.name = name; return this }
+ * }
+ * ```
+ */
+export abstract class BuilderBase<T> {
+  protected value: T
+
+  constructor(initial: T) {
+    this.value = initial
+  }
+
+  /**
+   * Generate a random UUID, typically used to seed identifier fields.
+   */
+  static randomUuid(): string {
+    return randomUUID()
+  }
+
+  /**
+   * Return a deep clone of the current value so callers cannot mutate
+   * the builder's internal state after building.
+   */
+  build(): T {
+    return structuredClone(this.value)
+  }
+}

--- a/packages/web/e2e/src/config/defineConfig.ts
+++ b/packages/web/e2e/src/config/defineConfig.ts
@@ -1,0 +1,150 @@
+import type { PlaywrightTestConfig } from '@playwright/test'
+import {
+  defineConfig as definePlaywrightConfig,
+  devices,
+} from '@playwright/test'
+
+const DEFAULT_PORT = 4000
+const DEFAULT_TEST_MATCH = 'src/modules/**/tests/*.e2e.spec.ts'
+
+/**
+ * Options for {@link defineConfig}, the typed wrapper around Playwright's own
+ * `defineConfig`.
+ */
+export interface WebE2eConfigOptions {
+  /**
+   * Authentication project wiring. When both `enabled` is `true` and
+   * `storageStatePath` is provided, a dedicated `'setup'` project runs first
+   * (matching `setupMatch`, default `'**\/*.setup.ts'`) and the `'chromium'`
+   * project depends on it while reusing the saved storage state. Otherwise a
+   * single `'chromium'` project is emitted.
+   */
+  auth?: {
+    enabled?: boolean
+    setupMatch?: string
+    storageStatePath?: string
+  }
+  /** Port the app runs on. Used to build `use.baseURL`. Default: `4000`. */
+  port?: number
+  /** Number of retries for failing tests. Default: `0`. */
+  retries?: number
+  /** Directory that contains the test files. Passed through to Playwright. */
+  testDir?: string
+  /**
+   * Testing feature toggles. Attached to the returned config's `metadata`
+   * under `webE2e` so consumers and fixtures can read them at runtime, e.g.
+   * `metadata: { webE2e: { accessibility, consoleMonitoring, coverage } }`.
+   */
+  testing?: {
+    accessibility?: boolean
+    consoleMonitoring?: boolean
+    coverage?: boolean
+  }
+  /** Glob(s) matching test files. Default targets `*.e2e.spec.ts` under `src/modules/{module}/tests`. */
+  testMatch?: string | string[]
+  /** Playwright `use` options, shallow-merged over the defaults (`baseURL`, `trace`). */
+  use?: PlaywrightTestConfig['use']
+  /** Playwright web server configuration. Passed through unchanged. */
+  webServer?: PlaywrightTestConfig['webServer']
+  /** Number of parallel workers. Passed through unchanged. */
+  workers?: number
+}
+
+/**
+ * Typed wrapper around Playwright's `defineConfig` with sensible defaults for
+ * web e2e suites (parallel execution, list + html reporters, a localhost
+ * `baseURL`, and an optional auth setup project).
+ *
+ * @example
+ * ```ts
+ * import { defineConfig } from '@wisemen/web-e2e/config'
+ *
+ * export default defineConfig({
+ *   port: 4000,
+ *   auth: {
+ *     enabled: true,
+ *     storageStatePath: 'tests/.auth/user.json',
+ *   },
+ *   webServer: {
+ *     command: 'pnpm preview',
+ *     url: 'http://localhost:4000',
+ *     reuseExistingServer: !process.env.CI,
+ *   },
+ * })
+ * ```
+ */
+export function defineConfig(options: WebE2eConfigOptions = {}): PlaywrightTestConfig {
+  const {
+    auth,
+    port = DEFAULT_PORT,
+    retries = 0,
+    testDir,
+    testing,
+    testMatch = DEFAULT_TEST_MATCH,
+    use,
+    webServer,
+    workers,
+  } = options
+
+  const baseURL = `http://localhost:${port}`
+
+  const projects: NonNullable<PlaywrightTestConfig['projects']> = []
+
+  if (auth?.enabled === true && auth.storageStatePath !== undefined) {
+    projects.push({
+      name: 'setup',
+      testMatch: auth.setupMatch ?? '**/*.setup.ts',
+    })
+    projects.push({
+      name: 'chromium',
+      dependencies: [
+        'setup',
+      ],
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: auth.storageStatePath,
+      },
+    })
+  }
+  else {
+    projects.push({
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    })
+  }
+
+  return definePlaywrightConfig({
+    fullyParallel: true,
+    metadata: {
+      webE2e: {
+        accessibility: testing?.accessibility ?? true,
+        consoleMonitoring: testing?.consoleMonitoring ?? true,
+        coverage: testing?.coverage ?? false,
+      },
+    },
+    projects,
+    reporter: [
+      [
+        'list',
+      ],
+      [
+        'html',
+        {
+          open: 'never',
+        },
+      ],
+    ],
+    retries,
+    testDir,
+    testMatch,
+    use: {
+      baseURL,
+      trace: 'on-first-retry',
+      ...use,
+    },
+    webServer,
+    workers,
+  })
+}

--- a/packages/web/e2e/src/config/index.ts
+++ b/packages/web/e2e/src/config/index.ts
@@ -1,0 +1,2 @@
+export type { WebE2eConfigOptions } from '@/config/defineConfig'
+export { defineConfig } from '@/config/defineConfig'

--- a/packages/web/e2e/src/fixtures/createTest.ts
+++ b/packages/web/e2e/src/fixtures/createTest.ts
@@ -1,0 +1,81 @@
+import { test as base } from '@playwright/test'
+import { http } from 'msw'
+import type { MockServiceWorker } from 'playwright-msw'
+import { createWorkerFixture } from 'playwright-msw'
+
+import { runAccessibilityCheck } from '@/utils/a11y.util'
+import { setupConsoleMonitoring } from '@/utils/console.util'
+import { setupContextWithCoverage } from '@/utils/coverage.util'
+import { permissionContext } from '@/utils/permissionContext.util'
+import { setupWebSocketMock } from '@/utils/websocket.util'
+
+export interface CreateTestOptions<T extends string = string> {
+  /** Default permissions for all tests (can be overridden per-test with test.use) */
+  defaultPermissions?: T[]
+  /** Warnings to exclude from console monitoring (in addition to the built-in defaults). Default: [] */
+  excludedConsoleWarnings?: string[]
+  /** Whether console errors should fail the test. Default: true */
+  failOnConsoleError?: boolean
+  /** MSW request handlers (auth, API mocks, etc.) */
+  handlers: Parameters<typeof createWorkerFixture>[0]
+  /** WebSocket URL pattern to mock (default: 'wss://&#42;/websockets&#42;') */
+  websocketUrlPattern?: string
+}
+
+export interface BaseTestFixtures<T extends string = string> {
+  http: typeof http
+  userPermissions: T[]
+  worker: MockServiceWorker
+}
+
+export function createTest<T extends string = string>(options: CreateTestOptions<T>) {
+  const {
+    defaultPermissions = [],
+    excludedConsoleWarnings = [],
+    failOnConsoleError = true,
+    handlers,
+    websocketUrlPattern,
+  } = options
+
+  return base.extend<BaseTestFixtures<T>>({
+    context: async ({
+      context,
+    }, use) => {
+      const coverage = await setupContextWithCoverage(context)
+
+      await use(context)
+      await coverage.cleanup()
+    },
+    http,
+    page: async ({
+      page, userPermissions,
+    }, use, testInfo) => {
+      const consoleMonitoring = setupConsoleMonitoring(page, {
+        excludedWarnings: excludedConsoleWarnings,
+        failOnError: failOnConsoleError,
+      })
+
+      permissionContext.setPermissions(userPermissions)
+
+      await page.addInitScript((permissions) => {
+        (window as any).__TEST_PERMISSIONS__ = permissions
+      }, userPermissions)
+
+      await setupWebSocketMock(page, websocketUrlPattern)
+      await use(page)
+      await runAccessibilityCheck(page, testInfo)
+
+      permissionContext.clearPermissions()
+      consoleMonitoring.validate()
+    },
+    userPermissions: [
+      async ({}, use): Promise<void> => {
+        await use(defaultPermissions)
+      },
+      {
+        option: true,
+      },
+    ],
+    worker: createWorkerFixture(handlers),
+  })
+}

--- a/packages/web/e2e/src/index.ts
+++ b/packages/web/e2e/src/index.ts
@@ -1,0 +1,59 @@
+// Re-export Playwright's assertion entrypoint so consumers import it from one place.
+export { expect } from '@playwright/test'
+
+// Auth
+export type { AuthSetupOptions } from '@/auth/createAuthSetup'
+export { createAuthSetup } from '@/auth/createAuthSetup'
+
+// Builders
+export { BuilderBase } from '@/builders/builderBase'
+
+// Fixtures
+export type {
+  BaseTestFixtures,
+  CreateTestOptions,
+} from '@/fixtures/createTest'
+export { createTest } from '@/fixtures/createTest'
+
+// Mocking — CRUD handler factory
+export type { CrudHandlerFactoryOptions } from '@/mocking/crudHandlerFactory'
+export { CrudHandlerFactory } from '@/mocking/crudHandlerFactory'
+
+// Mocking — error response builders
+export type {
+  ApiErrorObject,
+  ApiExpectedError,
+} from '@/mocking/errors/apiError.builder'
+export { ApiErrorBuilder } from '@/mocking/errors/apiError.builder'
+export { BadRequestBuilder } from '@/mocking/errors/badRequest.builder'
+export { ConflictBuilder } from '@/mocking/errors/conflict.builder'
+export { ForbiddenBuilder } from '@/mocking/errors/forbidden.builder'
+export { NotFoundBuilder } from '@/mocking/errors/notFound.builder'
+export { ServerErrorBuilder } from '@/mocking/errors/serverError.builder'
+export { UnauthorizedBuilder } from '@/mocking/errors/unauthorized.builder'
+
+// Page objects
+export { BreadcrumbTestUtil } from '@/page-objects/breadcrumb.page-object'
+export { BulkActionsUtil } from '@/page-objects/bulkActions.page-object'
+export { DialogTestUtil } from '@/page-objects/dialog.page-object'
+export { FormTestUtil } from '@/page-objects/form.page-object'
+export { MapTestUtil } from '@/page-objects/map.page-object'
+export { MultiStepFormUtil } from '@/page-objects/multiStepForm.page-object'
+export { PaginationTestUtil } from '@/page-objects/pagination.page-object'
+export { SearchFilterUtil } from '@/page-objects/searchFilter.page-object'
+export { StateTestUtil } from '@/page-objects/state.page-object'
+export { TabTestUtil } from '@/page-objects/tab.page-object'
+export { TableTestUtil } from '@/page-objects/table.page-object'
+export { TestUtil } from '@/page-objects/testUtil.page-object'
+export { ToastTestUtil } from '@/page-objects/toast.page-object'
+
+// Utils
+export { runAccessibilityCheck } from '@/utils/a11y.util'
+export type { ConsoleMonitoringOptions } from '@/utils/console.util'
+export { setupConsoleMonitoring } from '@/utils/console.util'
+export { setupContextWithCoverage } from '@/utils/coverage.util'
+export {
+  PermissionContext,
+  permissionContext,
+} from '@/utils/permissionContext.util'
+export { setupWebSocketMock } from '@/utils/websocket.util'

--- a/packages/web/e2e/src/mocking/crudHandlerFactory.ts
+++ b/packages/web/e2e/src/mocking/crudHandlerFactory.ts
@@ -1,0 +1,120 @@
+import type { HttpHandler } from 'msw'
+import {
+  http,
+  HttpResponse,
+} from 'msw'
+
+import { PaginationTestUtil } from '@/page-objects/pagination.page-object'
+
+/**
+ * Configuration for a {@link CrudHandlerFactory}.
+ */
+export interface CrudHandlerFactoryOptions {
+  /** The base URL prefix. Defaults to a wildcard host with the `/api/v1` path. */
+  baseUrl?: string
+  /** The collection endpoint, e.g. `'users'`. */
+  endpoint: string
+  /** The pagination shape used by `getIndex`. Defaults to `'offset'`. */
+  paginationType?: 'keyset' | 'offset'
+}
+
+/**
+ * Factory that produces MSW handlers for the standard CRUD endpoints of a
+ * single resource collection.
+ *
+ * @example
+ * ```ts
+ * const factory = new CrudHandlerFactory<UserDto>({ endpoint: 'users' })
+ * const handlers = [
+ *   factory.getIndex([user]),
+ *   factory.getDetail(user),
+ * ]
+ * ```
+ */
+export class CrudHandlerFactory<T extends Record<string, unknown>> {
+  private readonly baseUrl: string
+  private readonly endpoint: string
+  private readonly paginationType: 'keyset' | 'offset'
+
+  constructor(options: CrudHandlerFactoryOptions) {
+    this.endpoint = options.endpoint
+    this.baseUrl = options.baseUrl ?? '*/api/v1'
+    this.paginationType = options.paginationType ?? 'offset'
+  }
+
+  /**
+   * Build the collection path, joining the base URL and endpoint,
+   * e.g. the `users` endpoint under the default base URL.
+   */
+  private collectionPath(): string {
+    return `${this.baseUrl}/${this.endpoint}`
+  }
+
+  /**
+   * Build the resource path. Uses the object's `uuid` when present,
+   * otherwise falls back to a wildcard segment.
+   */
+  private resourcePath(data: T): string {
+    const uuid = typeof data.uuid === 'string' ? data.uuid : null
+
+    if (uuid !== null) {
+      return `${this.baseUrl}/${this.endpoint}/${uuid}`
+    }
+
+    return `${this.baseUrl}/${this.endpoint}/*`
+  }
+
+  /**
+   * POST to the collection, returning `response` with a `201` status.
+   */
+  create(response: Record<string, unknown>): HttpHandler {
+    return http.post(this.collectionPath(), () => {
+      return HttpResponse.json(response, {
+        status: 201,
+      })
+    })
+  }
+
+  /**
+   * DELETE a resource, returning an empty `204` response.
+   */
+  delete(): HttpHandler {
+    return http.delete(`${this.baseUrl}/${this.endpoint}/*`, () => {
+      return new HttpResponse(null, {
+        status: 204,
+      })
+    })
+  }
+
+  /**
+   * GET a single resource.
+   */
+  getDetail(data: T): HttpHandler {
+    return http.get(this.resourcePath(data), () => {
+      return HttpResponse.json(data)
+    })
+  }
+
+  /**
+   * GET the collection, returning `data` wrapped in the configured
+   * pagination shape.
+   */
+  getIndex(data: T[]): HttpHandler {
+    const body = this.paginationType === 'keyset'
+      ? PaginationTestUtil.toKeysetPaginationResponse(data)
+      : PaginationTestUtil.toOffsetPaginationResponse(data)
+
+    return http.get(this.collectionPath(), () => {
+      return HttpResponse.json(body)
+    })
+  }
+
+  /**
+   * PATCH a single resource, returning the updated `data`.
+   */
+  update(data: T): HttpHandler {
+    return http.patch(this.resourcePath(data), () => {
+      return HttpResponse.json(data)
+    })
+  }
+}

--- a/packages/web/e2e/src/mocking/errors/apiError.builder.test.ts
+++ b/packages/web/e2e/src/mocking/errors/apiError.builder.test.ts
@@ -1,0 +1,129 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+import type { ApiExpectedError } from '@/mocking/errors/apiError.builder'
+import { BadRequestBuilder } from '@/mocking/errors/badRequest.builder'
+import { ConflictBuilder } from '@/mocking/errors/conflict.builder'
+import { ForbiddenBuilder } from '@/mocking/errors/forbidden.builder'
+import { NotFoundBuilder } from '@/mocking/errors/notFound.builder'
+import { ServerErrorBuilder } from '@/mocking/errors/serverError.builder'
+import { UnauthorizedBuilder } from '@/mocking/errors/unauthorized.builder'
+
+describe('error response builders', () => {
+  it('emits a single default error when nothing is configured', async () => {
+    const response = new BadRequestBuilder().build()
+
+    expect(response.status).toBe(400)
+
+    const body = await response.json() as ApiExpectedError
+
+    expect(body.errors).toHaveLength(1)
+    expect(body.errors[0]).toEqual({
+      code: 'bad_request',
+      detail: 'Bad request',
+      status: '400',
+    })
+  })
+
+  it('adds a field-level error with a source pointer', async () => {
+    const response = new BadRequestBuilder()
+      .withFieldError('email', 'Email already exists')
+      .build()
+
+    const body = await response.json() as ApiExpectedError
+
+    expect(body.errors).toEqual([
+      {
+        code: 'bad_request',
+        detail: 'Email already exists',
+        source: {
+          pointer: 'email',
+        },
+        status: '400',
+      },
+    ])
+  })
+
+  it('accumulates multiple field errors', async () => {
+    const response = new BadRequestBuilder()
+      .withFieldError('email', 'Invalid email')
+      .withFieldError('name', 'Name is required')
+      .build()
+
+    const body = await response.json() as ApiExpectedError
+
+    expect(body.errors).toHaveLength(2)
+    expect(body.errors.map((error) => error.source?.pointer)).toEqual([
+      'email',
+      'name',
+    ])
+  })
+
+  it('sets a top-level message via withMessage', async () => {
+    const response = new ForbiddenBuilder()
+      .withMessage('You do not have permission')
+      .build()
+
+    expect(response.status).toBe(403)
+
+    const body = await response.json() as ApiExpectedError
+
+    expect(body.errors[0]?.detail).toBe('You do not have permission')
+    expect(body.errors[0]?.source).toBeUndefined()
+  })
+
+  it('overrides the error code via withCode', async () => {
+    const response = new BadRequestBuilder()
+      .withMessage('Custom')
+      .withCode('custom_code')
+      .build()
+
+    const body = await response.json() as ApiExpectedError
+
+    expect(body.errors[0]?.code).toBe('custom_code')
+  })
+
+  it('maps each builder to the correct status and code', async () => {
+    const cases = [
+      {
+        builder: new UnauthorizedBuilder(),
+        code: 'unauthorized',
+        status: 401,
+      },
+      {
+        builder: new ForbiddenBuilder(),
+        code: 'forbidden',
+        status: 403,
+      },
+      {
+        builder: new NotFoundBuilder(),
+        code: 'not_found',
+        status: 404,
+      },
+      {
+        builder: new ConflictBuilder(),
+        code: 'conflict',
+        status: 409,
+      },
+      {
+        builder: new ServerErrorBuilder(),
+        code: 'internal_server_error',
+        status: 500,
+      },
+    ]
+
+    for (const testCase of cases) {
+      const response = testCase.builder.build()
+
+      expect(response.status).toBe(testCase.status)
+
+      const body = await response.json() as ApiExpectedError
+
+      expect(body.errors[0]?.code).toBe(testCase.code)
+      expect(body.errors[0]?.status).toBe(String(testCase.status))
+    }
+  })
+})

--- a/packages/web/e2e/src/mocking/errors/apiError.builder.ts
+++ b/packages/web/e2e/src/mocking/errors/apiError.builder.ts
@@ -1,0 +1,113 @@
+import type { StrictResponse } from 'msw'
+import { HttpResponse } from 'msw'
+
+/**
+ * A single API error entry, matching the error shape emitted by
+ * `@wisemen/vue-core-api-utils`.
+ */
+export interface ApiErrorObject {
+  code: string
+  detail: string
+  source?: { pointer: string }
+  /** The HTTP status as a string, e.g. `'400'`. */
+  status: string
+}
+
+/**
+ * The full error response body: a list of {@link ApiErrorObject}.
+ */
+export interface ApiExpectedError {
+  errors: ApiErrorObject[]
+}
+
+/**
+ * Base builder for MSW error responses that conform to the
+ * `@wisemen/vue-core-api-utils` error shape.
+ *
+ * Concrete subclasses fix the HTTP status, default code, and default
+ * detail via `super(...)`. Consumers chain `withMessage`, `withCode`, and
+ * `withFieldError`, then call `build()` to obtain an `HttpResponse`.
+ */
+export abstract class ApiErrorBuilder {
+  private codeOverride: string | null = null
+  private readonly defaultCode: string
+  private readonly defaultDetail: string
+
+  private readonly errors: ApiErrorObject[] = []
+
+  private readonly status: number
+
+  protected constructor(status: number, defaultCode: string, defaultDetail: string) {
+    this.status = status
+    this.defaultCode = defaultCode
+    this.defaultDetail = defaultDetail
+  }
+
+  /**
+   * Build the MSW error response. If no errors were added, a single
+   * default error is emitted using the (optionally overridden) code and
+   * the default detail for this status.
+   */
+  build(): StrictResponse<ApiExpectedError> {
+    const errors: ApiErrorObject[] = this.errors.length > 0
+      ? this.errors
+      : [
+          {
+            code: this.codeOverride ?? this.defaultCode,
+            detail: this.defaultDetail,
+            status: String(this.status),
+          },
+        ]
+
+    return HttpResponse.json<ApiExpectedError>({
+      errors,
+    }, {
+      status: this.status,
+    })
+  }
+
+  /**
+   * Override the code used for generic errors. If errors already exist,
+   * the last one's code is updated too.
+   */
+  withCode(code: string): this {
+    this.codeOverride = code
+
+    const lastError = this.errors.at(-1)
+
+    if (lastError !== undefined) {
+      lastError.code = code
+    }
+
+    return this
+  }
+
+  /**
+   * Push a field-level error with a JSON pointer source.
+   */
+  withFieldError(pointer: string, detail: string): this {
+    this.errors.push({
+      code: this.codeOverride ?? this.defaultCode,
+      detail,
+      source: {
+        pointer,
+      },
+      status: String(this.status),
+    })
+
+    return this
+  }
+
+  /**
+   * Push a top-level error with the given detail (no source pointer).
+   */
+  withMessage(detail: string): this {
+    this.errors.push({
+      code: this.codeOverride ?? this.defaultCode,
+      detail,
+      status: String(this.status),
+    })
+
+    return this
+  }
+}

--- a/packages/web/e2e/src/mocking/errors/badRequest.builder.ts
+++ b/packages/web/e2e/src/mocking/errors/badRequest.builder.ts
@@ -1,0 +1,10 @@
+import { ApiErrorBuilder } from '@/mocking/errors/apiError.builder'
+
+/**
+ * Builds a `400 Bad Request` error response.
+ */
+export class BadRequestBuilder extends ApiErrorBuilder {
+  constructor() {
+    super(400, 'bad_request', 'Bad request')
+  }
+}

--- a/packages/web/e2e/src/mocking/errors/conflict.builder.ts
+++ b/packages/web/e2e/src/mocking/errors/conflict.builder.ts
@@ -1,0 +1,10 @@
+import { ApiErrorBuilder } from '@/mocking/errors/apiError.builder'
+
+/**
+ * Builds a `409 Conflict` error response.
+ */
+export class ConflictBuilder extends ApiErrorBuilder {
+  constructor() {
+    super(409, 'conflict', 'Conflict')
+  }
+}

--- a/packages/web/e2e/src/mocking/errors/forbidden.builder.ts
+++ b/packages/web/e2e/src/mocking/errors/forbidden.builder.ts
@@ -1,0 +1,10 @@
+import { ApiErrorBuilder } from '@/mocking/errors/apiError.builder'
+
+/**
+ * Builds a `403 Forbidden` error response.
+ */
+export class ForbiddenBuilder extends ApiErrorBuilder {
+  constructor() {
+    super(403, 'forbidden', 'Forbidden')
+  }
+}

--- a/packages/web/e2e/src/mocking/errors/notFound.builder.ts
+++ b/packages/web/e2e/src/mocking/errors/notFound.builder.ts
@@ -1,0 +1,10 @@
+import { ApiErrorBuilder } from '@/mocking/errors/apiError.builder'
+
+/**
+ * Builds a `404 Not Found` error response.
+ */
+export class NotFoundBuilder extends ApiErrorBuilder {
+  constructor() {
+    super(404, 'not_found', 'Not found')
+  }
+}

--- a/packages/web/e2e/src/mocking/errors/serverError.builder.ts
+++ b/packages/web/e2e/src/mocking/errors/serverError.builder.ts
@@ -1,0 +1,10 @@
+import { ApiErrorBuilder } from '@/mocking/errors/apiError.builder'
+
+/**
+ * Builds a `500 Internal Server Error` error response.
+ */
+export class ServerErrorBuilder extends ApiErrorBuilder {
+  constructor() {
+    super(500, 'internal_server_error', 'Internal server error')
+  }
+}

--- a/packages/web/e2e/src/mocking/errors/unauthorized.builder.ts
+++ b/packages/web/e2e/src/mocking/errors/unauthorized.builder.ts
@@ -1,0 +1,10 @@
+import { ApiErrorBuilder } from '@/mocking/errors/apiError.builder'
+
+/**
+ * Builds a `401 Unauthorized` error response.
+ */
+export class UnauthorizedBuilder extends ApiErrorBuilder {
+  constructor() {
+    super(401, 'unauthorized', 'Unauthorized')
+  }
+}

--- a/packages/web/e2e/src/page-objects/breadcrumb.page-object.ts
+++ b/packages/web/e2e/src/page-objects/breadcrumb.page-object.ts
@@ -1,0 +1,37 @@
+import type {
+  Locator,
+  Page,
+} from '@playwright/test'
+
+const BREADCRUMB_NAME_REGEX = /breadcrumb/i
+
+/**
+ * Utility for interacting with the breadcrumb navigation in E2E tests.
+ */
+export class BreadcrumbTestUtil {
+  private page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /**
+   * Returns the breadcrumb item marked as the current page.
+   */
+  getCurrentItem(): Locator {
+    return this.page.getByRole('navigation', {
+      name: BREADCRUMB_NAME_REGEX,
+    }).locator('[aria-current="page"]')
+  }
+
+  /**
+   * Returns the breadcrumb item with the given label.
+   */
+  getItem(label: string): Locator {
+    return this.page.getByRole('navigation', {
+      name: BREADCRUMB_NAME_REGEX,
+    }).getByRole('link', {
+      name: label,
+    })
+  }
+}

--- a/packages/web/e2e/src/page-objects/bulkActions.page-object.ts
+++ b/packages/web/e2e/src/page-objects/bulkActions.page-object.ts
@@ -1,0 +1,31 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+/**
+ * Utility for interacting with the bulk-actions bar in E2E tests.
+ */
+export class BulkActionsUtil {
+  private page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /**
+   * Clicks the bulk action with the given name.
+   */
+  async clickBulkAction(actionName: string): Promise<void> {
+    await this.page.getByRole('button', {
+      name: actionName,
+    }).or(this.page.getByRole('menuitem', {
+      name: actionName,
+    })).click()
+  }
+
+  /**
+   * Asserts that the given number of items are selected.
+   */
+  async expectSelectedCount(count: number): Promise<void> {
+    await expect(this.page.getByText(`${count} selected`)).toBeVisible()
+  }
+}

--- a/packages/web/e2e/src/page-objects/dialog.page-object.ts
+++ b/packages/web/e2e/src/page-objects/dialog.page-object.ts
@@ -1,0 +1,21 @@
+import type {
+  Locator,
+  Page,
+} from '@playwright/test'
+import { expect } from '@playwright/test'
+
+export class DialogTestUtil {
+  private page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  expectNoActiveDialog(): Promise<void> {
+    return expect(this.page.getByRole('dialog')).toHaveCount(0)
+  }
+
+  getActiveDialog(): Locator {
+    return this.page.getByRole('dialog')
+  }
+}

--- a/packages/web/e2e/src/page-objects/form.page-object.ts
+++ b/packages/web/e2e/src/page-objects/form.page-object.ts
@@ -1,0 +1,468 @@
+import type {
+  Locator,
+  Page,
+} from '@playwright/test'
+import { expect } from '@playwright/test'
+
+interface DateValue {
+  day: string
+  month: string
+  year: string
+}
+
+interface TimeValue {
+  hour: string
+  minute: string
+}
+
+interface DateTimeValue {
+  date: DateValue
+  time: TimeValue
+}
+
+abstract class FormField {
+  label: string
+  locator: Locator
+
+  constructor(locator: Locator, label: string) {
+    this.locator = locator
+    this.label = label
+  }
+
+  async expectToBeDisabled(): Promise<void> {
+    await expect(this.locator.getByLabel(this.label, {
+      exact: true,
+    })).toBeDisabled()
+  }
+
+  async expectToBeEnabled(): Promise<void> {
+    await expect(this.locator.getByLabel(this.label, {
+      exact: true,
+    })).toBeEnabled()
+  }
+
+  /**
+   *  Fills the form field with the given value.
+   * @param value The value to fill the form field with.
+   * @returns A promise that resolves when the action is complete.
+   */
+  abstract fill(value: unknown): Promise<void>
+
+  /**
+   * Gets the value of the form field.
+   * @returns A promise that resolves to the value of the form field.
+   */
+  abstract getValue(): Promise<unknown>
+}
+
+class TextField extends FormField {
+  async fill(value: string): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).fill(value)
+  }
+
+  async getValue(): Promise<string> {
+    return await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).inputValue()
+  }
+}
+
+class DateField extends FormField {
+  async fill(value?: DateValue): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).focus()
+
+    if (value === undefined) {
+      await this.locator.page().keyboard.press('ArrowUp')
+      await this.locator.page().keyboard.press('Tab')
+      await this.locator.page().keyboard.press('ArrowUp')
+      await this.locator.page().keyboard.press('Tab')
+      await this.locator.page().keyboard.press('ArrowUp')
+    }
+    else {
+      await this.locator.page().keyboard.type(value.month)
+      await this.locator.page().keyboard.type(value.day)
+      await this.locator.page().keyboard.type(value.year)
+    }
+  }
+
+  async getValue(): Promise<DateValue> {
+    const inputValue = await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).inputValue()
+    const [
+      year,
+      month,
+      day,
+    ] = inputValue.split('-')
+
+    if (year === undefined || month === undefined || day === undefined) {
+      throw new Error(`Could not parse date value from input: ${inputValue}`)
+    }
+
+    return {
+      day,
+      month,
+      year,
+    }
+  }
+}
+
+class TimeField extends FormField {
+  async fill(value: TimeValue): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).focus()
+    await this.locator.page().keyboard.type(value.hour)
+    await this.locator.page().keyboard.type(value.minute)
+  }
+
+  async getValue(): Promise<TimeValue> {
+    const inputValue = await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).inputValue()
+    const [
+      hour,
+      minute,
+    ] = inputValue.split(':')
+
+    if (hour === undefined || minute === undefined) {
+      throw new Error(`Could not parse time value from input: ${inputValue}`)
+    }
+
+    return {
+      hour,
+      minute,
+    }
+  }
+}
+
+class PinInputField extends FormField {
+  async fill(value: string): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).fill(value)
+  }
+
+  async getValue(): Promise<string> {
+    return await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).inputValue()
+  }
+}
+
+class SelectField extends FormField {
+  async fill(value: string): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).click()
+    await this.locator.page().getByRole('option', {
+      name: value,
+    }).click()
+  }
+
+  async getValue(): Promise<string> {
+    return await this.locator.getByRole('combobox', {
+      name: this.label,
+    }).textContent() || ''
+  }
+}
+
+class AutocompleteField extends FormField {
+  async fill(value: string): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).click()
+    await this.locator.page().getByRole('option', {
+      name: value,
+    }).click()
+  }
+
+  async getValue(): Promise<string> {
+    return await this.locator.getByRole('combobox', {
+      name: this.label,
+    }).textContent() || ''
+  }
+}
+
+class CheckboxField extends FormField {
+  async fill(value: boolean): Promise<void> {
+    const checkbox = this.locator.getByRole('checkbox', {
+      name: this.label,
+    })
+
+    if (value) {
+      await checkbox.check()
+    }
+    else {
+      await checkbox.uncheck()
+    }
+  }
+
+  async getValue(): Promise<boolean> {
+    const checkbox = this.locator.getByRole('checkbox', {
+      name: this.label,
+    })
+
+    return await checkbox.isChecked()
+  }
+}
+
+class TextareaField extends FormField {
+  async fill(value: string): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).fill(value)
+  }
+
+  async getValue(): Promise<string> {
+    return await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).inputValue()
+  }
+}
+
+class EmailField extends FormField {
+  async fill(value: string): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).fill(value)
+  }
+
+  async getValue(): Promise<string> {
+    return await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).inputValue()
+  }
+}
+
+class PasswordField extends FormField {
+  async fill(value: string): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).fill(value)
+  }
+
+  async getValue(): Promise<string> {
+    return await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).inputValue()
+  }
+}
+
+class NumberField extends FormField {
+  async fill(value: string): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).fill(value)
+  }
+
+  async getValue(): Promise<string> {
+    return await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).inputValue()
+  }
+}
+
+class SwitchField extends FormField {
+  async fill(value: boolean): Promise<void> {
+    const switchControl = this.locator.getByRole('switch', {
+      name: this.label,
+    })
+
+    if (value) {
+      await switchControl.check()
+    }
+    else {
+      await switchControl.uncheck()
+    }
+  }
+
+  async getValue(): Promise<boolean> {
+    const switchControl = this.locator.getByRole('switch', {
+      name: this.label,
+    })
+
+    return await switchControl.isChecked()
+  }
+}
+
+class RadioField extends FormField {
+  async fill(value: string): Promise<void> {
+    await this.locator.getByRole('radio', {
+      name: value,
+    }).click()
+  }
+
+  async getValue(): Promise<string> {
+    const radios = await this.locator.getByRole('radio').all()
+
+    for (const radio of radios) {
+      const isChecked = await radio.isChecked()
+
+      if (isChecked) {
+        const ariaLabel = await radio.getAttribute('aria-label')
+        const textContent = await radio.textContent()
+
+        return ariaLabel ?? textContent ?? ''
+      }
+    }
+
+    return ''
+  }
+}
+
+class MultiSelectField extends FormField {
+  async fill(values: string[]): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).click()
+
+    for (const value of values) {
+      await this.locator.page().getByRole('option', {
+        name: value,
+      }).click()
+    }
+  }
+
+  async getValue(): Promise<string> {
+    return await this.locator.getByRole('combobox', {
+      name: this.label,
+    }).textContent() || ''
+  }
+}
+
+class FileUploadField extends FormField {
+  async fill(value: string | string[]): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).setInputFiles(value)
+  }
+
+  async getValue(): Promise<string> {
+    return await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).inputValue()
+  }
+}
+
+class DateTimeField extends FormField {
+  async fill(value: DateTimeValue): Promise<void> {
+    await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).focus()
+    await this.locator.page().keyboard.type(value.date.month)
+    await this.locator.page().keyboard.type(value.date.day)
+    await this.locator.page().keyboard.type(value.date.year)
+    await this.locator.page().keyboard.type(value.time.hour)
+    await this.locator.page().keyboard.type(value.time.minute)
+  }
+
+  async getValue(): Promise<string> {
+    return await this.locator.getByLabel(this.label, {
+      exact: true,
+    }).inputValue()
+  }
+}
+
+export class FormTestUtil {
+  locator: Locator
+  page: Page
+
+  constructor(page: Page, locator: Locator = page.locator('form')) {
+    this.page = page
+    this.locator = locator
+  }
+
+  getAutocompleteFieldByLabel(label: string): AutocompleteField {
+    return new AutocompleteField(this.locator, label)
+  }
+
+  /**
+   * Returns the button with the given text.
+   */
+  getButtonByText(text: string): Locator {
+    return this.page.getByRole('button', {
+      name: text,
+    })
+  }
+
+  getCheckboxFieldByLabel(label: string): CheckboxField {
+    return new CheckboxField(this.locator, label)
+  }
+
+  getDateFieldByLabel(label: string): DateField {
+    return new DateField(this.locator, label)
+  }
+
+  getDateTimeFieldByLabel(label: string): DateTimeField {
+    return new DateTimeField(this.locator, label)
+  }
+
+  getEmailFieldByLabel(label: string): EmailField {
+    return new EmailField(this.locator, label)
+  }
+
+  getFileUploadFieldByLabel(label: string): FileUploadField {
+    return new FileUploadField(this.locator, label)
+  }
+
+  getMultiSelectFieldByLabel(label: string): MultiSelectField {
+    return new MultiSelectField(this.locator, label)
+  }
+
+  getNumberFieldByLabel(label: string): NumberField {
+    return new NumberField(this.locator, label)
+  }
+
+  getPasswordFieldByLabel(label: string): PasswordField {
+    return new PasswordField(this.locator, label)
+  }
+
+  getPinInputFieldByLabel(label: string): PinInputField {
+    return new PinInputField(this.locator, label)
+  }
+
+  getRadioFieldByLabel(label: string): RadioField {
+    return new RadioField(this.locator, label)
+  }
+
+  getSelectFieldByLabel(label: string): SelectField {
+    return new SelectField(this.locator, label)
+  }
+
+  getSwitchFieldByLabel(label: string): SwitchField {
+    return new SwitchField(this.locator, label)
+  }
+
+  getTextareaFieldByLabel(label: string): TextareaField {
+    return new TextareaField(this.locator, label)
+  }
+
+  getTextFieldByLabel(label: string): TextField {
+    return new TextField(this.locator, label)
+  }
+
+  getTimeFieldByLabel(label: string): TimeField {
+    return new TimeField(this.locator, label)
+  }
+
+  async submit(): Promise<void> {
+    const formId = await this.locator.getAttribute('id')
+    const formSubmitButton = this.page.locator(`[form="${formId}"]`)
+
+    await expect(formSubmitButton).toHaveCount(1)
+
+    await formSubmitButton.click()
+  }
+
+  async submitAndExpectSuccessfulResponse(
+    _url: string,
+    _requestBody: Record<string, unknown>,
+  ): Promise<void> {
+    await this.submit()
+  }
+}

--- a/packages/web/e2e/src/page-objects/map.page-object.ts
+++ b/packages/web/e2e/src/page-objects/map.page-object.ts
@@ -1,0 +1,42 @@
+import type { Locator } from '@playwright/test'
+
+export class MapTestUtil {
+  private mapCanvasLocator: Locator
+
+  constructor(mapCanvasLocator: Locator) {
+    this.mapCanvasLocator = mapCanvasLocator
+  }
+
+  async drawPolygon(): Promise<void> {
+    await this.mapCanvasLocator.click({
+      position: {
+        x: 100,
+        y: 100,
+      },
+    })
+    await this.mapCanvasLocator.click({
+      position: {
+        x: 200,
+        y: 100,
+      },
+    })
+    await this.mapCanvasLocator.click({
+      position: {
+        x: 200,
+        y: 200,
+      },
+    })
+    await this.mapCanvasLocator.click({
+      position: {
+        x: 100,
+        y: 200,
+      },
+    })
+    await this.mapCanvasLocator.click({
+      position: {
+        x: 100,
+        y: 100,
+      },
+    })
+  }
+}

--- a/packages/web/e2e/src/page-objects/multiStepForm.page-object.ts
+++ b/packages/web/e2e/src/page-objects/multiStepForm.page-object.ts
@@ -1,0 +1,54 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+const FINISH_BUTTON_REGEX = /finish|submit|done/i
+const NEXT_STEP_BUTTON_REGEX = /next|continue/i
+const PREVIOUS_STEP_BUTTON_REGEX = /back|previous/i
+
+/**
+ * Utility for driving multi-step (wizard) forms in E2E tests.
+ */
+export class MultiStepFormUtil {
+  private page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /**
+   * Asserts that the given step is the current step. Best-effort: matches the
+   * step indicator marked with `aria-current="step"` against the step number.
+   */
+  async expectStep(step: number): Promise<void> {
+    const currentStep = this.page.locator('[aria-current="step"]')
+
+    await expect(currentStep).toContainText(String(step))
+  }
+
+  /**
+   * Completes the multi-step form.
+   */
+  async finish(): Promise<void> {
+    await this.page.getByRole('button', {
+      name: FINISH_BUTTON_REGEX,
+    }).click()
+  }
+
+  /**
+   * Advances to the next step.
+   */
+  async goToNextStep(): Promise<void> {
+    await this.page.getByRole('button', {
+      name: NEXT_STEP_BUTTON_REGEX,
+    }).click()
+  }
+
+  /**
+   * Returns to the previous step.
+   */
+  async goToPreviousStep(): Promise<void> {
+    await this.page.getByRole('button', {
+      name: PREVIOUS_STEP_BUTTON_REGEX,
+    }).click()
+  }
+}

--- a/packages/web/e2e/src/page-objects/pagination.page-object.test.ts
+++ b/packages/web/e2e/src/page-objects/pagination.page-object.test.ts
@@ -1,0 +1,71 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+
+import { PaginationTestUtil } from '@/page-objects/pagination.page-object'
+
+describe('paginationTestUtil static response shapers', () => {
+  it('wraps an array in an offset pagination envelope', () => {
+    const result = PaginationTestUtil.toOffsetPaginationResponse([
+      {
+        id: 1,
+      },
+      {
+        id: 2,
+      },
+      {
+        id: 3,
+      },
+    ])
+
+    expect(result).toEqual({
+      items: [
+        {
+          id: 1,
+        },
+        {
+          id: 2,
+        },
+        {
+          id: 3,
+        },
+      ],
+      meta: {
+        limit: 3,
+        offset: 0,
+        total: 3,
+      },
+    })
+  })
+
+  it('wraps an array in a keyset pagination envelope', () => {
+    const result = PaginationTestUtil.toKeysetPaginationResponse([
+      {
+        id: 1,
+      },
+    ])
+
+    expect(result).toEqual({
+      items: [
+        {
+          id: 1,
+        },
+      ],
+      meta: {
+        limit: 1,
+        next: null,
+      },
+    })
+  })
+
+  it('handles empty collections', () => {
+    expect(PaginationTestUtil.toOffsetPaginationResponse([]).meta).toEqual({
+      limit: 0,
+      offset: 0,
+      total: 0,
+    })
+    expect(PaginationTestUtil.toKeysetPaginationResponse([]).meta.next).toBeNull()
+  })
+})

--- a/packages/web/e2e/src/page-objects/pagination.page-object.ts
+++ b/packages/web/e2e/src/page-objects/pagination.page-object.ts
@@ -1,0 +1,96 @@
+import type { Page } from '@playwright/test'
+
+const NEXT_PAGE_BUTTON_REGEX = /next/i
+const PREVIOUS_PAGE_BUTTON_REGEX = /prev/i
+
+/**
+ * Utility for pagination in E2E tests.
+ *
+ * This class intentionally serves a dual purpose:
+ * - The static methods shape raw arrays into the keyset/offset pagination
+ *   envelopes the API returns, so they can be used to build mock responses.
+ * - The instance methods (constructed with a `Page`) drive the paginator UI
+ *   in the browser.
+ */
+export class PaginationTestUtil {
+  private page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  static toKeysetPaginationResponse<T>(response: T[]): {
+    items: T[]
+    meta: {
+      limit: number
+      next: string | null
+    }
+  } {
+    return {
+      items: response,
+      meta: {
+        limit: response.length,
+        next: null,
+      },
+    }
+  }
+
+  static toOffsetPaginationResponse<T>(response: T[]): {
+    items: T[]
+    meta: {
+      limit: number
+      offset: number
+      total: number
+    }
+  } {
+    return {
+      items: response,
+      meta: {
+        limit: response.length,
+        offset: 0,
+        total: response.length,
+      },
+    }
+  }
+
+  /**
+   * Reads the current (active) page number from the paginator. Best-effort:
+   * parses the text of the element marked with `aria-current="page"` inside
+   * the navigation landmark. Returns `0` when it cannot be determined.
+   */
+  async getCurrentPage(): Promise<number> {
+    const currentItem = this.page.getByRole('navigation').locator('[aria-current="page"]')
+    const text = await currentItem.textContent()
+    const parsed = Number.parseInt(text ?? '', 10)
+
+    return Number.isNaN(parsed) ? 0 : parsed
+  }
+
+  /**
+   * Navigates to the next page.
+   */
+  async goToNextPage(): Promise<void> {
+    await this.page.getByRole('navigation').getByRole('button', {
+      name: NEXT_PAGE_BUTTON_REGEX,
+    }).click()
+  }
+
+  /**
+   * Navigates to the page with the given number.
+   */
+  async goToPage(page: number): Promise<void> {
+    await this.page.getByRole('navigation').getByRole('button', {
+      name: String(page),
+      exact: true,
+    }).click()
+  }
+
+  /**
+   * Navigates to the previous page.
+   */
+  async goToPreviousPage(): Promise<void> {
+    await this.page.getByRole('navigation').getByRole('button', {
+      name: PREVIOUS_PAGE_BUTTON_REGEX,
+    }).click()
+  }
+}

--- a/packages/web/e2e/src/page-objects/searchFilter.page-object.ts
+++ b/packages/web/e2e/src/page-objects/searchFilter.page-object.ts
@@ -1,0 +1,60 @@
+import type {
+  Locator,
+  Page,
+} from '@playwright/test'
+
+const SEARCH_BOX_NAME_REGEX = /search/i
+const CLEAR_FILTERS_BUTTON_REGEX = /clear (all )?filters/i
+
+/**
+ * Utility for interacting with search and filter controls in E2E tests.
+ */
+export class SearchFilterUtil {
+  private page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  private getSearchBox(): Locator {
+    return this.page.getByRole('searchbox').or(this.page.getByRole('textbox', {
+      name: SEARCH_BOX_NAME_REGEX,
+    }))
+  }
+
+  /**
+   * Opens the filter control with the given label and selects the given option.
+   */
+  async applyFilter(filterLabel: string, value: string): Promise<void> {
+    await this.page.getByRole('button', {
+      name: filterLabel,
+    }).click()
+
+    await this.page.getByRole('option', {
+      name: value,
+    }).click()
+  }
+
+  /**
+   * Clears all active filters.
+   */
+  async clearFilters(): Promise<void> {
+    await this.page.getByRole('button', {
+      name: CLEAR_FILTERS_BUTTON_REGEX,
+    }).click()
+  }
+
+  /**
+   * Clears the search input.
+   */
+  async clearSearch(): Promise<void> {
+    await this.getSearchBox().clear()
+  }
+
+  /**
+   * Fills the search input with the given query.
+   */
+  async search(query: string): Promise<void> {
+    await this.getSearchBox().fill(query)
+  }
+}

--- a/packages/web/e2e/src/page-objects/state.page-object.ts
+++ b/packages/web/e2e/src/page-objects/state.page-object.ts
@@ -1,0 +1,47 @@
+import type {
+  Locator,
+  Page,
+} from '@playwright/test'
+
+const EMPTY_STATE_MESSAGE_REGEX = /no results|empty|nothing (found|here)/i
+
+/**
+ * Utility for asserting loading, error and empty states in E2E tests.
+ */
+export class StateTestUtil {
+  private page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /**
+   * Returns the empty-state message, if present.
+   */
+  getEmptyStateMessage(): Locator {
+    return this.page.getByText(EMPTY_STATE_MESSAGE_REGEX)
+  }
+
+  /**
+   * Returns the error message alert, if present.
+   */
+  getErrorMessage(): Locator {
+    return this.page.getByRole('alert')
+  }
+
+  /**
+   * Returns the loading indicator, matched via `aria-busy` or the `status` role.
+   */
+  getLoadingIndicator(): Locator {
+    return this.page.locator('[aria-busy="true"], [role="status"]')
+  }
+
+  /**
+   * Waits for the loading indicator to disappear.
+   */
+  async waitForLoadingToComplete(): Promise<void> {
+    await this.getLoadingIndicator().waitFor({
+      state: 'hidden',
+    })
+  }
+}

--- a/packages/web/e2e/src/page-objects/tab.page-object.ts
+++ b/packages/web/e2e/src/page-objects/tab.page-object.ts
@@ -1,0 +1,38 @@
+import type {
+  Locator,
+  Page,
+} from '@playwright/test'
+
+/**
+ * Utility for interacting with tabs in E2E tests.
+ */
+export class TabTestUtil {
+  private page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /**
+   * Returns the currently active tab panel.
+   */
+  getActivePanel(): Locator {
+    return this.page.getByRole('tabpanel')
+  }
+
+  /**
+   * Returns the tab with the given name.
+   */
+  getTab(name: string): Locator {
+    return this.page.getByRole('tab', {
+      name,
+    })
+  }
+
+  /**
+   * Switches to the tab with the given name.
+   */
+  async switchTab(name: string): Promise<void> {
+    await this.getTab(name).click()
+  }
+}

--- a/packages/web/e2e/src/page-objects/table.page-object.ts
+++ b/packages/web/e2e/src/page-objects/table.page-object.ts
@@ -1,0 +1,180 @@
+import type { Locator } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+export class TableTestUtil {
+  private tableLocator: Locator
+
+  constructor(tableLocator: Locator) {
+    this.tableLocator = tableLocator
+  }
+
+  /**
+   * Clicks the row at the given index (0-based, skipping the header row).
+   */
+  async clickRow(rowIndex: number): Promise<void> {
+    await this.getRow(rowIndex).click()
+  }
+
+  async clickRowAction(rowIndex: number, actionName: string): Promise<void> {
+    const row = this.getRowByIndex(rowIndex)
+
+    await row.getByRole('button', {
+      name: 'Options',
+    }).click()
+
+    await this.tableLocator.page().getByRole('menuitem', {
+      name: actionName,
+    }).click()
+  }
+
+  /**
+   * Asserts that each data row's cell at the given column index contains the
+   * corresponding expected value.
+   */
+  async expectColumnValues(columnIndex: number, values: (string | RegExp)[]): Promise<void> {
+    for (const [
+      rowIndex,
+      value,
+    ] of values.entries()) {
+      await expect(this.getCell(rowIndex, columnIndex)).toContainText(value)
+    }
+  }
+
+  /**
+   * Asserts that the table contains the specified headers.
+   * @param headers Array of expected header texts.
+   *
+   * @example
+   * await tableTestUtil.expectHeaders([
+   *   'Name',
+   *   'Email',
+   *   'Phone',
+   * ])
+   */
+  async expectHeaders(headers: string[]): Promise<void> {
+    const headerRow = this.tableLocator.getByRole('row').nth(0)
+    const headerCells = headerRow.getByRole('columnheader')
+
+    for (const [
+      i,
+      header,
+    ] of headers.entries()) {
+      await expect(headerCells.nth(i)).toContainText(header)
+    }
+  }
+
+  async expectRowActionToBeHidden(rowIndex: number, actionName: string): Promise<void> {
+    const row = this.getRowByIndex(rowIndex)
+
+    const actionsButton = row.getByRole('button', {
+      name: 'Options',
+    })
+
+    await (expect(actionsButton).toBeHidden() || expect(this.tableLocator.page().getByRole('menuitem', {
+      name: actionName,
+    })).toBeHidden())
+  }
+
+  /**
+   * Asserts that the number of data rows (excluding the header) equals `count`.
+   */
+  async expectRowCount(count: number): Promise<void> {
+    const rowCount = await this.getRowCount()
+
+    expect(rowCount).toBe(count)
+  }
+
+  /**
+   * Asserts that the specified row contains the expected values.
+   * @param rowIndex 0-based index
+   * @param values Array of expected values for each cell in the row. Use `null` or `undefined` to expect a dash ('-').
+   *
+   * @example
+   * await tableTestUtil.expectRowValues(0, [
+   *   'John Doe',
+   *   'Test Street 1',
+   *   null,
+   * ])
+   */
+  async expectRowValues(rowIndex: number, values: (string | RegExp | null | undefined)[]): Promise<void> {
+    // +1 to skip header row
+    const row = this.tableLocator.getByRole('row').nth(rowIndex + 1)
+    const cells = row.getByRole('cell')
+
+    for (const [
+      i,
+      value_,
+    ] of values.entries()) {
+      const value = value_ ?? '-'
+
+      await expect(cells.nth(i)).toContainText(value)
+    }
+  }
+
+  /**
+   * Returns the cell at the given column index in the given data row (0-based,
+   * skipping the header row).
+   */
+  getCell(rowIndex: number, columnIndex: number): Locator {
+    return this.getRow(rowIndex).getByRole('cell').nth(columnIndex)
+  }
+
+  /**
+   * Returns the data row at the given index. Alias of `getRowByIndex`.
+   */
+  getRow(rowIndex: number): Locator {
+    return this.getRowByIndex(rowIndex)
+  }
+
+  /**
+   * Opens the row's options menu and returns the menu item for the given action.
+   */
+  getRowActionButton(rowIndex: number, actionName: string): Locator {
+    void this.getRow(rowIndex).getByRole('button', {
+      name: 'Options',
+    }).click()
+
+    return this.tableLocator.page().getByRole('menuitem', {
+      name: actionName,
+    })
+  }
+
+  getRowByIndex(rowIndex: number): Locator {
+    // +1 to skip header row
+    return this.tableLocator.getByRole('row').nth(rowIndex + 1)
+  }
+
+  /**
+   * Returns the number of data rows (excluding the header row).
+   */
+  async getRowCount(): Promise<number> {
+    const rowCount = await this.tableLocator.getByRole('row').count()
+
+    return Math.max(rowCount - 1, 0)
+  }
+
+  /**
+   * Checks the select-all checkbox in the header row.
+   */
+  async selectAllRows(): Promise<void> {
+    const headerRow = this.tableLocator.getByRole('row').first()
+
+    await headerRow.getByRole('checkbox').check()
+  }
+
+  /**
+   * Checks the checkbox of the data row at the given index.
+   */
+  async selectRow(rowIndex: number): Promise<void> {
+    await this.getRow(rowIndex).getByRole('checkbox').check()
+  }
+
+  /**
+   * Sorts the table by clicking the column header whose text contains `header`.
+   */
+  async sortByColumn(header: string): Promise<void> {
+    await this.tableLocator.getByRole('columnheader', {
+      name: header,
+    }).click()
+  }
+}

--- a/packages/web/e2e/src/page-objects/testUtil.page-object.ts
+++ b/packages/web/e2e/src/page-objects/testUtil.page-object.ts
@@ -1,0 +1,59 @@
+import type {
+  Locator,
+  Page,
+} from '@playwright/test'
+import { expect } from '@playwright/test'
+
+/**
+ * General-purpose test utility for interacting with dialogs on the page.
+ */
+export class TestUtil {
+  private page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /**
+   * Asserts that the active dialog contains the given text.
+   */
+  async expectDialogWithText(text: string): Promise<void> {
+    await expect(this.getActiveDialog()).toContainText(text)
+  }
+
+  /**
+   * Asserts that the active dialog has a heading with the given title.
+   */
+  async expectDialogWithTitle(title: string): Promise<void> {
+    await expect(this.getActiveDialog().getByRole('heading', {
+      name: title,
+    })).toBeVisible()
+  }
+
+  /**
+   * Asserts that there is no active dialog on the page.
+   */
+  expectNoActiveDialog(): Promise<void> {
+    return expect(this.page.getByRole('dialog')).toHaveCount(0)
+  }
+
+  /**
+   * Returns the currently active dialog.
+   */
+  getActiveDialog(): Locator {
+    return this.page.getByRole('dialog')
+  }
+
+  /**
+   * Waits for a dialog to become visible and returns it.
+   */
+  async waitForDialog(): Promise<Locator> {
+    const dialog = this.page.getByRole('dialog')
+
+    await dialog.waitFor({
+      state: 'visible',
+    })
+
+    return dialog
+  }
+}

--- a/packages/web/e2e/src/page-objects/toast.page-object.ts
+++ b/packages/web/e2e/src/page-objects/toast.page-object.ts
@@ -1,0 +1,55 @@
+import type {
+  Locator,
+  Page,
+} from '@playwright/test'
+
+type ToastType = 'error' | 'info' | 'success' | 'warning'
+
+const DISMISS_BUTTON_REGEX = /dismiss|close/i
+
+/**
+ * Utility for interacting with toast notifications in E2E tests.
+ */
+export class ToastTestUtil {
+  private page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  /**
+   * Dismisses the toast of the given type by clicking its dismiss/close button.
+   */
+  async dismissToast(type: ToastType): Promise<void> {
+    await this.getToastByType(type).getByRole('button', {
+      name: DISMISS_BUTTON_REGEX,
+    }).click()
+  }
+
+  /**
+   * Returns the most recently rendered toast.
+   */
+  getLastToast(): Locator {
+    return this.page.getByRole('alert').last()
+  }
+
+  /**
+   * Locates a toast of the given type.
+   *
+   * Expects each toast to expose its type through a `data-toast-type`
+   * attribute (e.g. `data-toast-type="success"`) on the toast root element,
+   * which carries either the `alert` or `status` role.
+   */
+  getToastByType(type: ToastType): Locator {
+    return this.page.locator(`[role="alert"][data-toast-type="${type}"], [role="status"][data-toast-type="${type}"]`)
+  }
+
+  /**
+   * Waits for the toast of the given type to become visible.
+   */
+  async waitForToast(type: ToastType): Promise<void> {
+    await this.getToastByType(type).waitFor({
+      state: 'visible',
+    })
+  }
+}

--- a/packages/web/e2e/src/utils/a11y.util.ts
+++ b/packages/web/e2e/src/utils/a11y.util.ts
@@ -1,0 +1,51 @@
+import AxeBuilder from '@axe-core/playwright'
+import type {
+  Page,
+  TestInfo,
+} from '@playwright/test'
+import { expect } from '@playwright/test'
+
+export async function runAccessibilityCheck(page: Page, testInfo: TestInfo): Promise<void> {
+  if (page.isClosed()) {
+    return
+  }
+
+  const accessibilityScanResults = await new AxeBuilder({
+    page,
+  })
+    .withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+    ])
+    .analyze()
+    .catch((error) => {
+      if (error.message.includes('Execution context was destroyed')) {
+        console.warn('Skipping accessibility check due to navigation context being destroyed')
+
+        return {
+          violations: [],
+        }
+      }
+      throw error
+    })
+
+  const wcag21aaViolations = accessibilityScanResults.violations
+    .filter(
+      (v) => v.tags.includes('wcag21aa'),
+    )
+    .map((v) => ({
+      ...v,
+      nodes: v.nodes.map((node) => {
+        return node.html
+      }),
+    }))
+
+  expect(wcag21aaViolations).toEqual([])
+
+  await testInfo.attach('accessibility-scan-results', {
+    body: JSON.stringify(accessibilityScanResults, null, 2),
+    contentType: 'application/json',
+  })
+}

--- a/packages/web/e2e/src/utils/console.util.ts
+++ b/packages/web/e2e/src/utils/console.util.ts
@@ -1,0 +1,77 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+interface ConsoleMonitor {
+  validate: () => void
+}
+
+export interface ConsoleMonitoringOptions {
+  /** Warnings to exclude in addition to the built-in {@link DEFAULT_EXCLUDED_WARNINGS}. Default: `[]`. */
+  excludedWarnings?: string[]
+  /** Whether collected console errors should fail the test. Default: `true`. */
+  failOnError?: boolean
+  /** Whether collected console warnings should fail the test. Default: `false`. */
+  failOnWarning?: boolean
+}
+
+const DEFAULT_EXCLUDED_WARNINGS = [
+  // Motion warning, only seems to happen during tests
+  'You are trying to animate filter from',
+  'You are trying to animate transform from',
+]
+
+/**
+ * Sets up console monitoring for a page, collecting `error` and `warning`
+ * console events emitted while the test runs.
+ *
+ * Unlike the original implementation — whose `validate()` was a no-op (both
+ * assertions were commented out) — this version actually asserts on teardown:
+ * console errors fail the test by default (`failOnError`), while warnings do
+ * not (opt in via `failOnWarning`). Warnings are filtered against
+ * {@link DEFAULT_EXCLUDED_WARNINGS} plus any caller-supplied `excludedWarnings`.
+ *
+ * @example
+ * ```ts
+ * const monitor = setupConsoleMonitoring(page)
+ * // ...run test...
+ * monitor.validate() // throws if any console error was logged
+ * ```
+ */
+export function setupConsoleMonitoring(
+  page: Page,
+  options: ConsoleMonitoringOptions = {},
+): ConsoleMonitor {
+  const {
+    excludedWarnings = [],
+    failOnError = true,
+    failOnWarning = false,
+  } = options
+
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  const allExcluded = [
+    ...DEFAULT_EXCLUDED_WARNINGS,
+    ...excludedWarnings,
+  ]
+
+  page.on('console', (event): void => {
+    if (event.type() === 'error') {
+      errors.push(event.text())
+    }
+    if (event.type() === 'warning' && !allExcluded.some((excluded) => event.text().includes(excluded))) {
+      warnings.push(event.text())
+    }
+  })
+
+  return {
+    validate(): void {
+      if (failOnError) {
+        expect(errors, 'Console errors were logged during the test').toEqual([])
+      }
+      if (failOnWarning) {
+        expect(warnings, 'Console warnings were logged during the test').toEqual([])
+      }
+    },
+  }
+}

--- a/packages/web/e2e/src/utils/coverage.util.ts
+++ b/packages/web/e2e/src/utils/coverage.util.ts
@@ -1,0 +1,63 @@
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import process from 'node:process'
+
+import type { BrowserContext } from '@playwright/test'
+
+function generateUUID(): string {
+  return crypto.randomBytes(16).toString('hex')
+}
+
+class CoverageUtil {
+  private static readonly cliOutput = path.join(process.cwd(), '.nyc_output')
+
+  static collect(coverageJSON: string): void {
+    if (coverageJSON) {
+      fs.writeFileSync(
+        path.join(CoverageUtil.cliOutput, `playwright_coverage_${generateUUID()}.json`),
+        coverageJSON,
+      )
+    }
+  }
+
+  static async setup(): Promise<void> {
+    await fs.promises.mkdir(CoverageUtil.cliOutput, {
+      recursive: true,
+    })
+  }
+}
+
+function setupIstanbulCoverage(): Promise<void> {
+  return CoverageUtil.setup()
+}
+
+function collectIstanbulCoverage(coverageJSON: string): void {
+  return CoverageUtil.collect(coverageJSON)
+}
+
+export async function setupContextWithCoverage(context: BrowserContext): Promise<{ cleanup: () => Promise<void> }> {
+  await setupIstanbulCoverage()
+
+  await context.addInitScript(() => {
+    (globalThis as any).__coverage__ = {}
+  })
+
+  return {
+    cleanup: async (): Promise<void> => {
+      for (const page of context.pages()) {
+        try {
+          const coverage = await page.evaluate(() => JSON.stringify((globalThis as any).__coverage__ || {}))
+
+          if (coverage && coverage !== '{}') {
+            collectIstanbulCoverage(coverage)
+          }
+        }
+        catch {
+          // Ignore errors when the execution context is destroyed (e.g., after navigation)
+          // This is expected behavior and doesn't indicate a test failure
+        }
+      }
+    },
+  }
+}

--- a/packages/web/e2e/src/utils/permissionContext.util.ts
+++ b/packages/web/e2e/src/utils/permissionContext.util.ts
@@ -1,0 +1,35 @@
+/**
+ * Global permission context for test execution.
+ * This allows tests to dynamically set permissions that will be used by MSW handlers.
+ *
+ * The generic type `T` allows each app to pass its own permission type.
+ * By default it uses `string`, so you can use it without specifying a type:
+ *
+ * @example
+ * ```ts
+ * permissionContext.setPermissions(['user.read', 'user.create'])
+ * ```
+ *
+ * Or with a custom type:
+ * ```ts
+ * const typedContext = new PermissionContext<MyPermissionType>()
+ * typedContext.setPermissions(['user.read'])
+ * ```
+ */
+export class PermissionContext<T = string> {
+  private permissions: T[] = []
+
+  clearPermissions(): void {
+    this.permissions = []
+  }
+
+  getPermissions(): T[] {
+    return this.permissions
+  }
+
+  setPermissions(permissions: T[]): void {
+    this.permissions = permissions
+  }
+}
+
+export const permissionContext = new PermissionContext()

--- a/packages/web/e2e/src/utils/websocket.util.ts
+++ b/packages/web/e2e/src/utils/websocket.util.ts
@@ -1,0 +1,11 @@
+import type { Page } from '@playwright/test'
+
+export async function setupWebSocketMock(page: Page, urlPattern: string = 'wss://*/websockets*'): Promise<void> {
+  await page.routeWebSocket(urlPattern, (ws) => {
+    ws.onMessage((message) => {
+      if (message === 'request') {
+        ws.send('response')
+      }
+    })
+  })
+}

--- a/packages/web/e2e/tsconfig.json
+++ b/packages/web/e2e/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "jsx": "preserve",
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "baseUrl": ".",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "allowJs": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "declaration": false,
+    "outDir": "dist",
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "eslint.config.ts",
+    "src/**/*",
+    "src/**/*.ts"
+  ]
+}

--- a/packages/web/e2e/tsdown.config.ts
+++ b/packages/web/e2e/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: [
+    'src/index.ts',
+    'src/config/index.ts',
+  ],
+  format: [
+    'esm',
+  ],
+  shims: true,
+})

--- a/packages/web/e2e/vitest.config.ts
+++ b/packages/web/e2e/vitest.config.ts
@@ -1,0 +1,26 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  configDefaults,
+  defineConfig,
+} from 'vitest/config'
+
+const META_URL = import.meta.url
+const projectRootDir = resolve(__dirname)
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(projectRootDir, 'src'),
+    },
+  },
+
+  test: {
+    environment: 'node',
+    exclude: [
+      ...configDefaults.exclude,
+    ],
+    root: fileURLToPath(new URL('./', META_URL)),
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,6 +620,12 @@ catalogs:
       specifier: 2.7.1
       version: 2.7.1
   test:
+    '@axe-core/playwright':
+      specifier: 4.11.3
+      version: 4.11.3
+    '@playwright/test':
+      specifier: 1.57.0
+      version: 1.57.0
     '@vitest/browser-playwright':
       specifier: 4.1.0
       version: 4.1.0
@@ -635,9 +641,15 @@ catalogs:
     jsdom:
       specifier: 27.4.0
       version: 27.4.0
+    msw:
+      specifier: 2.14.6
+      version: 2.14.6
     playwright:
       specifier: 1.57.0
       version: 1.57.0
+    playwright-msw:
+      specifier: 3.0.1
+      version: 3.0.1
     vitest:
       specifier: 4.1.0
       version: 4.1.0
@@ -823,7 +835,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   docs:
     dependencies:
@@ -2454,7 +2466,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/web/actions:
     dependencies:
@@ -2512,7 +2524,7 @@ importers:
         version: 4.5.4(@types/node@24.8.1)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -2552,7 +2564,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -2586,7 +2598,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/web/components-next:
     dependencies:
@@ -2686,7 +2698,7 @@ importers:
         version: 4.5.4(@types/node@24.8.1)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -2744,7 +2756,7 @@ importers:
         version: 0.20.2(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0)(workbox-window@7.4.0)
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue-i18n:
         specifier: catalog:vue
         version: 11.2.8(vue@3.5.27(typescript@5.9.3))
@@ -2828,7 +2840,7 @@ importers:
         version: 4.5.4(@types/node@24.8.1)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -2886,7 +2898,7 @@ importers:
         version: 4.5.4(@types/node@24.8.1)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -2977,7 +2989,7 @@ importers:
         version: 10.3.0(@types/react@19.2.9)(esbuild@0.27.7)(rollup@4.60.3)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/addon-vitest':
         specifier: catalog:storybook
-        version: 10.2.1(@vitest/browser-playwright@4.1.0)(@vitest/browser@4.1.8(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(@vitest/runner@4.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.1.0)
+        version: 10.2.1(@vitest/browser-playwright@4.1.0)(@vitest/browser@4.1.8(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(@vitest/runner@4.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.1.0)
       '@storybook/vue3':
         specifier: catalog:storybook
         version: 10.3.0(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vue@3.5.27(typescript@5.9.3))
@@ -2998,10 +3010,10 @@ importers:
         version: 6.0.3(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.27(typescript@5.9.3))
       '@vitest/browser-playwright':
         specifier: catalog:test
-        version: 4.1.0(playwright@1.57.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
+        version: 4.1.0(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(playwright@1.57.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
       '@vitest/coverage-v8':
         specifier: catalog:test
-        version: 4.1.0(@vitest/browser@4.1.8(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(vitest@4.1.0)
+        version: 4.1.0(@vitest/browser@4.1.8(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(vitest@4.1.0)
       '@vue/test-utils':
         specifier: catalog:test
         version: 2.4.6
@@ -3052,7 +3064,7 @@ importers:
         version: 4.5.4(@types/node@24.8.1)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -3068,6 +3080,39 @@ importers:
       zod:
         specifier: catalog:general
         version: 4.3.5
+
+  packages/web/e2e:
+    devDependencies:
+      '@axe-core/playwright':
+        specifier: catalog:test
+        version: 4.11.3(playwright-core@1.57.0)
+      '@playwright/test':
+        specifier: catalog:test
+        version: 1.57.0
+      '@types/node':
+        specifier: catalog:types
+        version: 24.8.1
+      '@wisemen/eslint-config-vue':
+        specifier: workspace:*
+        version: link:../eslint-config
+      eslint:
+        specifier: catalog:lint-web
+        version: 9.39.4(jiti@2.6.1)
+      msw:
+        specifier: catalog:test
+        version: 2.14.6(@types/node@24.8.1)(typescript@5.9.3)
+      playwright-msw:
+        specifier: catalog:test
+        version: 3.0.1(@playwright/test@1.57.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))
+      tsdown:
+        specifier: catalog:build
+        version: 0.18.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(synckit@0.11.12)(typescript@5.9.3)(vue-tsc@3.2.2(typescript@5.9.3))
+      typescript:
+        specifier: catalog:build
+        version: 5.9.3
+      vitest:
+        specifier: catalog:test
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/web/eslint-config:
     dependencies:
@@ -3152,7 +3197,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/web/eslint-plugin:
     dependencies:
@@ -3265,7 +3310,7 @@ importers:
         version: 4.5.4(@types/node@24.8.1)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -3299,7 +3344,7 @@ importers:
         version: 4.0.4
       '@vitest/coverage-v8':
         specifier: catalog:test
-        version: 4.1.0(@vitest/browser@4.1.8(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(vitest@4.1.0)
+        version: 4.1.0(@vitest/browser@4.1.8(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(vitest@4.1.0)
       '@wisemen/eslint-config-vue':
         specifier: workspace:*
         version: link:../eslint-config
@@ -3320,7 +3365,7 @@ importers:
         version: 8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -3344,7 +3389,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -3396,7 +3441,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/web/i18n-factory:
     devDependencies:
@@ -3417,7 +3462,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/web/icons:
     devDependencies:
@@ -3459,7 +3504,7 @@ importers:
         version: 4.5.4(@types/node@24.8.1)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -3529,7 +3574,7 @@ importers:
         version: 4.5.4(@types/node@25.3.0)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -3648,7 +3693,7 @@ importers:
         version: 4.5.4(@types/node@24.8.1)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -3740,7 +3785,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/web/template-typescript:
     devDependencies:
@@ -3761,7 +3806,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/web/template-vue:
     dependencies:
@@ -3816,7 +3861,7 @@ importers:
         version: 4.5.4(@types/node@24.8.1)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: catalog:vue
         version: 3.5.27(typescript@5.9.3)
@@ -3843,7 +3888,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/web/utils:
     devDependencies:
@@ -3867,7 +3912,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/web/zod-validation:
     dependencies:
@@ -3895,7 +3940,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:test
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vue-i18n:
         specifier: catalog:vue
         version: 11.2.8(vue@3.5.27(typescript@5.9.3))
@@ -4177,6 +4222,11 @@ packages:
   '@aws/lambda-invoke-store@0.2.3':
     resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
     engines: {node: '>=18.0.0'}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@azure/abort-controller@2.1.2':
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
@@ -5363,6 +5413,10 @@ packages:
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
 
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/checkbox@4.3.2':
     resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
     engines: {node: '>=18'}
@@ -5381,9 +5435,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/core@10.3.2':
     resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -5420,6 +5492,10 @@ packages:
   '@inquirer/figures@1.0.15':
     resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
     engines: {node: '>=18'}
+
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
   '@inquirer/input@4.3.1':
     resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
@@ -5487,6 +5563,15 @@ packages:
   '@inquirer/type@3.0.10':
     resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -5617,6 +5702,14 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
+  '@mswjs/cookies@1.1.1':
+    resolution: {integrity: sha512-W68qOHEjx1iD+4VjQudlx26CPIoxmIAtK4ZCexU0/UJBG6jYhcuyzKJx+Iw8uhBIGd9eba64XgWVgo20it1qwA==}
+    engines: {node: '>=18'}
+
+  '@mswjs/interceptors@0.41.9':
+    resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
+    engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -5839,6 +5932,18 @@ packages:
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@openfeature/core@1.11.0':
     resolution: {integrity: sha512-P0u3/ht/oZCQT89fOed+laLk0kZR529a825cS02uPDglxXbE97irWYpDAeRGGVETIzKfuy+H2g8c3Ccv/tXJNQ==}
@@ -6983,6 +7088,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -8364,11 +8474,17 @@ packages:
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
   '@types/sortablejs@1.15.9':
     resolution: {integrity: sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -9236,6 +9352,10 @@ packages:
 
   axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
+    engines: {node: '>=4'}
+
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
 
   axios@1.16.0:
@@ -10839,6 +10959,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
@@ -10894,6 +11018,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
   hey-listen@1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
@@ -11166,6 +11293,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -12099,6 +12229,16 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.14.6:
+    resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
@@ -12113,6 +12253,10 @@ packages:
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -12287,6 +12431,9 @@ packages:
     resolution: {integrity: sha512-zBd1G8HkewNd2A8oQ8c6BN/f/c9EId7rSUueOLGu28govmUctXmM+3765GwsByv9nYUdrLqHphXlYIc86saYsg==}
     engines: {node: '>=18'}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -12435,6 +12582,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
   path-to-regexp@8.4.0:
     resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
@@ -12554,6 +12704,13 @@ packages:
     resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  playwright-msw@3.0.1:
+    resolution: {integrity: sha512-w2bVjt7kPIThOQF9OS/1vDDs0HsQfV9inxMVSUv74x/zhCcrgzVN47xpPk84okf3OcCRHHBJKq8sNeBfCDyhMg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@playwright/test': '>=1.20.0'
+      msw: ^2.0.0
 
   playwright@1.57.0:
     resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
@@ -12930,6 +13087,9 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -13115,6 +13275,9 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -13325,6 +13488,9 @@ packages:
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -13591,6 +13757,10 @@ packages:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
 
@@ -13702,6 +13872,10 @@ packages:
 
   type-fest@5.4.4:
     resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
+    engines: {node: '>=20'}
+
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
 
   type-is@1.6.18:
@@ -13968,6 +14142,9 @@ packages:
       synckit:
         optional: true
 
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
+
   upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
     engines: {node: '>=4'}
@@ -14223,8 +14400,8 @@ packages:
   vue-component-type-helpers@3.3.0:
     resolution: {integrity: sha512-vwR8DDsBysI9NWXa0okPFpCcW+BUC3sPTuLBNo1faMzw4QWMFd+3/lFYFu29ZN0q+8UReXWJHEYesC9dcXYCLg==}
 
-  vue-component-type-helpers@3.3.5:
-    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
+  vue-component-type-helpers@3.3.7:
+    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -15175,6 +15352,11 @@ snapshots:
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
+
+  '@axe-core/playwright@4.11.3(playwright-core@1.57.0)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.57.0
 
   '@azure/abort-controller@2.1.2':
     dependencies:
@@ -16698,6 +16880,8 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
+  '@inquirer/ansi@2.0.7': {}
+
   '@inquirer/checkbox@4.3.2(@types/node@24.8.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -16715,6 +16899,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.8.1
 
+  '@inquirer/confirm@6.1.1(@types/node@24.8.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.8.1)
+      '@inquirer/type': 4.0.7(@types/node@24.8.1)
+    optionalDependencies:
+      '@types/node': 24.8.1
+
+  '@inquirer/confirm@6.1.1(@types/node@25.3.0)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.3.0)
+      '@inquirer/type': 4.0.7(@types/node@25.3.0)
+    optionalDependencies:
+      '@types/node': 25.3.0
+    optional: true
+
   '@inquirer/core@10.3.2(@types/node@24.8.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -16727,6 +16926,31 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 24.8.1
+
+  '@inquirer/core@11.2.1(@types/node@24.8.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.8.1)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 24.8.1
+
+  '@inquirer/core@11.2.1(@types/node@25.3.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.3.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.3.0
+    optional: true
 
   '@inquirer/editor@4.2.23(@types/node@24.8.1)':
     dependencies:
@@ -16752,6 +16976,8 @@ snapshots:
       '@types/node': 24.8.1
 
   '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/figures@2.0.7': {}
 
   '@inquirer/input@4.3.1(@types/node@24.8.1)':
     dependencies:
@@ -16820,6 +17046,15 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@24.8.1)':
     optionalDependencies:
       '@types/node': 24.8.1
+
+  '@inquirer/type@4.0.7(@types/node@24.8.1)':
+    optionalDependencies:
+      '@types/node': 24.8.1
+
+  '@inquirer/type@4.0.7(@types/node@25.3.0)':
+    optionalDependencies:
+      '@types/node': 25.3.0
+    optional: true
 
   '@internationalized/date@3.10.1':
     dependencies:
@@ -17020,6 +17255,17 @@ snapshots:
   '@microsoft/tsdoc@0.15.1': {}
 
   '@microsoft/tsdoc@0.16.0': {}
+
+  '@mswjs/cookies@1.1.1': {}
+
+  '@mswjs/interceptors@0.41.9':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -17261,6 +17507,17 @@ snapshots:
       '@octokit/openapi-types': 25.1.0
 
   '@one-ini/wasm@0.1.1': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@openfeature/core@1.11.0': {}
 
@@ -18266,6 +18523,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@playwright/test@1.57.0':
+    dependencies:
+      playwright: 1.57.0
+
   '@polka/url@1.0.0-next.29': {}
 
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
@@ -19190,16 +19451,16 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-vitest@10.2.1(@vitest/browser-playwright@4.1.0)(@vitest/browser@4.1.8(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(@vitest/runner@4.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.1.0)':
+  '@storybook/addon-vitest@10.2.1(@vitest/browser-playwright@4.1.0)(@vitest/browser@4.1.8(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(@vitest/runner@4.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.1.0)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       storybook: 10.3.0(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
-      '@vitest/browser-playwright': 4.1.0(playwright@1.57.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
+      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
+      '@vitest/browser-playwright': 4.1.0(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(playwright@1.57.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
       '@vitest/runner': 4.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -19259,7 +19520,7 @@ snapshots:
       storybook: 10.3.0(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.27(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.5
+      vue-component-type-helpers: 3.3.7
 
   '@stylistic/eslint-plugin@5.10.0(eslint@10.2.1(jiti@2.6.1))':
     dependencies:
@@ -19661,9 +19922,15 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 25.3.0
 
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 25.3.0
+
   '@types/sortablejs@1.15.9': {}
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/statuses@2.0.6': {}
 
   '@types/tedious@4.0.14':
     dependencies:
@@ -20125,26 +20392,26 @@ snapshots:
       vite: 8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.27(typescript@5.9.3)
 
-  '@vitest/browser-playwright@4.1.0(playwright@1.57.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)':
+  '@vitest/browser-playwright@4.1.0(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(playwright@1.57.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)':
     dependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
-      '@vitest/mocker': 4.1.0(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
+      '@vitest/mocker': 4.1.0(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser-playwright@4.1.0(playwright@1.57.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)':
+  '@vitest/browser-playwright@4.1.0(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(playwright@1.57.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)':
     dependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
-      '@vitest/mocker': 4.1.0(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
+      '@vitest/mocker': 4.1.0(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -20152,16 +20419,16 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.1.8(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)':
+  '@vitest/browser@4.1.8(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.8(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -20169,16 +20436,16 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.8(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)':
+  '@vitest/browser@4.1.8(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.8(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -20187,7 +20454,7 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/coverage-v8@4.1.0(@vitest/browser@4.1.8(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(vitest@4.1.0)':
+  '@vitest/coverage-v8@4.1.0(@vitest/browser@4.1.8(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(vitest@4.1.0)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -20199,11 +20466,11 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
+      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
 
-  '@vitest/coverage-v8@4.1.0(@vitest/browser@4.1.8(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(vitest@4.1.0)':
+  '@vitest/coverage-v8@4.1.0(@vitest/browser@4.1.8(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0))(vitest@4.1.0)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -20215,9 +20482,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
+      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
 
   '@vitest/eslint-plugin@1.6.9(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.0)':
     dependencies:
@@ -20226,7 +20493,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -20247,36 +20514,40 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.0(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.14.6(@types/node@24.8.1)(typescript@5.9.3)
       vite: 8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.0(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.0(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.14.6(@types/node@25.3.0)(typescript@5.9.3)
       vite: 8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.8(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.8(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.14.6(@types/node@24.8.1)(typescript@5.9.3)
       vite: 8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.8(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.8(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.14.6(@types/node@25.3.0)(typescript@5.9.3)
       vite: 8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
     optional: true
 
@@ -20828,6 +21099,8 @@ snapshots:
       fastq: 1.19.1
 
   axe-core@4.11.1: {}
+
+  axe-core@4.11.4: {}
 
   axios@1.16.0:
     dependencies:
@@ -22721,6 +22994,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql@16.14.2: {}
+
   gray-matter@4.0.3:
     dependencies:
       js-yaml: 3.14.2
@@ -22794,6 +23069,11 @@ snapshots:
       '@types/hast': 3.0.4
 
   he@1.2.0: {}
+
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.2
 
   hey-listen@1.0.8: {}
 
@@ -23147,6 +23427,8 @@ snapshots:
   is-module@1.0.0: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -24196,6 +24478,57 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.1.1(@types/node@24.8.1)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.2
+      type-fest: 5.8.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.1.1(@types/node@25.3.0)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.2
+      type-fest: 5.8.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   muggle-string@0.4.1: {}
 
   multer@2.1.1:
@@ -24208,6 +24541,8 @@ snapshots:
   mute-stream@1.0.0: {}
 
   mute-stream@2.0.0: {}
+
+  mute-stream@3.0.0: {}
 
   nanoid@3.3.12: {}
 
@@ -24406,6 +24741,8 @@ snapshots:
     dependencies:
       macos-release: 3.5.1
       windows-release: 6.1.0
+
+  outvariant@1.4.3: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -24626,6 +24963,8 @@ snapshots:
       lru-cache: 11.2.7
       minipass: 7.1.3
 
+  path-to-regexp@6.3.0: {}
+
   path-to-regexp@8.4.0: {}
 
   path-to-regexp@8.4.2: {}
@@ -24742,6 +25081,13 @@ snapshots:
       pathe: 2.0.3
 
   playwright-core@1.57.0: {}
+
+  playwright-msw@3.0.1(@playwright/test@1.57.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3)):
+    dependencies:
+      '@mswjs/cookies': 1.1.1
+      '@playwright/test': 1.57.0
+      msw: 2.14.6(@types/node@24.8.1)(typescript@5.9.3)
+      strict-event-emitter: 0.5.1
 
   playwright@1.57.0:
     dependencies:
@@ -25198,6 +25544,8 @@ snapshots:
 
   retry@0.13.1: {}
 
+  rettime@0.11.11: {}
+
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
@@ -25459,6 +25807,8 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  set-cookie-parser@3.1.2: {}
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -25681,6 +26031,8 @@ snapshots:
       readable-stream: 3.6.2
 
   streamsearch@1.1.0: {}
+
+  strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
 
@@ -25936,6 +26288,10 @@ snapshots:
     dependencies:
       tldts: 7.0.16
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.0.16
+
   tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
@@ -26056,6 +26412,10 @@ snapshots:
   type-fest@2.19.0: {}
 
   type-fest@5.4.4:
+    dependencies:
+      tagged-tag: 1.0.0
+
+  type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
 
@@ -26290,6 +26650,8 @@ snapshots:
       rolldown: 1.0.0-rc.17
     optionalDependencies:
       synckit: 0.11.12
+
+  until-async@3.0.2: {}
 
   upath@1.2.0: {}
 
@@ -26545,10 +26907,10 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.8.1)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.0(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -26570,15 +26932,15 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.8.1
-      '@vitest/browser-playwright': 4.1.0(playwright@1.57.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
+      '@vitest/browser-playwright': 4.1.0(msw@2.14.6(@types/node@24.8.1)(typescript@5.9.3))(playwright@1.57.0)(vite@8.0.14(@types/node@24.8.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
       jsdom: 27.4.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.0)(@vitest/browser-playwright@4.1.0)(jsdom@27.4.0)(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.0(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -26600,7 +26962,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.3.0
-      '@vitest/browser-playwright': 4.1.0(playwright@1.57.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
+      '@vitest/browser-playwright': 4.1.0(msw@2.14.6(@types/node@25.3.0)(typescript@5.9.3))(playwright@1.57.0)(vite@8.0.14(@types/node@25.3.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
       jsdom: 27.4.0
     transitivePeerDependencies:
       - msw
@@ -26638,7 +27000,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.0: {}
 
-  vue-component-type-helpers@3.3.5: {}
+  vue-component-type-helpers@3.3.7: {}
 
   vue-demi@0.14.10(vue@3.5.27(typescript@5.9.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -216,7 +216,9 @@ catalogs:
   openapi:
     "@hey-api/openapi-ts": "0.94.0"
   peer:
+    "@axe-core/playwright": "^4.11.3"
     "@hey-api/openapi-ts": "^0.94.0"
+    "@playwright/test": "^1.57.0"
     "@tanstack/vue-query": "^5.100.6"
     "@typescript-eslint/parser": "^8.59.0"
     "@vitejs/plugin-vue": ">=6.0.3"
@@ -224,7 +226,9 @@ catalogs:
     formango: ^3.2.4
     "libphonenumber-js": ">=1.12.35"
     "motion-v": "^2.2.1"
+    msw: "^2.14.6"
     "neverthrow": "^8.2.0"
+    playwright-msw: "^3.0.1"
     "reka-ui": "^2.9.7"
     "tailwind-variants": ">=3.2.2"
     "temporal-polyfill": "^0.3.0"
@@ -275,12 +279,16 @@ catalogs:
     "@opentelemetry/sdk-trace-base": "2.7.1"
     "@opentelemetry/sdk-trace-web": "2.7.1"
   test:
+    "@axe-core/playwright": "4.11.3"
+    "@playwright/test": "1.57.0"
     "@vitest/browser-playwright": "4.1.0"
     "@vitest/coverage-v8": "4.1.0"
     "@vue/test-utils": "2.4.6"
     "expect": "30.2.0"
     "jsdom": "27.4.0"
+    msw: "2.14.6"
     playwright: 1.57.0
+    playwright-msw: "3.0.1"
     "vite-plugin-istanbul": "6.0.2"
     "vitest": "4.1.0"
   tooling:
@@ -380,6 +388,7 @@ allowBuilds:
   "@parcel/watcher": true
   "@scarf/scarf": true
   esbuild: true
+  msw: true
   protobufjs: true
   unrs-resolver: true
   vue-demi: true


### PR DESCRIPTION
## Summary

Adds a new publishable package **`@wisemen/web-e2e`** (`packages/web/e2e`) — a Playwright + MSW end-to-end testing toolkit. It ports and expands the local `@repo/testing` package used in the TCR GSE allocation platform so every Wisemen web app can share one E2E toolkit instead of re-inventing utilities.

## What's included

- **Fixture factory** — `createTest()` (MSW worker via `playwright-msw`, role-based permission context, websocket mocking, Istanbul coverage, a11y scan, console-error monitoring).
- **Page objects** — `FormTestUtil` (text/textarea/email/password/number/select/autocomplete/checkbox/switch/radio/multi-select/file-upload/date/time/date-time/pin fields + button), `TableTestUtil`, `DialogTestUtil`, `TestUtil`, `PaginationTestUtil` (static mock-shaping **and** UI navigation), `ToastTestUtil`, `StateTestUtil`, `BreadcrumbTestUtil`, `TabTestUtil`, `SearchFilterUtil`, `BulkActionsUtil`, `MultiStepFormUtil`, `MapTestUtil`.
- **Mocking** — `CrudHandlerFactory` and JSON:API error-response builders (`BadRequest`/`Unauthorized`/`Forbidden`/`NotFound`/`Conflict`/`ServerError`) matching the `@wisemen/vue-core-api-utils` error shape `{ errors: [{ code, detail, status, source }] }`.
- **Builders / auth / config** — `BuilderBase` fluent test-data builder, `createAuthSetup` (OIDC storage state), and a `defineConfig` Playwright config helper exported via `@wisemen/web-e2e/config`.
- README, unit tests, and a bumpy changeset.

## Repo/tooling changes

- Registered `@axe-core/playwright`, `@playwright/test` (pinned to the repo's `playwright` 1.57.0), `msw`, `playwright-msw` in the `test` and `peer` catalogs.
- Approved msw's install script via `allowBuilds` in `pnpm-workspace.yaml` (harmless funding notice; msw is the repo's first dependency with an install script).

## Improvement over the source

The original `console.util`'s `validate()` was a **no-op** (assertions commented out), so console monitoring did nothing. It now actually fails on `console.error` by default, with opt-out flags (`failOnConsoleError`, `excludedConsoleWarnings`).

## Validation

- `build` ✅ (clean `tsdown` output: `dist/index.*` + `dist/config/index.*`, matching `exports`)
- `type-check` ✅ · `lint` ✅ · unit tests ✅ (14 passing)
- **Drop-in verified in TCR:** swapped `@repo/testing/playwright` → `@wisemen/web-e2e` across 57 files. `vue-tsc --noEmit` clean; the gse + user e2e batch produced the **identical** pass/fail set (21 passed / 17 failed) as the original package on `main` — the 17 failures are pre-existing (TCR's `test:e2e` is disabled and has drifted), not caused by the package.

## Notes for review

- **Package name:** `@wisemen/web-e2e` diverges from the `@wisemen/vue-core-*` convention (chosen deliberately). Note the existing `e2e-tests` skill references `@wisemen/e2e` / `@wisemen/e2e/config` — its import examples would need updating to `@wisemen/web-e2e`.
- First release is versioned `minor` via the changeset (`0.0.0` → `0.1.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)