### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/form-field-group-stretch.md
+++ b/.bumpy/form-field-group-stretch.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Made FormFieldGroup stretch its columns to fill the available width instead of leaving them at their content size.

--- a/.bumpy/smooth-glad-elk.md
+++ b/.bumpy/smooth-glad-elk.md
@@ -1,6 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
-"@wisemen/vue-core-tailwind-config": patch
----
-
-Add dark mode variables to branded css class and only check via css

--- a/.bumpy/young-calm-finch.md
+++ b/.bumpy/young-calm-finch.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Handle the system apearance correctly in the branded sidebar

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -21,6 +21,14 @@
 
 
 
+
+## 1.14.2
+<sub>2026-07-15</sub>
+
+- [#1448](https://github.com/wisemen-digital/wisemen-core/pull/1448)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Made FormFieldGroup stretch its columns to fill the available width instead of leaving them at their content size.
+- [#1448](https://github.com/wisemen-digital/wisemen-core/pull/1448)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Handle the system apearance correctly in the branded sidebar
+- [#1448](https://github.com/wisemen-digital/wisemen-core/pull/1448)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Add dark mode variables to branded css class and only check via css
+
 ## 1.14.1
 <sub>2026-07-14</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",

--- a/packages/web/tailwind-config/CHANGELOG.md
+++ b/packages/web/tailwind-config/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 0.1.1
+<sub>2026-07-15</sub>
+
+- [#1448](https://github.com/wisemen-digital/wisemen-core/pull/1448)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Add dark mode variables to branded css class and only check via css
+
 ## 0.1.0
 <sub>2026-07-08</sub>
 

--- a/packages/web/tailwind-config/package.json
+++ b/packages/web/tailwind-config/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/vue-core-design-system` 1.14.1 → **1.14.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1451/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Made FormFieldGroup stretch its columns to fill the available width instead of leaving them at their content size. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1451/changes#diff-76c315c876897e6b8f2d784e1dfb359b9c323eefb566d21b88361f69ce7a8ea6))
- Handle the system apearance correctly in the branded sidebar ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1451/changes#diff-dbcdbd2974729fcc2d432f71a051adfda4c50461a988827796d0359132793fbc))
- Add dark mode variables to branded css class and only check via css ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1451/changes#diff-78fbdd1cea5fc59737910140488846a09cad296c9470226e00224a181ae4d59d))

#### `@wisemen/vue-core-tailwind-config` 0.1.0 → **0.1.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1451/changes#diff-ba8e5b6a73789f723bb439f0c1e6291c3806681c6f2715a0eec52792b99eee6c)</sub>

- Add dark mode variables to branded css class and only check via css ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1451/changes#diff-78fbdd1cea5fc59737910140488846a09cad296c9470226e00224a181ae4d59d))
