### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/vast-pink-pine.md
+++ b/.bumpy/vast-pink-pine.md
@@ -1,5 +1,0 @@
----
-"@wisemen/scoped-filter": patch
----
-
-feat: override QueryBuilder and WhereQueryBuilder instead of SelectQueryBuilder

--- a/packages/api/scoped-filter/CHANGELOG.md
+++ b/packages/api/scoped-filter/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 
 
+
+## 1.0.4
+<sub>2026-07-15</sub>
+
+- [#1449](https://github.com/wisemen-digital/wisemen-core/pull/1449)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - feat: override QueryBuilder and WhereQueryBuilder instead of SelectQueryBuilder
+
 ## 1.0.3
 <sub>2026-07-15</sub>
 

--- a/packages/api/scoped-filter/package.json
+++ b/packages/api/scoped-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/scoped-filter",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/scoped-filter` 1.0.3 → **1.0.4** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1450/changes#diff-e237bf1a849d4de86c426bf169d71c2e8790161bedaecc1e3b0a19f07e934fee)</sub>

- feat: override QueryBuilder and WhereQueryBuilder instead of SelectQueryBuilder ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1450/changes#diff-f825b1762bd5e9c0b0975c3236ced7ecf2be7135e90ac63716024b60809a4e33))
