### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/kind-wise-glow.md
+++ b/.bumpy/kind-wise-glow.md
@@ -1,5 +1,0 @@
----
-"@wisemen/scoped-filter": patch
----
-
-feat: support `null` type in Match typeorm operators

--- a/.bumpy/rich-dark-robin.md
+++ b/.bumpy/rich-dark-robin.md
@@ -1,5 +1,0 @@
----
-"@wisemen/scoped-filter": patch
----
-
-feat: add experiment to override typeorm querybuilder type

--- a/packages/api/scoped-filter/CHANGELOG.md
+++ b/packages/api/scoped-filter/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 
 
+
+## 1.0.3
+<sub>2026-07-15</sub>
+
+- [#1445](https://github.com/wisemen-digital/wisemen-core/pull/1445)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - feat: support `null` type in Match typeorm operators
+- [#1447](https://github.com/wisemen-digital/wisemen-core/pull/1447)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - feat: add experiment to override typeorm querybuilder type
+
 ## 1.0.2
 <sub>2026-07-14</sub>
 

--- a/packages/api/scoped-filter/package.json
+++ b/packages/api/scoped-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/scoped-filter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/scoped-filter` 1.0.2 → **1.0.3** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1446/changes#diff-e237bf1a849d4de86c426bf169d71c2e8790161bedaecc1e3b0a19f07e934fee)</sub>

- feat: support `null` type in Match typeorm operators ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1446/changes#diff-3118b0a6e69dc023451ad74faf0ea0cf78fd7f0d9fbeda9a3fc9b832f4185436))
- feat: add experiment to override typeorm querybuilder type ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1446/changes#diff-7af36110be1f2b564f07ae567eb39490960037a57f12cd7ea16e830be602a703))
