### PR TITLE
feat: add nestjs mail package

### DIFF
--- a/packages/api/nestjs-handlebars/CHANGELOG.md
+++ b/packages/api/nestjs-handlebars/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+- Initial release

--- a/packages/api/nestjs-handlebars/README.md
+++ b/packages/api/nestjs-handlebars/README.md
@@ -1,0 +1,9 @@
+# `@wisemen/nestjs-handlebars`
+
+Reusable NestJS Handlebars template rendering for Wisemen services.
+
+## What it provides
+
+- `HandlebarsRenderer` for `.hbs` template rendering
+- `HandlebarsModule.forRoot()` and `HandlebarsModule.forRootAsync()` for DI-friendly registration
+- Shared options and provider token exports for packages that want to wire the renderer themselves

--- a/packages/api/nestjs-handlebars/eslint.config.js
+++ b/packages/api/nestjs-handlebars/eslint.config.js
@@ -1,0 +1,5 @@
+import eslintNestJSConfig from '@wisemen/eslint-config-nestjs'
+
+export default [
+  ...eslintNestJSConfig
+]

--- a/packages/api/nestjs-handlebars/lib/handlebars.module-definitions.ts
+++ b/packages/api/nestjs-handlebars/lib/handlebars.module-definitions.ts
@@ -1,0 +1,11 @@
+import type { HandlebarsModuleOptions } from './handlebars.module-options.js'
+
+export const HANDLEBARS_MODULE_OPTIONS = 'wisemen.nestjs-handlebars.module.options'
+
+export function getTemplateRootPath (options: HandlebarsModuleOptions): string {
+  return options.templateRootPath ?? defaultTemplateRootPath()
+}
+
+function defaultTemplateRootPath (): string {
+  return process.cwd() + '/dist/src/modules'
+}

--- a/packages/api/nestjs-handlebars/lib/handlebars.module-options.ts
+++ b/packages/api/nestjs-handlebars/lib/handlebars.module-options.ts
@@ -1,0 +1,29 @@
+import type { FactoryProvider, ModuleMetadata } from '@nestjs/common'
+
+/**
+ * Synchronous configuration for `HandlebarsModule.forRoot(...)`.
+ */
+export interface HandlebarsModuleOptions {
+  /**
+   * Base path used by `HandlebarsRenderer` to resolve template file paths.
+   *
+   * Defaults to `<cwd>/dist/src/modules`.
+   */
+  templateRootPath?: string
+}
+
+/**
+ * Async configuration for `HandlebarsModule.forRootAsync(...)`.
+ */
+export interface HandlebarsModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
+  /**
+   * Optional modules that should be imported before resolving the factory.
+   */
+  imports?: ModuleMetadata['imports']
+  /**
+   * Factory that resolves the renderer options from config, secrets, or test setup.
+   */
+  useFactory: (...args: unknown[]) => Promise<HandlebarsModuleOptions> | HandlebarsModuleOptions
+  /** Dependencies injected into `useFactory`. */
+  inject?: FactoryProvider['inject']
+}

--- a/packages/api/nestjs-handlebars/lib/handlebars.module.ts
+++ b/packages/api/nestjs-handlebars/lib/handlebars.module.ts
@@ -1,0 +1,35 @@
+import { DynamicModule, Module, Provider } from '@nestjs/common'
+import { HANDLEBARS_MODULE_OPTIONS } from './handlebars.module-definitions.js'
+import type { HandlebarsModuleAsyncOptions, HandlebarsModuleOptions } from './handlebars.module-options.js'
+import { HandlebarsRenderer } from './handlebars.renderer.js'
+
+@Module({})
+export class HandlebarsModule {
+  static forRoot (options: HandlebarsModuleOptions): DynamicModule {
+    return this.forRootAsync({
+      useFactory: () => options
+    })
+  }
+
+  static forRootAsync (options: HandlebarsModuleAsyncOptions): DynamicModule {
+    return {
+      module: HandlebarsModule,
+      imports: options.imports ?? [],
+      providers: [
+        this.createOptionsProvider(options),
+        HandlebarsRenderer
+      ],
+      exports: [
+        HandlebarsRenderer
+      ]
+    }
+  }
+
+  private static createOptionsProvider (options: HandlebarsModuleAsyncOptions): Provider {
+    return {
+      provide: HANDLEBARS_MODULE_OPTIONS,
+      useFactory: options.useFactory,
+      inject: options.inject ?? []
+    }
+  }
+}

--- a/packages/api/nestjs-handlebars/lib/handlebars.renderer.ts
+++ b/packages/api/nestjs-handlebars/lib/handlebars.renderer.ts
@@ -2,14 +2,14 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { Inject, Injectable } from '@nestjs/common'
 import hbs from 'handlebars'
