### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/copper-light-fox.md
+++ b/.bumpy/copper-light-fox.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-nats": patch
----
-
-Added a way to publish on a stream

--- a/.bumpy/fix-date-picker-initial-placeholder.md
+++ b/.bumpy/fix-date-picker-initial-placeholder.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fixed the date picker and date range picker opening on a fully-disabled month when today's date (or the current value) falls before minDate or after maxDate; the calendar now opens clamped to the nearest selectable date.

--- a/packages/api/nestjs-nats/CHANGELOG.md
+++ b/packages/api/nestjs-nats/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 
 
+
+## 1.1.4
+<sub>2026-07-31</sub>
+
+- [#1412](https://github.com/wisemen-digital/wisemen-core/pull/1412)  *(patch)* Thanks [@JonasVannieuwenhuijsen](https://github.com/JonasVannieuwenhuijsen)! - Added a way to publish on a stream
+
 ## 1.1.3
 <sub>2026-07-29</sub>
 

--- a/packages/api/nestjs-nats/package.json
+++ b/packages/api/nestjs-nats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-nats",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -27,6 +27,12 @@
 
 
 
+
+## 1.18.1
+<sub>2026-07-31</sub>
+
+- [#1534](https://github.com/wisemen-digital/wisemen-core/pull/1534)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Fixed the date picker and date range picker opening on a fully-disabled month when today's date (or the current value) falls before minDate or after maxDate; the calendar now opens clamped to the nearest selectable date.
+
 ## 1.18.0
 <sub>2026-07-31</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/nestjs-nats` 1.1.3 → **1.1.4** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1536/changes#diff-81a951dd5868500cf33991ba2bcacfdd310d9cb41f91b73a9dd2b766ce9228ae)</sub>

- Added a way to publish on a stream ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1536/changes#diff-8c1a261c43514c5620b99f1b68bbb53be74f3bf625a989df705acd59e83a594a))

#### `@wisemen/vue-core-design-system` 1.18.0 → **1.18.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1536/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Fixed the date picker and date range picker opening on a fully-disabled month when today's date (or the current value) falls before minDate or after maxDate; the calendar now opens clamped to the nearest selectable date. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1536/changes#diff-597fd8095280a27e923658de0ae668008aaae02661dd0fc3cbac6721320718ff))
