### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/add-date-range-tomorrow-preset.md
+++ b/.bumpy/add-date-range-tomorrow-preset.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": minor
----
-
-Added a 'Tomorrow' preset to the date range field.

--- a/.bumpy/badge-left-config-disabled-icon-color.md
+++ b/.bumpy/badge-left-config-disabled-icon-color.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": minor
----
-
-Added Badge left config, isDisabled and iconColor props, a neutral color, and deprecated the outline variant and the icon/dot/avatar props.

--- a/.bumpy/fix-branded-dark-mode-background.md
+++ b/.bumpy/fix-branded-dark-mode-background.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fixed branded MainLayout showing no background in dark mode.

--- a/.bumpy/fix-dialog-close-button-not-visible.md
+++ b/.bumpy/fix-dialog-close-button-not-visible.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fixed the dialog close button and header/footer separators never rendering due to a broken deprecated-prop fallback.

--- a/.bumpy/fix-number-field-leading-zero.md
+++ b/.bumpy/fix-number-field-leading-zero.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fixed NumberField incorrectly parsing values like "0,11111" as thousands instead of decimals.

--- a/.bumpy/fix-reactive-branded-darkmode.md
+++ b/.bumpy/fix-reactive-branded-darkmode.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-tailwind-config": patch
----
-
-Fixed branded sidebar/topbar colors not updating instantly when toggling between light and dark mode.

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -24,6 +24,16 @@
 
 
 
+
+## 1.16.0
+<sub>2026-07-17</sub>
+
+- [#1458](https://github.com/wisemen-digital/wisemen-core/pull/1458)  *(minor)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Added Badge left config, isDisabled and iconColor props, a neutral color, and deprecated the outline variant and the icon/dot/avatar props.
+- [#1460](https://github.com/wisemen-digital/wisemen-core/pull/1460)  *(minor)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Added a 'Tomorrow' preset to the date range field.
+- [#1459](https://github.com/wisemen-digital/wisemen-core/pull/1459)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Fixed NumberField incorrectly parsing values like "0,11111" as thousands instead of decimals.
+- [#1460](https://github.com/wisemen-digital/wisemen-core/pull/1460)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Fixed the dialog close button and header/footer separators never rendering due to a broken deprecated-prop fallback.
+- [#1464](https://github.com/wisemen-digital/wisemen-core/pull/1464)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Fixed branded MainLayout showing no background in dark mode.
+
 ## 1.15.1
 <sub>2026-07-17</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",

--- a/packages/web/tailwind-config/CHANGELOG.md
+++ b/packages/web/tailwind-config/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 
 
+
+## 0.1.2
+<sub>2026-07-17</sub>
+
+- [#1464](https://github.com/wisemen-digital/wisemen-core/pull/1464)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Fixed branded sidebar/topbar colors not updating instantly when toggling between light and dark mode.
+
 ## 0.1.1
 <sub>2026-07-15</sub>
 

--- a/packages/web/tailwind-config/package.json
+++ b/packages/web/tailwind-config/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/vue-core-design-system` 1.15.1 → **1.16.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1466/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Added Badge left config, isDisabled and iconColor props, a neutral color, and deprecated the outline variant and the icon/dot/avatar props. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1466/changes#diff-1cfc481646fffa7b46d567a80c5345ee1431621c820e74aa2ebbd0d7a452e80f))
- Fixed NumberField incorrectly parsing values like "0,11111" as thousands instead of decimals. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1466/changes#diff-c51cd88b62662505772fd96144da7ef8fc586772d9945610c820cfd82edb34cd))
- Added a 'Tomorrow' preset to the date range field. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1466/changes#diff-6061137668e630d963deb3b6f756d3adbc796a498f5f607decf9a70e46066cb6))
- Fixed the dialog close button and header/footer separators never rendering due to a broken deprecated-prop fallback. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1466/changes#diff-bf211725ef329c301873290b0abb8ebe563da713d7d23a67d359aaf14cfb045d))
- Fixed branded MainLayout showing no background in dark mode. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1466/changes#diff-cf347c307817bbbc1f69b57fccd12088f5f8abb7a79b95416e3c5338e498f891))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/vue-core-tailwind-config` 0.1.1 → **0.1.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1466/changes#diff-ba8e5b6a73789f723bb439f0c1e6291c3806681c6f2715a0eec52792b99eee6c)</sub>

- Fixed branded sidebar/topbar colors not updating instantly when toggling between light and dark mode. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1466/changes#diff-c7ec35e1ac86c9a7411c8898c93cd95416a09b178055ba90e4c1849f17afd4aa))