-import { MAIL_MODULE_OPTIONS, getTemplateRootPath } from './mail.module-definitions.js'
-import type { MailModuleOptions } from './mail.module-options.js'
+import { HANDLEBARS_MODULE_OPTIONS, getTemplateRootPath } from './handlebars.module-definitions.js'
+import type { HandlebarsModuleOptions } from './handlebars.module-options.js'
 
 @Injectable()
 export class HandlebarsRenderer {
   constructor (
-    @Inject(MAIL_MODULE_OPTIONS)
-    private readonly options: MailModuleOptions
+    @Inject(HANDLEBARS_MODULE_OPTIONS)
+    private readonly options: HandlebarsModuleOptions
   ) {}
 
   async render (

--- a/packages/api/nestjs-handlebars/lib/index.ts
+++ b/packages/api/nestjs-handlebars/lib/index.ts
@@ -1,0 +1,7 @@
+export { HANDLEBARS_MODULE_OPTIONS, getTemplateRootPath } from './handlebars.module-definitions.js'
+export { HandlebarsModule } from './handlebars.module.js'
+export { HandlebarsRenderer } from './handlebars.renderer.js'
+export {
+  type HandlebarsModuleAsyncOptions,
+  type HandlebarsModuleOptions
+} from './handlebars.module-options.js'

--- a/packages/api/nestjs-handlebars/package.json
+++ b/packages/api/nestjs-handlebars/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@wisemen/nestjs-mail",
+  "name": "@wisemen/nestjs-handlebars",
   "version": "0.0.1",
   "publishConfig": {
     "access": "public"
@@ -8,8 +8,7 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "files": [
-    "dist/",
-    "skills/"
+    "dist/"
   ],
   "scripts": {
     "lint:oxlint": "oxlint --type-aware lib",
@@ -22,13 +21,10 @@
     "release": "pnpx release-it"
   },
   "peerDependencies": {
-    "@nestjs/common": "catalog:backend-peer",
-    "@wisemen/api-error": "workspace:^",
-    "@wisemen/nestjs-handlebars": "workspace:^"
+    "@nestjs/common": "catalog:backend-peer"
   },
   "dependencies": {
-    "@wisemen/pgboss-nestjs-job": "workspace:*",
-    "mailpit-api": "^2.0.0"
+    "handlebars": "^4.7.8"
   },
   "devDependencies": {
     "@types/node": "catalog:backend",
@@ -43,6 +39,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/wisemen-digital/wisemen-core",
-    "directory": "packages/api/nestjs-mail"
+    "directory": "packages/api/nestjs-handlebars"
   }
 }

--- a/packages/api/nestjs-handlebars/tsconfig.json
+++ b/packages/api/nestjs-handlebars/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./lib",
+    "declaration": true,
+    "target": "esnext",
+    "module": "NodeNext",
+    "types": [
+      "node"
+    ],
+    "strictFunctionTypes": false,
+    "moduleResolution": "nodenext",
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "resolveJsonModule": true,
+    "strictNullChecks": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "./lib/**/*.ts"
+  ],
+  "exclude": [
+    "./lib/**/*.spec.ts"
+  ],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/api/nestjs-mail/.oxlintrc.json
+++ b/packages/api/nestjs-mail/.oxlintrc.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "extends": [
+    "./node_modules/@wisemen/eslint-config-nestjs/configs/default.json",
+    "./node_modules/@wisemen/eslint-config-nestjs/configs/imports.json",
+    "./node_modules/@wisemen/eslint-config-nestjs/configs/overrides.json"
+  ],
+  "plugins": [
+    "typescript",
+    "unicorn",
+    "import"
+  ],
+  "categories": {
+    "correctness": "off"
+  },
+  "env": {
+    "builtin": true,
+    "node": true
+  },
+  "ignorePatterns": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/api/nestjs-mail/README.md
+++ b/packages/api/nestjs-mail/README.md
@@ -5,7 +5,7 @@ Reusable NestJS mail infrastructure for Wisemen services.
 ## What it provides
 
 - `MailModule.forRoot()` and `MailModule.forRootAsync()` for DI-friendly mail client wiring
-- `HandlebarsRenderer` for `.hbs` template rendering
+- `HandlebarsRenderer` integration through `@wisemen/nestjs-handlebars`
 - Mail providers for MailPit, Scaleway, and SendGrid
 - Shared mail errors, enums, and message types
 
@@ -30,3 +30,5 @@ export class AppModule {}
 ```
 
 Project-specific policy belongs outside the package. In larger apps, use `forRootAsync()` and resolve the `client` options from environment variables, feature flags, secrets, or test doubles in your own factory.
+
+Install `@wisemen/nestjs-handlebars` alongside this package when you want to inject `HandlebarsRenderer` for template-based mail rendering.

--- a/packages/api/nestjs-mail/README.md
+++ b/packages/api/nestjs-mail/README.md
@@ -1,0 +1,32 @@
+# `@wisemen/nestjs-mail`
+
+Reusable NestJS mail infrastructure for Wisemen services.
+
+## What it provides
+
+- `MailModule.forRoot()` and `MailModule.forRootAsync()` for DI-friendly mail client wiring
+- `HandlebarsRenderer` for `.hbs` template rendering
+- Mail providers for MailPit, Scaleway, and SendGrid
+- Shared mail errors, enums, and message types
+
+## Usage
+
+```ts
+import { Module } from '@nestjs/common'
+import { MailModule } from '@wisemen/nestjs-mail'
+
+@Module({
+  imports: [
+    MailModule.forRoot({
+      templateRootPath: process.cwd() + '/dist/src/modules',
+      client: {
+        type: 'mailpit',
+        url: 'http://127.0.0.1:8025'
+      }
+    })
+  ]
+})
+export class AppModule {}
+```
+
+Project-specific policy belongs outside the package. In larger apps, use `forRootAsync()` and resolve the `client` options from environment variables, feature flags, secrets, or test doubles in your own factory.

--- a/packages/api/nestjs-mail/eslint.config.js
+++ b/packages/api/nestjs-mail/eslint.config.js
@@ -1,0 +1,5 @@
+import eslintNestJSConfig from '@wisemen/eslint-config-nestjs'
+
+export default [
+  ...eslintNestJSConfig
+]

--- a/packages/api/nestjs-mail/lib/clients/mail-client.factory.ts
+++ b/packages/api/nestjs-mail/lib/clients/mail-client.factory.ts
@@ -1,0 +1,25 @@
+import { MailProvider } from '../enums/mail-provider.enum.js'
+import type { MailModuleOptions } from '../modules/mail.module-options.js'
+import { exhaustiveCheck } from '../utils/exhaustive-check.js'
+import type { MailClient } from './mail.client.js'
+import { MailPitMailClient } from './mailpit-mail.client.js'
+import { MockMailClient } from './mock-mail.client.js'
+import { ScalewayMailClient } from './scaleway-mail.client.js'
+import { SendGridMailClient } from './sendgrid-mail.client.js'
+
+export function createMailClient (options: MailModuleOptions['client']): MailClient {
+  switch (options.type) {
+    case 'mailpit':
+      return new MailPitMailClient(options)
+    case 'mock':
+      return new MockMailClient()
+    case MailProvider.SCALEWAY:
+      return new ScalewayMailClient(options)
+    case MailProvider.SEND_GRID:
+      return new SendGridMailClient(options)
+    default:
+      exhaustiveCheck(options)
+  }
+}
+
+export const mailClientFactory = createMailClient

--- a/packages/api/nestjs-mail/lib/clients/mail.client.ts
+++ b/packages/api/nestjs-mail/lib/clients/mail.client.ts
@@ -1,0 +1,38 @@
+import { exhaustiveCheck } from '../utils/exhaustive-check.js'
+
+export enum MailFileExtension {
+  PDF = 'pdf',
+  CSV = 'csv'
+}
+
+export interface MailAttachment {
+  file: { name: string, ext: MailFileExtension }
+  buffer: Buffer
+}
+
+export interface SendMailOptions {
+  to: string | string[]
+  cc?: string | string[]
+  bcc?: string | string[]
+  from?: string
+  subject: string
+  text?: string
+  html?: string
+  attachments?: MailAttachment[]
+  replyTo?: string
+}
+
+export abstract class MailClient {
+  abstract sendMail (sendMailOptions: SendMailOptions): Promise<void>
+
+  protected getMimeTypeForAttachmentExt (ext: MailFileExtension): string {
+    switch (ext) {
+      case MailFileExtension.CSV:
+        return 'text/csv'
+      case MailFileExtension.PDF:
+        return 'application/pdf'
+      default:
+        exhaustiveCheck(ext)
+    }
+  }
+}

--- a/packages/api/nestjs-mail/lib/clients/mailpit-mail.client.ts
+++ b/packages/api/nestjs-mail/lib/clients/mailpit-mail.client.ts
@@ -7,8 +7,8 @@ import { MailClient, type MailAttachment, type SendMailOptions } from './mail.cl
 @Injectable()
 export class MailPitMailClient extends MailClient {
   private _client?: MailpitClient
-  private readonly defaultFrom: string
-  private readonly tag?: string
+  private defaultFrom: string
+  private tag?: string
 
   constructor (
     options: MailPitMailClientOptions

--- a/packages/api/nestjs-mail/lib/clients/mailpit-mail.client.ts
+++ b/packages/api/nestjs-mail/lib/clients/mailpit-mail.client.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common'
+import { MailpitClient, type MailpitAttachmentRequest, type MailpitEmailAddressRequest } from 'mailpit-api'
+import { MailUnavailableError } from '../errors/mail-unavailable.error.js'
+import type { MailPitMailClientOptions } from '../modules/mail.module-options.js'
+import { MailClient, type MailAttachment, type SendMailOptions } from './mail.client.js'
+
+@Injectable()
+export class MailPitMailClient extends MailClient {
+  private _client?: MailpitClient
+  private readonly defaultFrom: string
+  private readonly tag?: string
+
+  constructor (
+    options: MailPitMailClientOptions
+  ) {
+    super()
+
+    this.defaultFrom = options.defaultFrom ?? 'test@wisemen.digital'
+    this.tag = options.tag
+    this._client = new MailpitClient(options.url, { auth: options.auth })
+  }
+
+  get client (): MailpitClient {
+    if (this._client == null) {
+      throw new MailUnavailableError('MailPit client is not configured')
+    }
+
+    return this._client
+  }
+
+  async sendMail (options: SendMailOptions): Promise<void> {
+    await this.client.sendMessage({
+      From: { Email: options.from ?? this.defaultFrom },
+      To: this.mapToEmailAddressRequests(options.to),
+      Cc: options.cc !== undefined ? this.mapToEmailAddressRequests(options.cc) : undefined,
+      Bcc: options.bcc !== undefined ? this.mapToEmails(options.bcc) : undefined,
+      Subject: options.subject,
+      Text: options.text,
+      HTML: options.html,
+      ReplyTo: options.replyTo !== undefined
+        ? this.mapToEmailAddressRequests(options.replyTo)
+        : undefined,
+      Attachments: options.attachments !== undefined
+        ? this.mapAttachments(options.attachments)
+        : undefined,
+      Tags: this.tag !== undefined ? [this.tag] : undefined
+    })
+  }
+
+  private mapToEmailAddressRequests (value: string | string[]): MailpitEmailAddressRequest[] {
+    const emails = Array.isArray(value) ? value : [value]
+    return emails.map(email => ({ Email: email }))
+  }
+
+  private mapToEmails (value: string | string[]): string[] {
+    return Array.isArray(value) ? value : [value]
+  }
+
+  private mapAttachments (attachments: MailAttachment[]): MailpitAttachmentRequest[] {
+    return attachments.map(attachment => ({
+      Filename: attachment.file.name,
+      Content: attachment.buffer.toString('base64'),
+      ContentType: this.getMimeTypeForAttachmentExt(attachment.file.ext)
+    }))
+  }
+}

--- a/packages/api/nestjs-mail/lib/clients/mailpit-mail.client.ts
+++ b/packages/api/nestjs-mail/lib/clients/mailpit-mail.client.ts
@@ -58,7 +58,7 @@ export class MailPitMailClient extends MailClient {
 
   private mapAttachments (attachments: MailAttachment[]): MailpitAttachmentRequest[] {
     return attachments.map(attachment => ({
-      Filename: attachment.file.name,
+      Filename: `${attachment.file.name}.${attachment.file.ext}`,
       Content: attachment.buffer.toString('base64'),
       ContentType: this.getMimeTypeForAttachmentExt(attachment.file.ext)
     }))

--- a/packages/api/nestjs-mail/lib/clients/mock-mail.client.ts
+++ b/packages/api/nestjs-mail/lib/clients/mock-mail.client.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common'
+import { MailClient, type SendMailOptions } from './mail.client.js'
+
+@Injectable()
+export class MockMailClient extends MailClient {
+  async sendMail (params: SendMailOptions): Promise<void> {
+    await Promise.resolve(params)
+  }
+}

--- a/packages/api/nestjs-mail/lib/clients/scaleway-mail.client.ts
+++ b/packages/api/nestjs-mail/lib/clients/scaleway-mail.client.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common'
+import { MailApiError } from '../errors/mail-api.error.js'
+import type { ScalewayMailClientOptions } from '../modules/mail.module-options.js'
+import { MailClient, type SendMailOptions } from './mail.client.js'
+
+@Injectable()
+export class ScalewayMailClient extends MailClient {
+  private readonly region: string
+  private readonly projectId: string
+  private readonly from: string
+  private readonly headers: Record<string, string>
+
+  constructor (
+    options: ScalewayMailClientOptions
+  ) {
+    super()
+    this.region = options.region ?? 'fr-par'
+    this.projectId = options.projectId
+    this.from = options.from
+    this.headers = {
+      'X-Auth-Token': options.apiKey,
+      'Content-Type': 'application/json'
+    }
+  }
+
+  async sendMail (options: SendMailOptions): Promise<void> {
+    const response = await fetch(`https://api.scaleway.com/transactional-email/v1alpha1/regions/${this.region}/emails`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify(this.buildPayload(options))
+    })
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new MailApiError('Scaleway', response.status, body)
+    }
+  }
+
+  private buildPayload (options: SendMailOptions): object {
+    const from = { email: options.from ?? this.from }
+    const to = [options.to].flat().map(email => ({ email }))
+    const cc = options.cc === undefined
+      ? undefined
+      : [options.cc].flat().map(email => ({ email }))
+    const bcc = options.bcc === undefined
+      ? undefined
+      : [options.bcc].flat().map(email => ({ email }))
+    const attachments = options.attachments?.map(attachment => ({
+      name: `${attachment.file.name}.${attachment.file.ext}`,
+      content: attachment.buffer.toString('base64'),
+      type: this.getMimeTypeForAttachmentExt(attachment.file.ext)
+    }))
+    const additionalHeaders = options.replyTo !== undefined
+      ? [{ key: 'Reply-To', value: options.replyTo }]
+      : undefined
+
+    return {
+      from,
+      to,
+      cc,
+      bcc,
+      subject: options.subject,
+      text: options.text,
+      html: options.html,
+      attachments,
+      additional_headers: additionalHeaders,
+      project_id: this.projectId
+    }
+  }
+}

