### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/new-pure-nest.md
+++ b/.bumpy/new-pure-nest.md
@@ -1,8 +1,0 @@
----
-"@wisemen/vue-core-components": patch
-"@wisemen/vue-core-custom-views": patch
-"@wisemen/vue-core-design-system": minor
-"@wisemen/vue-core-preferences": patch
----
-
-Make select and autocomplete popovers responsive on mobile. The popover will become a bottom drawer with the options

--- a/packages/web/components-next/CHANGELOG.md
+++ b/packages/web/components-next/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 3.0.5
+<sub>2026-08-03</sub>
+
+- [#1531](https://github.com/wisemen-digital/wisemen-core/pull/1531)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Make select and autocomplete popovers responsive on mobile. The popover will become a bottom drawer with the options
+
 ## 3.0.4
 <sub>2026-06-30</sub>
 

--- a/packages/web/components-next/package.json
+++ b/packages/web/components-next/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/packages/web/custom-views/CHANGELOG.md
+++ b/packages/web/custom-views/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 
 
+
+## 1.0.2
+<sub>2026-08-03</sub>
+
+- [#1531](https://github.com/wisemen-digital/wisemen-core/pull/1531)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Make select and autocomplete popovers responsive on mobile. The popover will become a bottom drawer with the options
+
 ## 1.0.1
 <sub>2026-07-08</sub>
 

--- a/packages/web/custom-views/package.json
+++ b/packages/web/custom-views/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -28,6 +28,12 @@
 
 
 
+
+## 1.19.0
+<sub>2026-08-03</sub>
+
+- [#1531](https://github.com/wisemen-digital/wisemen-core/pull/1531)  *(minor)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Make select and autocomplete popovers responsive on mobile. The popover will become a bottom drawer with the options
+
 ## 1.18.1
 <sub>2026-07-31</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",

--- a/packages/web/preferences/CHANGELOG.md
+++ b/packages/web/preferences/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 
 
+
+## 1.2.1
+<sub>2026-08-03</sub>
+
+- [#1531](https://github.com/wisemen-digital/wisemen-core/pull/1531)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Make select and autocomplete popovers responsive on mobile. The popover will become a bottom drawer with the options
+
 ## 1.2.0
 <sub>2026-07-01</sub>
 

--- a/packages/web/preferences/package.json
+++ b/packages/web/preferences/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": false,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/vue-core-design-system` 1.18.1 → **1.19.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1541/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Make select and autocomplete popovers responsive on mobile. The popover will become a bottom drawer with the options ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1541/changes#diff-1d1413d5507e710354c632f30217cc719eeae3ceea29c9898dd32a80bf5a9974))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/vue-core-components` 3.0.4 → **3.0.5** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1541/changes#diff-dacd957532d07c2981690c94fd022af305f9e1423c1e310c9aa0f63ce5c5ac3c)</sub>

- Make select and autocomplete popovers responsive on mobile. The popover will become a bottom drawer with the options ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1541/changes#diff-1d1413d5507e710354c632f30217cc719eeae3ceea29c9898dd32a80bf5a9974))

#### `@wisemen/vue-core-custom-views` 1.0.1 → **1.0.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1541/changes#diff-698fe1cb31ce021af5b2ba00ba239f7f739eff1802c11a466be51eac75b7a1ce)</sub>

- Make select and autocomplete popovers responsive on mobile. The popover will become a bottom drawer with the options ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1541/changes#diff-1d1413d5507e710354c632f30217cc719eeae3ceea29c9898dd32a80bf5a9974))

#### `@wisemen/vue-core-preferences` 1.2.0 → **1.2.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1541/changes#diff-cfdc1fee17929d63089c347b317135f368c0977c9f5b5527065f35955de689eb)</sub>

- Make select and autocomplete popovers responsive on mobile. The popover will become a bottom drawer with the options ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1541/changes#diff-1d1413d5507e710354c632f30217cc719eeae3ceea29c9898dd32a80bf5a9974))
