### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/fast-glad-bee.md
+++ b/.bumpy/fast-glad-bee.md
@@ -1,8 +1,0 @@
----
-"@wisemen/payload-core-links": patch
-"@wisemen/payload-core-settings": patch
-"@wisemen/payload-core-translate": patch
-"@wisemen/payload-core-utils": patch
----
-
-Added localized admin labels for the admin dashboard

--- a/.bumpy/jolly-safe-oak.md
+++ b/.bumpy/jolly-safe-oak.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fix isCurrentContextOnly and currentContextOnly props both being required

--- a/.bumpy/tidy-gentle-finch.md
+++ b/.bumpy/tidy-gentle-finch.md
@@ -1,5 +1,0 @@
----
-"@wisemen/opentelemetry": patch
----
-
-Add Nestjs otel logger

--- a/packages/api/opentelemetry/CHANGELOG.md
+++ b/packages/api/opentelemetry/CHANGELOG.md
@@ -1,6 +1,12 @@
 # @wisemen/opentelemetry
 
 
+
+## 0.2.4
+<sub>2026-07-17</sub>
+
+- [#1399](https://github.com/wisemen-digital/wisemen-core/pull/1399)  *(patch)* Thanks [@PauwelsPieter](https://github.com/PauwelsPieter)! - Add Nestjs otel logger
+
 ## 0.2.3
 <sub>2026-06-30</sub>
 

--- a/packages/api/opentelemetry/package.json
+++ b/packages/api/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/opentelemetry",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/payload/auth/CHANGELOG.md
+++ b/packages/payload/auth/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 
 
+
+## 0.1.1
+<sub>2026-07-17</sub>
+
+- *(patch)* Updated dependency `@wisemen/payload-core-utils` v0.0.4
+
 ## 0.1.0
 <sub>2026-07-14</sub>
 

--- a/packages/payload/auth/package.json
+++ b/packages/payload/auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wisemen/payload-core-auth",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "imports": {
     "#*": "./src/*"

--- a/packages/payload/links/CHANGELOG.md
+++ b/packages/payload/links/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 
 
+
+## 0.0.4
+<sub>2026-07-17</sub>
+
+- [#1465](https://github.com/wisemen-digital/wisemen-core/pull/1465)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Added localized admin labels for the admin dashboard
+
 ## 0.0.3
 <sub>2026-07-13</sub>
 

--- a/packages/payload/links/package.json
+++ b/packages/payload/links/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wisemen/payload-core-links",
   "type": "module",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": false,
   "imports": {
     "#*": "./src/*"

--- a/packages/payload/settings/CHANGELOG.md
+++ b/packages/payload/settings/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 0.0.5
+<sub>2026-07-17</sub>
+
+- [#1465](https://github.com/wisemen-digital/wisemen-core/pull/1465)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Added localized admin labels for the admin dashboard
+
 ## 0.0.4
 <sub>2026-07-13</sub>
 

--- a/packages/payload/settings/package.json
+++ b/packages/payload/settings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wisemen/payload-core-settings",
   "type": "module",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": false,
   "imports": {
     "#*": "./src/*"

--- a/packages/payload/translate/CHANGELOG.md
+++ b/packages/payload/translate/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+
+## 0.0.3
+<sub>2026-07-17</sub>
+
+- [#1465](https://github.com/wisemen-digital/wisemen-core/pull/1465)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Added localized admin labels for the admin dashboard
+
 ## 0.0.2
 <sub>2026-07-07</sub>
 

--- a/packages/payload/translate/package.json
+++ b/packages/payload/translate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wisemen/payload-core-translate",
   "type": "module",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": false,
   "imports": {
     "#*": "./src/*"

--- a/packages/payload/utils/CHANGELOG.md
+++ b/packages/payload/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 
 
+
+## 0.0.4
+<sub>2026-07-17</sub>
+
+- [#1465](https://github.com/wisemen-digital/wisemen-core/pull/1465)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Added localized admin labels for the admin dashboard
+
 ## 0.0.3
 <sub>2026-07-13</sub>
 

--- a/packages/payload/utils/package.json
+++ b/packages/payload/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wisemen/payload-core-utils",
   "type": "module",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": false,
   "imports": {
     "#*": "./src/*"

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 
 
+
+## 1.15.1
+<sub>2026-07-17</sub>
+
+- [#1457](https://github.com/wisemen-digital/wisemen-core/pull/1457)  *(patch)* Thanks [@wouterlms](https://github.com/wouterlms)! - Fix isCurrentContextOnly and currentContextOnly props both being required
+
 ## 1.15.0
 <sub>2026-07-16</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/opentelemetry` 0.2.3 → **0.2.4** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-6304e36b5db5e7292f398c1066f7512b2d5b2eba9b324a87f1b646585c1aa49b)</sub>

- Add Nestjs otel logger ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-6357620f4362731030853f9f0a2b0bb53fb4412a2040f95497425bc698f2ba5c))

#### `@wisemen/payload-core-auth` 0.1.0 → **0.1.1** _(dep)_ <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-619e8be260db96f79e37d386f4ece52dee63e19017843bc42d3d3502d2ae63fb)</sub>

- Updated dependencies

#### `@wisemen/payload-core-links` 0.0.3 → **0.0.4** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-d089a7918b1906510c915effc20b83e7924bed71435f7c46b5e7273cdeff5796)</sub>

- Added localized admin labels for the admin dashboard ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-63f9d183c4a1d63e50ee701b715ed6387117d818846e2305f7fab026160f41b2))

#### `@wisemen/payload-core-settings` 0.0.4 → **0.0.5** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-3f444f030f12d589970d48090572c34959d9ac2b7471d16c100691de8d0f3ce5)</sub>

- Added localized admin labels for the admin dashboard ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-63f9d183c4a1d63e50ee701b715ed6387117d818846e2305f7fab026160f41b2))

#### `@wisemen/payload-core-translate` 0.0.2 → **0.0.3** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-a54dcc7b88d4691b865d70b05800c6ffeb2fadb2034d69d9e3bdcbcde47da224)</sub>

- Added localized admin labels for the admin dashboard ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-63f9d183c4a1d63e50ee701b715ed6387117d818846e2305f7fab026160f41b2))

#### `@wisemen/payload-core-utils` 0.0.3 → **0.0.4** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-636089b281d9d552b722bdf2a6100ba4423a7bf541e111b42dec42753af96d94)</sub>

- Added localized admin labels for the admin dashboard ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-63f9d183c4a1d63e50ee701b715ed6387117d818846e2305f7fab026160f41b2))

#### `@wisemen/vue-core-design-system` 1.15.0 → **1.15.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Fix isCurrentContextOnly and currentContextOnly props both being required ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1461/changes#diff-c70bc092d40f54531b07a2fbc7f27781e2223b529f6a56077dbe55d7742f2557))