--- a/packages/api/nestjs-mail/lib/clients/scaleway-mail.client.ts
+++ b/packages/api/nestjs-mail/lib/clients/scaleway-mail.client.ts
@@ -5,10 +5,10 @@ import { MailClient, type SendMailOptions } from './mail.client.js'
 
 @Injectable()
 export class ScalewayMailClient extends MailClient {
-  private readonly region: string
-  private readonly projectId: string
-  private readonly from: string
-  private readonly headers: Record<string, string>
+  private region: string
+  private projectId: string
+  private from: string
+  private headers: Record<string, string>
 
   constructor (
     options: ScalewayMailClientOptions

--- a/packages/api/nestjs-mail/lib/clients/sendgrid-mail.client.ts
+++ b/packages/api/nestjs-mail/lib/clients/sendgrid-mail.client.ts
@@ -1,7 +1,73 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { Injectable } from '@nestjs/common'
 import { MailApiError } from '../errors/mail-api.error.js'
 import type { SendGridMailClientOptions } from '../modules/mail.module-options.js'
 import { MailClient, type SendMailOptions } from './mail.client.js'
+
+interface SendGridEmailAddress {
+  email: string
+  name?: string
+}
+
+interface SendGridPersonalization {
+  to: SendGridEmailAddress[]
+  cc?: SendGridEmailAddress[]
+  bcc?: SendGridEmailAddress[]
+  subject?: string
+  headers?: Record<string, string>
+  substitutions?: Record<string, string>
+  custom_args?: Record<string, string>
+  send_at?: number
+  dynamic_template_data?: Record<string, unknown>
+}
+
+interface SendGridContent {
+  type: string
+  value: string
+}
+
+interface SendGridAttachment {
+  content: string
+  filename: string
+  type?: string
+  disposition?: string
+  content_id?: string
+}
+
+interface SendGridMailSendRequest {
+  personalizations: SendGridPersonalization[]
+  from: SendGridEmailAddress
+  reply_to?: SendGridEmailAddress
+  reply_to_list?: SendGridEmailAddress[]
+  subject?: string
+  content?: SendGridContent[]
+  attachments?: SendGridAttachment[]
+  template_id?: string
+  categories?: string[]
+  send_at?: number
+  custom_args?: Record<string, string>
+  asm?: {
+    group_id: number
+    groups_to_display?: number[]
+  }
+  batch_id?: string
+  ip_pool_name?: string
+  mail_settings?: {
+    bypass_list_management?: { enable?: boolean }
+    footer?: { enable?: boolean, text?: string, html?: string }
+    sandbox_mode?: { enable?: boolean }
+  }
+  tracking_settings?: {
+    click_tracking?: { enable?: boolean, enable_text?: boolean }
+    open_tracking?: { enable?: boolean, substitution_tag?: string }
+    subscription_tracking?: {
+      enable?: boolean
+      text?: string
+      html?: string
+      substitution_tag?: string
+    }
+  }
+}
 
 @Injectable()
 export class SendGridMailClient extends MailClient {
@@ -32,15 +98,33 @@ export class SendGridMailClient extends MailClient {
     }
   }
 
-  private buildPayload (options: SendMailOptions): object {
+  private buildPayload (options: SendMailOptions): SendGridMailSendRequest {
     if (options.html == null && options.text == null) {
       throw new Error('Either html or text content must be provided')
+    }
+
+    const content: SendGridContent[] = []
+
+    if (options.text !== undefined) {
+      content.push({
+        type: 'text/plain',
+        value: options.text
+      })
+    }
+
+    if (options.html !== undefined) {
+      content.push({
+        type: 'text/html',
+        value: options.html
+      })
     }
 
     return {
       personalizations: [
         {
-          to: [options.to].flat().map(email => ({ email })),
+          to: this.mapEmailAddresses(options.to),
+          cc: this.mapEmailAddresses(options.cc), 
+          bcc: this.mapEmailAddresses(options.bcc),
           subject: options.subject
         }
       ],
@@ -48,16 +132,7 @@ export class SendGridMailClient extends MailClient {
         email: options.from ?? this.defaultFrom
       },
       reply_to: options.replyTo !== undefined ? { email: options.replyTo } : undefined,
-      content: [
-        {
-          type: 'text/plain',
-          value: options.text ?? ''
-        },
-        {
-          type: 'text/html',
-          value: options.html ?? ''
-        }
-      ],
+      content,
       attachments: options.attachments?.map(attachment => ({
         content: attachment.buffer.toString('base64'),
         filename: `${attachment.file.name}.${attachment.file.ext}`,
@@ -65,5 +140,21 @@ export class SendGridMailClient extends MailClient {
         disposition: 'attachment'
       }))
     }
+  }
+
+  private mapEmailAddresses (
+    value: string | string[] 
+  ): SendGridEmailAddress[]
+  private mapEmailAddresses (
+    value: string | string[] | undefined
+  ): SendGridEmailAddress[] | undefined
+  private mapEmailAddresses (
+    value: string | string[] | undefined
+  ): SendGridEmailAddress[] | undefined {
+    if(value === undefined) {
+      return undefined
+    }
+
+    return [value].flat().map(email => ({ email }))
   }
 }

--- a/packages/api/nestjs-mail/lib/clients/sendgrid-mail.client.ts
+++ b/packages/api/nestjs-mail/lib/clients/sendgrid-mail.client.ts
@@ -5,8 +5,8 @@ import { MailClient, type SendMailOptions } from './mail.client.js'
 
 @Injectable()
 export class SendGridMailClient extends MailClient {
-  private readonly defaultFrom: string
-  private readonly headers: Record<string, string>
+  private defaultFrom: string
+  private headers: Record<string, string>
 
   constructor (
     options: SendGridMailClientOptions

--- a/packages/api/nestjs-mail/lib/clients/sendgrid-mail.client.ts
+++ b/packages/api/nestjs-mail/lib/clients/sendgrid-mail.client.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common'
+import { MailApiError } from '../errors/mail-api.error.js'
+import type { SendGridMailClientOptions } from '../modules/mail.module-options.js'
+import { MailClient, type SendMailOptions } from './mail.client.js'
+
+@Injectable()
+export class SendGridMailClient extends MailClient {
+  private readonly defaultFrom: string
+  private readonly headers: Record<string, string>
+
+  constructor (
+    options: SendGridMailClientOptions
+  ) {
+    super()
+    this.headers = {
+      'Authorization': 'Bearer ' + options.apiToken,
+      'Content-Type': 'application/json'
+    }
+    this.defaultFrom = options.defaultFrom
+  }
+
+  async sendMail (options: SendMailOptions): Promise<void> {
+    const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify(this.buildPayload(options))
+    })
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new MailApiError('SendGrid', response.status, body)
+    }
+  }
+
+  private buildPayload (options: SendMailOptions): object {
+    if (options.html == null && options.text == null) {
+      throw new Error('Either html or text content must be provided')
+    }
+
+    return {
+      personalizations: [
+        {
+          to: [options.to].flat().map(email => ({ email })),
+          subject: options.subject
+        }
+      ],
+      from: {
+        email: options.from ?? this.defaultFrom
+      },
+      reply_to: options.replyTo !== undefined ? { email: options.replyTo } : undefined,
+      content: [
+        {
+          type: 'text/plain',
+          value: options.text ?? ''
+        },
+        {
+          type: 'text/html',
+          value: options.html ?? ''
+        }
+      ],
+      attachments: options.attachments?.map(attachment => ({
+        content: attachment.buffer.toString('base64'),
+        filename: `${attachment.file.name}.${attachment.file.ext}`,
+        type: this.getMimeTypeForAttachmentExt(attachment.file.ext),
+        disposition: 'attachment'
+      }))
+    }
+  }
+}

--- a/packages/api/nestjs-mail/lib/enums/mail-provider.enum.ts
+++ b/packages/api/nestjs-mail/lib/enums/mail-provider.enum.ts
@@ -1,0 +1,4 @@
+export enum MailProvider {
+  SEND_GRID = 'send-grid',
+  SCALEWAY = 'scaleway'
+}

--- a/packages/api/nestjs-mail/lib/errors/mail-api.error.ts
+++ b/packages/api/nestjs-mail/lib/errors/mail-api.error.ts
@@ -1,0 +1,10 @@
+export class MailApiError extends Error {
+  constructor (
+    readonly provider: string,
+    readonly status: number,
+    readonly body: string
+  ) {
+    super(`${provider} responded with ${status}: ${body}`)
+    this.name = 'MailApiError'
+  }
+}

--- a/packages/api/nestjs-mail/lib/errors/mail-unavailable.error.ts
+++ b/packages/api/nestjs-mail/lib/errors/mail-unavailable.error.ts
@@ -1,0 +1,10 @@
+import { ApiErrorCode, ServiceUnavailableApiError } from '@wisemen/api-error'
+
+export class MailUnavailableError extends ServiceUnavailableApiError {
+  @ApiErrorCode('mail_unavailable')
+  readonly code = 'mail_unavailable'
+
+  constructor (detail: string) {
+    super(detail)
+  }
+}

--- a/packages/api/nestjs-mail/lib/index.ts
+++ b/packages/api/nestjs-mail/lib/index.ts
@@ -1,0 +1,25 @@
+export { createMailClient, mailClientFactory } from './clients/mail-client.factory.js'
+export { MailClient, MailFileExtension, type MailAttachment, type SendMailOptions } from './clients/mail.client.js'
+export { MailPitMailClient } from './clients/mailpit-mail.client.js'
+export { MockMailClient } from './clients/mock-mail.client.js'
+export { ScalewayMailClient } from './clients/scaleway-mail.client.js'
+export { SendGridMailClient } from './clients/sendgrid-mail.client.js'
+export { MailApiError } from './errors/mail-api.error.js'
+export { MailUnavailableError } from './errors/mail-unavailable.error.js'
+export { MailProvider } from './enums/mail-provider.enum.js'
+export { HandlebarsRenderer } from './modules/handlebars.renderer.js'
+export { MailModule } from './modules/mail.module.js'
+export {
+  type MailClientOptions,
+  type MailModuleAsyncOptions,
+  type MailModuleOptions,
+  type MailPitMailClientOptions,
+  type MockMailClientOptions,
+  type ScalewayMailClientOptions,
+  type SendGridMailClientOptions
+} from './modules/mail.module-options.js'
+export { MAIL_QUEUE_NAME } from './queue/mail-queue-name.js'
+export { MailQueueModule } from './queue/mail-queue.module.js'
+export { type MailQueueModuleOptions } from './queue/mail-queue.module-options.js'
+export { SendHtmlMailJob, type SendHtmlMailJobData } from './queue/send-html-mail.job.js'
+export { SendTemplateMailJob, type SendTemplateMailJobData } from './queue/send-template-mail.job.js'

--- a/packages/api/nestjs-mail/lib/index.ts
+++ b/packages/api/nestjs-mail/lib/index.ts
@@ -7,7 +7,6 @@ export { SendGridMailClient } from './clients/sendgrid-mail.client.js'
 export { MailApiError } from './errors/mail-api.error.js'
 export { MailUnavailableError } from './errors/mail-unavailable.error.js'
 export { MailProvider } from './enums/mail-provider.enum.js'
-export { HandlebarsRenderer } from './modules/handlebars.renderer.js'
 export { MailModule } from './modules/mail.module.js'
 export {
   type MailClientOptions,

--- a/packages/api/nestjs-mail/lib/modules/handlebars.renderer.ts
+++ b/packages/api/nestjs-mail/lib/modules/handlebars.renderer.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { Inject, Injectable } from '@nestjs/common'
+import hbs from 'handlebars'
+import { MAIL_MODULE_OPTIONS, getTemplateRootPath } from './mail.module-definitions.js'
+import type { MailModuleOptions } from './mail.module-options.js'
+
+@Injectable()
+export class HandlebarsRenderer {
+  constructor (
+    @Inject(MAIL_MODULE_OPTIONS)
+    private readonly options: MailModuleOptions
+  ) {}
+
+  async render (
+    hbsFilePath: string,
+    data?: Record<string, unknown>
+  ): Promise<string> {
+    const templatePath = path.resolve(getTemplateRootPath(this.options), hbsFilePath)
+    const template = await fs.readFile(templatePath, 'utf-8')
+    const renderTemplate = hbs.compile(template)
+
+    return renderTemplate(data ?? {})
+  }
+}

--- a/packages/api/nestjs-mail/lib/modules/mail.module-definitions.ts
+++ b/packages/api/nestjs-mail/lib/modules/mail.module-definitions.ts
@@ -1,0 +1,11 @@
+import type { MailModuleOptions } from './mail.module-options.js'
+
+export const MAIL_MODULE_OPTIONS = 'wisemen.nestjs-mail.module.options'
+
+export function getTemplateRootPath (options: MailModuleOptions): string {
+  return options.templateRootPath ?? defaultTemplateRootPath()
+}
+
+function defaultTemplateRootPath (): string {
+  return process.cwd() + '/dist/src/modules'
+}

--- a/packages/api/nestjs-mail/lib/modules/mail.module-options.ts
+++ b/packages/api/nestjs-mail/lib/modules/mail.module-options.ts
@@ -1,0 +1,99 @@
+import type { FactoryProvider, ModuleMetadata } from '@nestjs/common'
+import { MailProvider } from '../enums/mail-provider.enum.js'
+
+/**
+ * Options for configuring a MailPit-backed mail client.
+ */
+export interface MailPitMailClientOptions {
+  /** Selects the MailPit client implementation. */
+  type: 'mailpit'
+  /** Base URL of the MailPit HTTP API. */
+  url: string
+  /** Default sender address used when `sendMail()` omits `from`. */
+  defaultFrom?: string
+  /** Optional HTTP basic auth credentials for protected MailPit instances. */
+  auth?: {
+    /** MailPit username. */
+    username: string
+    /** MailPit password. */
+    password: string
+  }
+  /** Optional MailPit tag added to every message. */
+  tag?: string
+}
+
+/**
+ * Options for configuring the Scaleway transactional email client.
+ */
+export interface ScalewayMailClientOptions {
+  /** Selects the Scaleway client implementation. */
+  type: MailProvider.SCALEWAY
+  /** Scaleway project identifier used for transactional email. */
+  projectId: string
+  /** Default sender address used when `sendMail()` omits `from`. */
+  from: string
+  /** Scaleway API token used for authenticated requests. */
+  apiKey: string
+  /** Scaleway region. Defaults to `fr-par` when omitted. */
+  region?: string
+}
+
+/**
+ * Options for configuring the SendGrid client.
+ */
+export interface SendGridMailClientOptions {
+  /** Selects the SendGrid client implementation. */
+  type: MailProvider.SEND_GRID
+  /** Default sender address used when `sendMail()` omits `from`. */
+  defaultFrom: string
+  /** SendGrid API token used for authenticated requests. */
+  apiToken: string
+}
+
+/**
+ * Options for configuring a no-op test client.
+ */
+export interface MockMailClientOptions {
+  /** Selects the mock client implementation. */
+  type: 'mock'
+}
+
+/**
+ * Supported concrete mail client configurations.
+ */
+export type MailClientOptions =
+  | MailPitMailClientOptions
+  | ScalewayMailClientOptions
+  | SendGridMailClientOptions
+  | MockMailClientOptions
+
+/**
+ * Synchronous configuration for `MailModule.forRoot(...)`.
+ */
+export interface MailModuleOptions {
+  /**
+   * Base path used by `HandlebarsRenderer` to resolve template file paths.
+   *
+   * Defaults to `<cwd>/dist/src/modules`.
+   */
+  templateRootPath?: string
+  /** Concrete mail client configuration to register in Nest DI. */
+  client: MailClientOptions
+}
+
+/**
+ * Async configuration for `MailModule.forRootAsync(...)`.
+ */
+export interface MailModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
+  /**
+   * Optional modules that should be imported before resolving the factory.
+   */
+  imports?: ModuleMetadata['imports']
+  /**
+   * Factory that resolves the module options from config, secrets, feature
+   * flags, or test setup.
+   */
+  useFactory: (...args: unknown[]) => Promise<MailModuleOptions> | MailModuleOptions
+  /** Dependencies injected into `useFactory`. */
+  inject?: FactoryProvider['inject']
+}

--- a/packages/api/nestjs-mail/lib/modules/mail.module.ts
+++ b/packages/api/nestjs-mail/lib/modules/mail.module.ts
@@ -1,7 +1,7 @@
 import { DynamicModule, Module, Provider } from '@nestjs/common'
+import { HANDLEBARS_MODULE_OPTIONS, HandlebarsRenderer, type HandlebarsModuleOptions } from '@wisemen/nestjs-handlebars'
 import { createMailClient } from '../clients/mail-client.factory.js'
 import { MailClient } from '../clients/mail.client.js'
-import { HandlebarsRenderer } from './handlebars.renderer.js'
 import { MAIL_MODULE_OPTIONS } from './mail.module-definitions.js'
 import type { MailModuleAsyncOptions, MailModuleOptions } from './mail.module-options.js'
 
@@ -20,6 +20,7 @@ export class MailModule {
       providers: [
         this.createOptionsProvider(options),
         this.createMailClientProvider(),
+        this.createHandlebarsOptionsProvider(),
         HandlebarsRenderer
       ],
       exports: [
@@ -41,6 +42,16 @@ export class MailModule {
     return {
       provide: MailClient,
       useFactory: (options: MailModuleOptions) => createMailClient(options.client),
+      inject: [MAIL_MODULE_OPTIONS]
+    }
+  }
+
+  private static createHandlebarsOptionsProvider (): Provider {
+    return {
+      provide: HANDLEBARS_MODULE_OPTIONS,
+      useFactory: (options: MailModuleOptions): HandlebarsModuleOptions => ({
+        templateRootPath: options.templateRootPath
+      }),
       inject: [MAIL_MODULE_OPTIONS]
     }
   }

--- a/packages/api/nestjs-mail/lib/modules/mail.module.ts
+++ b/packages/api/nestjs-mail/lib/modules/mail.module.ts
@@ -1,0 +1,47 @@
+import { DynamicModule, Module, Provider } from '@nestjs/common'
+import { createMailClient } from '../clients/mail-client.factory.js'
+import { MailClient } from '../clients/mail.client.js'
+import { HandlebarsRenderer } from './handlebars.renderer.js'
+import { MAIL_MODULE_OPTIONS } from './mail.module-definitions.js'
+import type { MailModuleAsyncOptions, MailModuleOptions } from './mail.module-options.js'
+
+@Module({})
+export class MailModule {
+  static forRoot (options: MailModuleOptions): DynamicModule {
+    return this.forRootAsync({
+      useFactory: () => options
+    })
+  }
+
+  static forRootAsync (options: MailModuleAsyncOptions): DynamicModule {
+    return {
+      module: MailModule,
+      imports: options.imports ?? [],
+      providers: [
+        this.createOptionsProvider(options),
+        this.createMailClientProvider(),
+        HandlebarsRenderer
+      ],
+      exports: [
+        HandlebarsRenderer,
+        MailClient
+      ]
+    }
+  }
+
+  private static createOptionsProvider (options: MailModuleAsyncOptions): Provider {
+    return {
+      provide: MAIL_MODULE_OPTIONS,
+      useFactory: options.useFactory,
+      inject: options.inject ?? []
+    }
+  }
+
+  private static createMailClientProvider (): Provider {
+    return {
+      provide: MailClient,
+      useFactory: (options: MailModuleOptions) => createMailClient(options.client),
+      inject: [MAIL_MODULE_OPTIONS]
+    }
+  }
+}

--- a/packages/api/nestjs-mail/lib/queue/mail-queue-name.ts
+++ b/packages/api/nestjs-mail/lib/queue/mail-queue-name.ts
@@ -1,0 +1,1 @@
+export const MAIL_QUEUE_NAME = 'mail'

--- a/packages/api/nestjs-mail/lib/queue/mail-queue.module-options.ts
+++ b/packages/api/nestjs-mail/lib/queue/mail-queue.module-options.ts
@@ -1,0 +1,12 @@
+import type { ModuleMetadata } from '@nestjs/common'
+
+/**
+ * Configuration for `MailQueueModule.forRoot(...)`.
+ */
+export interface MailQueueModuleOptions {
+  /**
+   * Modules imported into the queue module so the mail job handlers can
+   * resolve dependencies such as `MailClient` and `HandlebarsRenderer`.
+   */
+  imports?: ModuleMetadata['imports']
+}

--- a/packages/api/nestjs-mail/lib/queue/mail-queue.module.ts
+++ b/packages/api/nestjs-mail/lib/queue/mail-queue.module.ts
@@ -1,0 +1,18 @@
+import { DynamicModule, Module } from '@nestjs/common'
+import { SendHtmlMailJobHandler } from './send-html-mail.job-handler.js'
+import type { MailQueueModuleOptions } from './mail-queue.module-options.js'
+import { SendTemplateMailJobHandler } from './send-template-mail.job-handler.js'
+
+@Module({})
+export class MailQueueModule {
+  static forRoot (options: MailQueueModuleOptions = {}): DynamicModule {
+    return {
+      module: MailQueueModule,
+      imports: options.imports ?? [],
+      providers: [
+        SendHtmlMailJobHandler,
+        SendTemplateMailJobHandler
+      ]
+    }
+  }
+}

--- a/packages/api/nestjs-mail/lib/queue/send-html-mail.job-handler.ts
+++ b/packages/api/nestjs-mail/lib/queue/send-html-mail.job-handler.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common'
+import { JobHandler, PgBossJobHandler } from '@wisemen/pgboss-nestjs-job'
+import { MailClient } from '../clients/mail.client.js'
+import { SendHtmlMailJob, type SendHtmlMailJobData } from './send-html-mail.job.js'
+
+@Injectable()
+@PgBossJobHandler(SendHtmlMailJob)
+export class SendHtmlMailJobHandler extends JobHandler<SendHtmlMailJob> {
+  constructor (
+    private readonly mailClient: MailClient
+  ) {
+    super()
+  }
+
+  async run (mail: SendHtmlMailJobData): Promise<void> {
+    await this.mailClient.sendMail({
+      to: mail.to,
+      cc: mail.cc,
+      bcc: mail.bcc,
+      from: mail.from,
+      replyTo: mail.replyTo,
+      subject: mail.subject,
+      text: mail.text,
+      html: mail.html
+    })
+  }
+}

--- a/packages/api/nestjs-mail/lib/queue/send-html-mail.job-handler.ts
+++ b/packages/api/nestjs-mail/lib/queue/send-html-mail.job-handler.ts
@@ -7,7 +7,7 @@ import { SendHtmlMailJob, type SendHtmlMailJobData } from './send-html-mail.job.
 @PgBossJobHandler(SendHtmlMailJob)
 export class SendHtmlMailJobHandler extends JobHandler<SendHtmlMailJob> {
   constructor (
-    private readonly mailClient: MailClient
+    private mailClient: MailClient
   ) {
     super()
   }

--- a/packages/api/nestjs-mail/lib/queue/send-html-mail.job.ts
+++ b/packages/api/nestjs-mail/lib/queue/send-html-mail.job.ts
@@ -1,0 +1,21 @@
+import { BaseJob, type BaseJobData, PgBossJob } from '@wisemen/pgboss-nestjs-job'
+import { MAIL_QUEUE_NAME } from './mail-queue-name.js'
+
+export interface SendHtmlMailJobData extends BaseJobData {
+  from?: string
+  to: string
+  cc?: string
+  bcc?: string
+  replyTo?: string
+  subject: string
+  data: BaseJobData
+  text: string
+  html: string
+}
+
+@PgBossJob(MAIL_QUEUE_NAME)
+export class SendHtmlMailJob extends BaseJob<SendHtmlMailJobData> {
+  constructor (data: SendHtmlMailJobData) {
+    super(data)
+  }
+}

--- a/packages/api/nestjs-mail/lib/queue/send-template-mail.job-handler.ts
+++ b/packages/api/nestjs-mail/lib/queue/send-template-mail.job-handler.ts
@@ -1,15 +1,15 @@
 import { Injectable } from '@nestjs/common'
+import { HandlebarsRenderer } from '@wisemen/nestjs-handlebars'
 import { JobHandler, PgBossJobHandler } from '@wisemen/pgboss-nestjs-job'
 import { MailClient } from '../clients/mail.client.js'
-import { HandlebarsRenderer } from '../modules/handlebars.renderer.js'
 import { SendTemplateMailJob, type SendTemplateMailJobData } from './send-template-mail.job.js'
 
 @Injectable()
 @PgBossJobHandler(SendTemplateMailJob)
 export class SendTemplateMailJobHandler extends JobHandler<SendTemplateMailJob> {
   constructor (
-    private readonly mailClient: MailClient,
-    private readonly handlebarsRenderer: HandlebarsRenderer
+    private mailClient: MailClient,
+    private handlebarsRenderer: HandlebarsRenderer
   ) {
     super()
   }

--- a/packages/api/nestjs-mail/lib/queue/send-template-mail.job-handler.ts
+++ b/packages/api/nestjs-mail/lib/queue/send-template-mail.job-handler.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common'
+import { JobHandler, PgBossJobHandler } from '@wisemen/pgboss-nestjs-job'
+import { MailClient } from '../clients/mail.client.js'
+import { HandlebarsRenderer } from '../modules/handlebars.renderer.js'
+import { SendTemplateMailJob, type SendTemplateMailJobData } from './send-template-mail.job.js'
+
+@Injectable()
+@PgBossJobHandler(SendTemplateMailJob)
+export class SendTemplateMailJobHandler extends JobHandler<SendTemplateMailJob> {
+  constructor (
+    private readonly mailClient: MailClient,
+    private readonly handlebarsRenderer: HandlebarsRenderer
+  ) {
+    super()
+  }
+
+  async run (mail: SendTemplateMailJobData): Promise<void> {
+    const [html, text] = await Promise.all([
+      this.handlebarsRenderer.render(mail.htmlHbsFilePath, mail.data),
+      this.handlebarsRenderer.render(mail.textHbsFilePath, mail.data)
+    ])
+
+    await this.mailClient.sendMail({
+      to: mail.to,
+      cc: mail.cc,
+      bcc: mail.bcc,
+      from: mail.from,
+      replyTo: mail.replyTo,
+      subject: mail.subject,
+      text,
+      html
+    })
+  }
+}

--- a/packages/api/nestjs-mail/lib/queue/send-template-mail.job.ts
+++ b/packages/api/nestjs-mail/lib/queue/send-template-mail.job.ts
@@ -1,0 +1,21 @@
+import { BaseJob, type BaseJobData, PgBossJob } from '@wisemen/pgboss-nestjs-job'
+import { MAIL_QUEUE_NAME } from './mail-queue-name.js'
+
+export interface SendTemplateMailJobData extends BaseJobData {
+  from?: string
+  to: string
+  cc?: string
+  bcc?: string
+  replyTo?: string
+  subject: string
+  data: BaseJobData
+  textHbsFilePath: string
+  htmlHbsFilePath: string
+}
+
+@PgBossJob(MAIL_QUEUE_NAME)
+export class SendTemplateMailJob extends BaseJob<SendTemplateMailJobData> {
+  constructor (data: SendTemplateMailJobData) {
+    super(data)
+  }
+}

--- a/packages/api/nestjs-mail/lib/utils/exhaustive-check.ts
+++ b/packages/api/nestjs-mail/lib/utils/exhaustive-check.ts
@@ -1,0 +1,3 @@
+export function exhaustiveCheck (value: never): never {
+  throw new Error(`Unhandled value: ${String(value)}`)
+}

--- a/packages/api/nestjs-mail/package.json
+++ b/packages/api/nestjs-mail/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@wisemen/nestjs-mail",
+  "version": "0.0.1",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist/",
+    "skills/"
+  ],
+  "scripts": {
+    "lint:oxlint": "oxlint --type-aware lib",
+    "lint:eslint": "eslint lib",
+    "lint": "pnpm run lint:oxlint && pnpm run lint:eslint",
+    "prebuild": "rm -rf ./dist",
+    "clean": "rm -rf ./dist",
+    "build": "tsc",
+    "prerelease": "npm run build",
+    "release": "pnpx release-it"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "catalog:backend-peer",
+    "@wisemen/api-error": "workspace:^"
+  },
+  "dependencies": {
+    "@wisemen/pgboss-nestjs-job": "workspace:*",
+    "handlebars": "^4.7.8",
+    "mailpit-api": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:backend",
+    "@wisemen/eslint-config-nestjs": "workspace:*",
+    "eslint": "catalog:lint-api",
+    "oxlint": "catalog:lint-api",
+    "oxlint-tsgolint": "catalog:lint-api",
+    "typescript": "catalog:peer"
+  },
+  "author": "Wisemen",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wisemen-digital/wisemen-core",
+    "directory": "packages/api/nestjs-mail"
+  }
+}

--- a/packages/api/nestjs-mail/skills/getting-started/SKILL.md
+++ b/packages/api/nestjs-mail/skills/getting-started/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: getting-started
+description: Use when configuring transactional mail delivery in NestJS APIs with @wisemen/nestjs-mail.
+---
+
+# @wisemen/nestjs-mail - Getting Started
+
+Use `MailModule.forRootAsync(...)` to register a shared `MailClient` and
+`HandlebarsRenderer`, then keep provider selection in your application layer.
+
+## Send Mail
+
+Inject `MailClient` into a use case, service, or job handler and call
+`sendMail(...)` with html or text content.
+
+```ts
+import { Injectable } from '@nestjs/common'
+import { MailClient } from '@wisemen/nestjs-mail'
+
+@Injectable()
+export class SendWelcomeMailUseCase {
+  constructor(private readonly mailClient: MailClient) {}
+
+  async send(to: string): Promise<void> {
+    await this.mailClient.sendMail({
+      to,
+      subject: 'Welcome',
+      text: 'Welcome to the platform'
+    })
+  }
+}
+```
+
+## Render Handlebars Templates
+
+Use `HandlebarsRenderer` when the mail body should come from `.hbs` templates in
+your built application output.
+
+```ts
+import { Injectable } from '@nestjs/common'
+import { HandlebarsRenderer, MailClient } from '@wisemen/nestjs-mail'
+
+@Injectable()
+export class SendTemplateMailUseCase {
+  constructor(
+    private readonly mailClient: MailClient,
+    private readonly renderer: HandlebarsRenderer
+  ) {}
+
+  async send(to: string, data: Record<string, unknown>): Promise<void> {
+    const [html, text] = await Promise.all([
+      this.renderer.render('mail/templates/welcome.html.hbs', data),
+      this.renderer.render('mail/templates/welcome.text.hbs', data)
+    ])
+
+    await this.mailClient.sendMail({
+      to,
+      subject: 'Welcome',
+      html,
+      text
+    })
+  }
+}
+```

--- a/packages/api/nestjs-mail/skills/getting-started/SKILL.md
+++ b/packages/api/nestjs-mail/skills/getting-started/SKILL.md
@@ -38,7 +38,8 @@ your built application output.
 
 ```ts
 import { Injectable } from '@nestjs/common'
-import { HandlebarsRenderer, MailClient } from '@wisemen/nestjs-mail'
+import { HandlebarsRenderer } from '@wisemen/nestjs-handlebars'
+import { MailClient } from '@wisemen/nestjs-mail'
 
 @Injectable()
 export class SendTemplateMailUseCase {

--- a/packages/api/nestjs-mail/tsconfig.json
+++ b/packages/api/nestjs-mail/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./lib",
+    "declaration": true,
+    "target": "esnext",
+    "module": "NodeNext",
+    "types": [
+      "node"
+    ],
+    "strictFunctionTypes": false,
+    "moduleResolution": "nodenext",
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "resolveJsonModule": true,
+    "strictNullChecks": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "./lib/**/*.ts"
+  ],
+  "exclude": [
+    "./lib/**/*.spec.ts"
+  ],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1874,6 +1874,34 @@ importers:
         specifier: catalog:build
         version: 4.21.0
 
+  packages/api/nestjs-handlebars:
+    dependencies:
+      '@nestjs/common':
+        specifier: catalog:backend-peer
+        version: 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.9
+    devDependencies:
+      '@types/node':
+        specifier: catalog:backend
+        version: 25.3.0
+      '@wisemen/eslint-config-nestjs':
+        specifier: workspace:*
+        version: link:../eslint-config-nestjs
+      eslint:
+        specifier: catalog:lint-api
+        version: 10.2.1(jiti@2.7.0)
+      oxlint:
+        specifier: catalog:lint-api
+        version: 1.59.0(oxlint-tsgolint@0.20.0)
+      oxlint-tsgolint:
+        specifier: catalog:lint-api
+        version: 0.20.0
+      typescript:
+        specifier: catalog:peer
+        version: 5.9.3
+
   packages/api/nestjs-mail:
     dependencies:
       '@nestjs/common':
@@ -1882,12 +1910,12 @@ importers:
       '@wisemen/api-error':
         specifier: workspace:^
         version: link:../api-error
+      '@wisemen/nestjs-handlebars':
+        specifier: workspace:^
+        version: link:../nestjs-handlebars
       '@wisemen/pgboss-nestjs-job':
         specifier: workspace:*
         version: link:../pgboss-nestjs-job
-      handlebars:
-        specifier: ^4.7.8
-        version: 4.7.9
       mailpit-api:
         specifier: ^2.0.0
         version: 2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1874,6 +1874,43 @@ importers:
         specifier: catalog:build
         version: 4.21.0
 
+  packages/api/nestjs-mail:
+    dependencies:
+      '@nestjs/common':
+        specifier: catalog:backend-peer
+        version: 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@wisemen/api-error':
+        specifier: workspace:^
+        version: link:../api-error
+      '@wisemen/pgboss-nestjs-job':
+        specifier: workspace:*
+        version: link:../pgboss-nestjs-job
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.9
+      mailpit-api:
+        specifier: ^2.0.0
+        version: 2.1.0
+    devDependencies:
+      '@types/node':
+        specifier: catalog:backend
+        version: 25.3.0
+      '@wisemen/eslint-config-nestjs':
+        specifier: workspace:*
+        version: link:../eslint-config-nestjs
+      eslint:
+        specifier: catalog:lint-api
+        version: 10.2.1(jiti@2.7.0)
+      oxlint:
+        specifier: catalog:lint-api
+        version: 1.59.0(oxlint-tsgolint@0.20.0)
+      oxlint-tsgolint:
+        specifier: catalog:lint-api
+        version: 0.20.0
+      typescript:
+        specifier: catalog:peer
+        version: 5.9.3
+
   packages/api/nestjs-nats:
     dependencies:
       '@nats-io/jetstream':
@@ -12753,6 +12790,10 @@ packages:
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  mailpit-api@2.1.0:
+    resolution: {integrity: sha512-ZZG5ShQS2E5QH9p1xeD2U2sfahKEEgRvtzIlJXsLUtLSUbYjmxPeuvciwayj0oxA+hn85xzIEt1v8FsXtwqKCA==}
+    engines: {node: '>=18.0.0'}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -25637,6 +25678,8 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
+
+  mailpit-api@2.1.0: {}
 
   make-dir@4.0.0:
     dependencies:


### PR DESCRIPTION
## What
Add a reusable `@wisemen/nestjs-mail` package under `packages/api` with Nest-friendly mail client modules, a queue module, shared mail jobs, and a package getting-started skill.

## Why
Move the mail implementation and its fixed queue job behavior into a reusable package so other services can keep provider policy in-app while reusing the same mail infrastructure.

## How
Expose `forRootAsync`-based mail and queue modules, export the shared `mail` queue name and job handlers, reorganize the package into `clients`, `modules`, and `queue` folders, and document the module options with JSDoc.