### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/bright-kind-robin.md
+++ b/.bumpy/bright-kind-robin.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-async-api": patch
----
-
-fix: exported file

--- a/.bumpy/shy-grand-lake.md
+++ b/.bumpy/shy-grand-lake.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-feature-flags": patch
----
-
-chore: bump @openfeature/go-feature-flag-provider to 1.4.0

--- a/packages/api/nestjs-async-api/CHANGELOG.md
+++ b/packages/api/nestjs-async-api/CHANGELOG.md
@@ -1,6 +1,12 @@
 # @wisemen/nestjs-async-api
 
 
+
+## 0.1.4
+<sub>2026-07-28</sub>
+
+- [#1510](https://github.com/wisemen-digital/wisemen-core/pull/1510)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - fix: exported file
+
 ## 0.1.3
 <sub>2026-07-28</sub>
 

--- a/packages/api/nestjs-async-api/package.json
+++ b/packages/api/nestjs-async-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-async-api",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/nestjs-feature-flags/CHANGELOG.md
+++ b/packages/api/nestjs-feature-flags/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 0.0.6
+<sub>2026-07-28</sub>
+
+- [#1509](https://github.com/wisemen-digital/wisemen-core/pull/1509)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - chore: bump @openfeature/go-feature-flag-provider to 1.4.0
+
 ## 0.0.5
 <sub>2026-07-28</sub>
 

--- a/packages/api/nestjs-feature-flags/package.json
+++ b/packages/api/nestjs-feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-feature-flags",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/nestjs-async-api` 0.1.3 → **0.1.4** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1513/changes#diff-c124263b3d3d2632f78cd923b5580aa20f679fe12f8f449cbd6aec919175cdc4)</sub>

- fix: exported file ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1513/changes#diff-55a67031d89317f1e3dc5763372db8f032ff43833700a9379eaabad03d6aac47))

#### `@wisemen/nestjs-feature-flags` 0.0.5 → **0.0.6** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1513/changes#diff-890a7f6a0164fc3abf7011317a3c8f9a872ad7a91e002cf2e61bf1ce54e570d1)</sub>

- chore: bump @openfeature/go-feature-flag-provider to 1.4.0 ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1513/changes#diff-c2e6526051cf3010a4d0990aae78d50c2d3e820b1298baf6518258050a88535f))
