### PR TITLE
fix: drop Redis key from span name to prevent cardinality explosion

### DIFF
--- a/.bumpy/rich-fast-bee.md
+++ b/.bumpy/rich-fast-bee.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/opentelemetry": patch
+---
+
+drop Redis key from span name to prevent cardinality explosion

--- a/packages/api/opentelemetry/lib/register-instrumentation.ts
+++ b/packages/api/opentelemetry/lib/register-instrumentation.ts
@@ -40,10 +40,8 @@ export function registerInstrumentation (
         suppressInternalInstrumentation: true
       }),
       new RedisInstrumentation({
-        responseHook: (span: Span, cmdName: string, cmdArgs: (string | Buffer)[]) => {
-          const spanName = `[Redis] ${cmdName} ${cmdArgs[0]?.toString() ?? ''}`
-
-          span.updateName(spanName)
+        responseHook: (span: Span, cmdName: string) => {
+          span.updateName(`[Redis] ${cmdName}`)
         },
         dbStatementSerializer: (cmdName, cmdArgs) => {
           const maxArgsLength = 100


### PR DESCRIPTION
# fix(opentelemetry): Redis key uit span-naam halen

## Context

Onze SigNoz otel-collectors krijgen het zwaar door de `live-nats-metrics-listener` worker. De `signozspanmetricsprocessor` logt continu:

```
Too many operations to track, using overflow operation name
serviceName: energyking-api-worker-live-nats-metrics
maxNumberOfOperationsToTrackPerService: 2048
```

## Root cause

In `RedisInstrumentation.responseHook` wordt de volledige Redis-key in de span-naam gezet:

```ts
const spanName = `[Redis] ${cmdName} ${cmdArgs[0]?.toString() ?? ''}`
```

Elke unieke `command × gatewayUuid × assetUuid`-combinatie wordt daardoor een aparte operation:

```
[Redis] EXPIRE live-metrics.gateway.<uuid-1>.asset.<uuid-2>:latest-live-metrics
[Redis] SET    live-metrics.gateway.<uuid-1>:latest-live-metrics
[Redis] GET    gateway-sync.quarterHourlyBreakdownAggregatedAt.<uuid-1>
```

De `live-nats-metrics-listener` draait deze commands per NATS-message per gateway per asset — met honderden gateways schaalt dit veel te snel voorbij de 2.048-grens.

## Fix

De key uit de span-naam halen. Span-namen zijn nu alleen nog `[Redis] <command>`:

```
[Redis] EXPIRE
[Redis] SET
[Redis] GET
[Redis] MGET
[Redis] MSET
[Redis] PING
```

De volledige key blijft bewaard op elke span in `db.statement` (via `dbStatementSerializer`), dus ad-hoc zoeken op key blijft mogelijk via een `groupBy db.statement`.

## Trade-offs

- **Per-key p95/p99 in de Services → Operations tabel valt weg.** Voor Redis is dat geen echt verlies: latency wordt bepaald door netwerk + server, niet door welke key je raakt. Als Redis traag is, is alles traag.
- **Storage/ingest verandert niet.** Dit lost alleen de cardinality-druk in de span-metrics processor op, niet het volume dat naar ClickHouse gaat.
- **Raakt alle services die `@wisemen/opentelemetry` gebruiken.** Dat is de bedoeling — dezelfde bom zit potentieel in elke worker die Redis-keys met UUID's aanroept.

## Vervolgstappen na merge

1. Release van `@wisemen/opentelemetry` uitrollen.
2. In `apps/api/package.json` van energyking bumpen (staat nu op `0.1.4`, repo zit al op `0.2.3`).
3. `live-nats-metrics-listener` redeployen.
4. Optioneel de otel-collector pods herstarten om de bestaande operation-map in de processor te legen — anders verdwijnen de oude namen pas passief.
