### PR TITLE
feat(TBN-1403): add AddressResponse.from nullable factory

### DIFF
--- a/.bumpy/tbn-1403-address-response-from.md
+++ b/.bumpy/tbn-1403-address-response-from.md
@@ -1,0 +1,5 @@
+---
+"@wisemen/address": minor
+---
+
+add AddressResponse.from factory

--- a/packages/api/address/lib/address-response.ts
+++ b/packages/api/address/lib/address-response.ts
@@ -3,6 +3,13 @@ import { CoordinatesResponse } from '@wisemen/coordinates'
 import { Address } from './address.js'
 
 export class AddressResponse {
+  static from (address: Address): AddressResponse
+  static from (address: null): null
+  static from (address: Address | null): AddressResponse | null
+  static from (address: Address | null): AddressResponse | null {
+    return address !== null ? new AddressResponse(address) : null
+  }
+
   @ApiProperty({ type: 'string', nullable: true })
   placeName: string | null
 
@@ -43,8 +50,6 @@ export class AddressResponse {
     this.streetName = address.streetName ?? null
     this.streetNumber = address.streetNumber ?? null
     this.unit = address.unit ?? null
-    this.coordinates = address.coordinates != null
-      ? new CoordinatesResponse(address.coordinates)
-      : null
+    this.coordinates = CoordinatesResponse.from(address.coordinates ?? null)
   }
 }

--- a/packages/api/address/lib/tests/address-response.unit.test.ts
+++ b/packages/api/address/lib/tests/address-response.unit.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from 'node:test'
+import { expect } from 'expect'
+import { Coordinates, CoordinatesResponse } from '@wisemen/coordinates'
+import { AddressBuilder } from '../address.builder.js'
+import { AddressResponse } from '../address-response.js'
+
+describe('AddressResponse.from', () => {
+  it('returns null when address is null', () => {
+    expect(AddressResponse.from(null)).toBeNull()
+  })
+
+  it('returns a response when address is provided', () => {
+    const address = new AddressBuilder()
+      .withPlaceName('Main Office')
+      .withPlaceId('place-123')
+      .withCountry('Belgium')
+      .withCountryCode('BE')
+      .withCity('Brussels')
+      .withPostalCode('1000')
+      .withStreetName('Main Street')
+      .withStreetNumber('1')
+      .withUnit('A')
+      .withCoordinates(new Coordinates(50.8503, 4.3517))
+      .build()
+
+    const response = AddressResponse.from(address)
+
+    expect(response).toBeInstanceOf(AddressResponse)
+    expect(response?.coordinates).toBeInstanceOf(CoordinatesResponse)
+    expect(response).toMatchObject({
+      placeName: 'Main Office',
+      placeId: 'place-123',
+      country: 'Belgium',
+      countryCode: 'BE',
+      city: 'Brussels',
+      postalCode: '1000',
+      streetName: 'Main Street',
+      streetNumber: '1',
+      unit: 'A',
+      coordinates: {
+        latitude: 50.8503,
+        longitude: 4.3517
+      }
+    })
+  })
+})


### PR DESCRIPTION
## What
Adds `AddressResponse.from` to `@wisemen/address` for nullable-safe response mapping in TBN-1403, and adds a focused unit test plus the package bump entry.

## Why
Consumers of the address package need the same nullable response factory pattern that already exists in other API packages so nested response mapping stays consistent.

## How
The response now exposes overloaded `from` signatures for `Address | null` and delegates nested coordinate mapping to `CoordinatesResponse.from(...)` to keep nullable handling aligned with the existing coordinates package.