### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/brave-witty-lily.md
+++ b/.bumpy/brave-witty-lily.md
@@ -1,5 +1,0 @@
----
-"@wisemen/datewise": patch
----
-
-Replace toString() in transformer with toISOString()

--- a/.bumpy/class-validator-json-api-errors.md
+++ b/.bumpy/class-validator-json-api-errors.md
@@ -1,6 +1,0 @@
----
-"@wisemen/api-error": minor
-"@wisemen/nestjs-nats": patch
----
-
-add class-validator json api error conversion

--- a/.bumpy/odd-rich-gnu.md
+++ b/.bumpy/odd-rich-gnu.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-redis": patch
----
-
-chore: bump redis to 5.12.1

--- a/.bumpy/tbn-1403-address-response-from.md
+++ b/.bumpy/tbn-1403-address-response-from.md
@@ -1,5 +1,0 @@
----
-"@wisemen/address": minor
----
-
-add AddressResponse.from factory

--- a/.bumpy/witty-odd-owl.md
+++ b/.bumpy/witty-odd-owl.md
@@ -1,5 +1,0 @@
----
-"@wisemen/monetary": patch
----
-
-fix: remove @wisemen/nestjs-typeorm dependency

--- a/packages/api/address/CHANGELOG.md
+++ b/packages/api/address/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 0.5.0
+<sub>2026-07-29</sub>
+
+- [#1517](https://github.com/wisemen-digital/wisemen-core/pull/1517)  *(minor)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - add AddressResponse.from factory
+
 ## 0.4.8
 <sub>2026-07-28</sub>
 

--- a/packages/api/address/package.json
+++ b/packages/api/address/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/address",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/api-error/CHANGELOG.md
+++ b/packages/api/api-error/CHANGELOG.md
@@ -1,6 +1,12 @@
 # @wisemen/api-error
 
 
+
+## 1.1.0
+<sub>2026-07-29</sub>
+
+- [#1518](https://github.com/wisemen-digital/wisemen-core/pull/1518)  *(minor)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - add class-validator json api error conversion
+
 ## 1.0.1
 <sub>2026-07-28</sub>
 

--- a/packages/api/api-error/package.json
+++ b/packages/api/api-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/api-error",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/datewise/CHANGELOG.md
+++ b/packages/api/datewise/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 
 
+
+## 1.0.17
+<sub>2026-07-29</sub>
+
+- [#1520](https://github.com/wisemen-digital/wisemen-core/pull/1520)  *(patch)* Thanks [@YuHangHuu](https://github.com/YuHangHuu)! - Replace toString() in transformer with toISOString()
+
 ## 1.0.16
 <sub>2026-07-28</sub>
 

--- a/packages/api/datewise/package.json
+++ b/packages/api/datewise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/datewise",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/monetary/CHANGELOG.md
+++ b/packages/api/monetary/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 
 
+
+## 0.5.6
+<sub>2026-07-29</sub>
+
+- [#1516](https://github.com/wisemen-digital/wisemen-core/pull/1516)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - fix: remove @wisemen/nestjs-typeorm dependency
+
 ## 0.5.5
 <sub>2026-07-28</sub>
 

--- a/packages/api/monetary/package.json
+++ b/packages/api/monetary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/monetary",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/nestjs-nats/CHANGELOG.md
+++ b/packages/api/nestjs-nats/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 
 
+
+## 1.1.3
+<sub>2026-07-29</sub>
+
+- [#1518](https://github.com/wisemen-digital/wisemen-core/pull/1518)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - add class-validator json api error conversion
+
 ## 1.1.2
 <sub>2026-07-28</sub>
 

--- a/packages/api/nestjs-nats/package.json
+++ b/packages/api/nestjs-nats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-nats",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/nestjs-redis/CHANGELOG.md
+++ b/packages/api/nestjs-redis/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 1.0.4
+<sub>2026-07-29</sub>
+
+- [#1508](https://github.com/wisemen-digital/wisemen-core/pull/1508)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - chore: bump redis to 5.12.1
+
 ## 1.0.3
 <sub>2026-07-28</sub>
 

--- a/packages/api/nestjs-redis/package.json
+++ b/packages/api/nestjs-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-redis",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/address` 0.4.8 → **0.5.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-54d9fffe4154775b6af2a3dedf390cce50d111e98d559e97c44060aa20c0ccc1)</sub>

- add AddressResponse.from factory ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-b2d9f7ee6f0a476d340d992aa8d83087a89f183933cb93ca4deb716f9960b9a4))

#### `@wisemen/api-error` 1.0.1 → **1.1.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-8a0304c15da1950450931ab73175e9b986efc813e54e21999a1112eb1591134a)</sub>

- add class-validator json api error conversion ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-33541b3bca772f93f6e15d0eb9817c27f36e11a60c83bc28d3c697844973c6c0))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/datewise` 1.0.16 → **1.0.17** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-88a4357e34692fb8c47dd40f7e67e57f7dcddebdfabc0748f8ae39987bb00f80)</sub>

- Replace toString() in transformer with toISOString() ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-d6236bee3e95335840baee3e440d8a47107533a9dfd3f7420bb84a0a649f2ce5))

#### `@wisemen/monetary` 0.5.5 → **0.5.6** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-6fef78bc0eff06a7e167873054f51680fe05003d64da6bce2c0827e36e633fa3)</sub>

- fix: remove @wisemen/nestjs-typeorm dependency ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-5afe9e1f4b544f30cc62abbc3bead2cd88ca8b5de6c35ac3e0c24fc0f6c2ae99))

#### `@wisemen/nestjs-nats` 1.1.2 → **1.1.3** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-81a951dd5868500cf33991ba2bcacfdd310d9cb41f91b73a9dd2b766ce9228ae)</sub>

- add class-validator json api error conversion ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-33541b3bca772f93f6e15d0eb9817c27f36e11a60c83bc28d3c697844973c6c0))

#### `@wisemen/nestjs-redis` 1.0.3 → **1.0.4** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-adea7960faef76179c559df25509dc6de014f6526a86700b7724ffe66e1dda76)</sub>

- chore: bump redis to 5.12.1 ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1515/changes#diff-3c1a7549395a9f7d415d1866e777a95c6002741be39ec0170aceaacb4286a9ee))
