### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/rich-fast-bee.md
+++ b/.bumpy/rich-fast-bee.md
@@ -1,5 +1,0 @@
----
-"@wisemen/opentelemetry": patch
----
-
-drop Redis key from span name to prevent cardinality explosion

--- a/.bumpy/smooth-bright-clam.md
+++ b/.bumpy/smooth-bright-clam.md
@@ -1,5 +1,0 @@
----
-"@wisemen/scoped-filter": patch
----
-
-feat: add querybuilder extensions in number, plain date and timestamp matchers

--- a/packages/api/opentelemetry/CHANGELOG.md
+++ b/packages/api/opentelemetry/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 
 
+
+## 0.2.5
+<sub>2026-07-23</sub>
+
+- [#1477](https://github.com/wisemen-digital/wisemen-core/pull/1477)  *(patch)* Thanks [@daanpersoons](https://github.com/daanpersoons)! - drop Redis key from span name to prevent cardinality explosion
+
 ## 0.2.4
 <sub>2026-07-17</sub>
 

--- a/packages/api/opentelemetry/package.json
+++ b/packages/api/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/opentelemetry",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/scoped-filter/CHANGELOG.md
+++ b/packages/api/scoped-filter/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 
 
+
+## 1.0.5
+<sub>2026-07-23</sub>
+
+- [#1456](https://github.com/wisemen-digital/wisemen-core/pull/1456)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - feat: add querybuilder extensions in number, plain date and timestamp matchers
+
 ## 1.0.4
 <sub>2026-07-15</sub>
 

--- a/packages/api/scoped-filter/package.json
+++ b/packages/api/scoped-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/scoped-filter",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/opentelemetry` 0.2.4 → **0.2.5** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1476/changes#diff-6304e36b5db5e7292f398c1066f7512b2d5b2eba9b324a87f1b646585c1aa49b)</sub>

- drop Redis key from span name to prevent cardinality explosion ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1476/changes#diff-f79c7e281440fc1886767d7eecccb0043e188f3646977349b0d73ce4a2b5efe3))

#### `@wisemen/scoped-filter` 1.0.4 → **1.0.5** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1476/changes#diff-e237bf1a849d4de86c426bf169d71c2e8790161bedaecc1e3b0a19f07e934fee)</sub>

- feat: add querybuilder extensions in number, plain date and timestamp matchers ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1476/changes#diff-5e6f4d88dda9abf397b3f5ac10f4474629fb304f6a61be9beef76c064b78b357))
