### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/add-sidebar-subitem-count-and-dot.md
+++ b/.bumpy/add-sidebar-subitem-count-and-dot.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": minor
----
-
-Added badge/count and status dot support to main sidebar navigation sub-items.

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -25,6 +25,12 @@
 
 
 
+
+## 1.17.0
+<sub>2026-07-27</sub>
+
+- [#1494](https://github.com/wisemen-digital/wisemen-core/pull/1494)  *(minor)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Added badge/count and status dot support to main sidebar navigation sub-items.
+
 ## 1.16.0
 <sub>2026-07-17</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/vue-core-design-system` 1.16.0 → **1.17.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1495/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Added badge/count and status dot support to main sidebar navigation sub-items. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1495/changes#diff-ff1f7538cf75e655ee372178ed168d852e97e237b00899a3ea84af2e6b228a3b))
