### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/calm-happy-ibis.md
+++ b/.bumpy/calm-happy-ibis.md
@@ -1,5 +1,0 @@
----
-"@wisemen/payload-core-seeder": patch
----
-
-Initial release

--- a/.bumpy/tough-wide-rose.md
+++ b/.bumpy/tough-wide-rose.md
@@ -1,5 +1,0 @@
----
-"@wisemen/opentelemetry": patch
----
-
-Added correct semantic convention and added more error options

--- a/packages/api/opentelemetry/CHANGELOG.md
+++ b/packages/api/opentelemetry/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 
 
+
+## 0.2.7
+<sub>2026-07-29</sub>
+
+- [#1519](https://github.com/wisemen-digital/wisemen-core/pull/1519)  *(patch)* Thanks [@SebastiaanVanspauwen](https://github.com/SebastiaanVanspauwen)! - Added correct semantic convention and added more error options
+
 ## 0.2.6
 <sub>2026-07-28</sub>
 

--- a/packages/api/opentelemetry/package.json
+++ b/packages/api/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/opentelemetry",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/payload/seeder/CHANGELOG.md
+++ b/packages/payload/seeder/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.1
+<sub>2026-07-29</sub>
+
+- [#1522](https://github.com/wisemen-digital/wisemen-core/pull/1522)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Initial release

--- a/packages/payload/seeder/package.json
+++ b/packages/payload/seeder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/payload-core-seeder",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "PayloadCMS seeding with locales",
   "keywords": [


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/opentelemetry` 0.2.6 → **0.2.7** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1521/changes#diff-6304e36b5db5e7292f398c1066f7512b2d5b2eba9b324a87f1b646585c1aa49b)</sub>

- Added correct semantic convention and added more error options ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1521/changes#diff-a4c3bd3a937da8d55f3d6db95dbc1d5e2b6d32b5ad5b925a0e3a90c373f67693))

#### `@wisemen/payload-core-seeder` 0.1.0 → **0.1.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1521/changes#diff-8d5b06158128a329849decc2d1f69980d386ee399fc623f585e34529c1285b85)</sub>

- Initial release ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1521/changes#diff-6ebf7d79dbd948f654c7627eb2a1ade456f6e7f8814f27804f6e987b4ca2cf5f))
