### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/add-tabs-item-indicator-config.md
+++ b/.bumpy/add-tabs-item-indicator-config.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": minor
----
-
-Added a `config` prop to `TabsItem`/`TabsRouterLinkItem` for left content and a right-side indicator (count badge or dot, e.g. to flag a tab with a form error), matching `MenuItemConfig`'s API shape. The existing `icon`/`count` props are deprecated but still work.

--- a/.bumpy/fix-date-picker-placeholder-month.md
+++ b/.bumpy/fix-date-picker-placeholder-month.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fixed the date picker calendar opening on the current month instead of the month of the bound value.

--- a/.bumpy/fix-detail-pane-bordered-overflow.md
+++ b/.bumpy/fix-detail-pane-bordered-overflow.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fixed the detail pane's bordered variants clipping the sticky header and footer backgrounds to square corners instead of the pane's rounded border.

--- a/.bumpy/fix-switch-shrink.md
+++ b/.bumpy/fix-switch-shrink.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fixed the Switch component shrinking when placed in a flex container with limited space.

--- a/.bumpy/huge-fast-toad.md
+++ b/.bumpy/huge-fast-toad.md
@@ -1,5 +1,0 @@
----
-"@wisemen/scoped-filter": patch
----
-
-fix: allow empty include and exclude lists

--- a/.bumpy/shy-old-moth.md
+++ b/.bumpy/shy-old-moth.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-http-exception-filter": patch
----
-
-release

--- a/packages/api/nestjs-http-exception-filter/CHANGELOG.md
+++ b/packages/api/nestjs-http-exception-filter/CHANGELOG.md
@@ -1,3 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## 0.0.1
+<sub>2026-07-31</sub>
+
+- [#1529](https://github.com/wisemen-digital/wisemen-core/pull/1529)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - release

--- a/packages/api/nestjs-http-exception-filter/package.json
+++ b/packages/api/nestjs-http-exception-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-http-exception-filter",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/scoped-filter/CHANGELOG.md
+++ b/packages/api/scoped-filter/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 
 
+
+## 1.0.7
+<sub>2026-07-31</sub>
+
+- [#1529](https://github.com/wisemen-digital/wisemen-core/pull/1529)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - fix: allow empty include and exclude lists
+
 ## 1.0.6
 <sub>2026-07-28</sub>
 

--- a/packages/api/scoped-filter/package.json
+++ b/packages/api/scoped-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/scoped-filter",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -26,6 +26,15 @@
 
 
 
+
+## 1.18.0
+<sub>2026-07-31</sub>
+
+- [#1496](https://github.com/wisemen-digital/wisemen-core/pull/1496)  *(minor)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Added a `config` prop to `TabsItem`/`TabsRouterLinkItem` for left content and a right-side indicator (count badge or dot, e.g. to flag a tab with a form error), matching `MenuItemConfig`'s API shape. The existing `icon`/`count` props are deprecated but still work.
+- [#1497](https://github.com/wisemen-digital/wisemen-core/pull/1497)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Fixed the detail pane's bordered variants clipping the sticky header and footer backgrounds to square corners instead of the pane's rounded border.
+- [#1498](https://github.com/wisemen-digital/wisemen-core/pull/1498)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Fixed the date picker calendar opening on the current month instead of the month of the bound value.
+- [#1499](https://github.com/wisemen-digital/wisemen-core/pull/1499)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Fixed the Switch component shrinking when placed in a flex container with limited space.
+
 ## 1.17.0
 <sub>2026-07-27</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/vue-core-design-system` 1.17.0 → **1.18.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1528/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Added a `config` prop to `TabsItem`/`TabsRouterLinkItem` for left content and a right-side indicator (count badge or dot, e.g. to flag a tab with a form error), matching `MenuItemConfig`'s API shape. The existing `icon`/`count` props are deprecated but still work. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1528/changes#diff-5120b5fa6f30218aaed1f9d6d24e584fc206fe40f0bfac5684a1883063137759))
- Fixed the detail pane's bordered variants clipping the sticky header and footer backgrounds to square corners instead of the pane's rounded border. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1528/changes#diff-04ff5327907cfa60443c91e67144a845bf1c1ef2bebf9330398cbefaaf20ea87))
- Fixed the date picker calendar opening on the current month instead of the month of the bound value. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1528/changes#diff-f04713ba71b76846a9db21a9a82171b1d1afb09c5c3281f7b3ffcd1e81f0512e))
- Fixed the Switch component shrinking when placed in a flex container with limited space. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1528/changes#diff-8cda26cb0e54a0961471537e8284c75a8a891d45fefb76a619002a282b9025ff))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/nestjs-http-exception-filter` 0.0.0 → **0.0.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1528/changes#diff-486fddd3f387712139103666bbebbc27b3774368acf1671ccacd7adfe6dde02c)</sub>

- release ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1528/changes#diff-f77d8d16edb534744bb5333ae17129d159f93eff3824019be941930a7fad83a1))

#### `@wisemen/scoped-filter` 1.0.6 → **1.0.7** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1528/changes#diff-e237bf1a849d4de86c426bf169d71c2e8790161bedaecc1e3b0a19f07e934fee)</sub>

- fix: allow empty include and exclude lists ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1528/changes#diff-1403ea264c09548817f00e89f8a2bd1d110c5acf5ada33da3ac6536570439d26))
