### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/sharp-warm-star.md
+++ b/.bumpy/sharp-warm-star.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-typeorm": patch
----
-
-fix: expose insert types

--- a/packages/api/nestjs-typeorm/CHANGELOG.md
+++ b/packages/api/nestjs-typeorm/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 1.2.2
+<sub>2026-07-22</sub>
+
+- [#1471](https://github.com/wisemen-digital/wisemen-core/pull/1471)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - fix: expose insert types
+
 ## 1.2.1
 <sub>2026-07-15</sub>
 

--- a/packages/api/nestjs-typeorm/package.json
+++ b/packages/api/nestjs-typeorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-typeorm",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/nestjs-typeorm` 1.2.1 → **1.2.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1472/changes#diff-bac944f10dda4f06d53357e58bd3a885fbcec0089e1d7ef00a8c810116af354b)</sub>

- fix: expose insert types ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1472/changes#diff-eb1900185696f42977051fe341d4eb3bdc870a516f4778627168d48fcf936bf4))
