### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/soft-quiet-heron.md
+++ b/.bumpy/soft-quiet-heron.md
@@ -1,5 +1,0 @@
----
-"@wisemen/payload-core-translate": patch
----
-
-Added a max concurrency on the deepl plugin to prevent 429

--- a/packages/payload/translate/CHANGELOG.md
+++ b/packages/payload/translate/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 
 
+
+## 0.0.4
+<sub>2026-07-24</sub>
+
+- [#1484](https://github.com/wisemen-digital/wisemen-core/pull/1484)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Added a max concurrency on the deepl plugin to prevent 429
+
 ## 0.0.3
 <sub>2026-07-17</sub>
 

--- a/packages/payload/translate/package.json
+++ b/packages/payload/translate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wisemen/payload-core-translate",
   "type": "module",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": false,
   "imports": {
     "#*": "./src/*"


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/payload-core-translate` 0.0.3 → **0.0.4** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1485/changes#diff-a54dcc7b88d4691b865d70b05800c6ffeb2fadb2034d69d9e3bdcbcde47da224)</sub>

- Added a max concurrency on the deepl plugin to prevent 429 ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1485/changes#diff-65409addc49f3ddd8dbae56dcb9a03fa0510eb3a959eba471235586df1416778))
