### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/basic-auth-for-feature.md
+++ b/.bumpy/basic-auth-for-feature.md
@@ -1,5 +1,0 @@
----
-'@wisemen/nestjs-auth': minor
----
-
-Added basic auth for nestjs.

--- a/.bumpy/fix-number-field-unit-parsing.md
+++ b/.bumpy/fix-number-field-unit-parsing.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fixed NumberField not parsing unit, percent, or currency formatted values, causing edits to revert on blur.

--- a/.bumpy/gentle-grand-fox.md
+++ b/.bumpy/gentle-grand-fox.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-auth": minor
----
-
-add basic auth

--- a/.bumpy/new-clean-oak.md
+++ b/.bumpy/new-clean-oak.md
@@ -1,5 +1,0 @@
----
-"@wisemen/nestjs-http-exception-filter": patch
----
-
-catch api error like errors that fail check because of version mismatches

--- a/packages/api/nestjs-auth/CHANGELOG.md
+++ b/packages/api/nestjs-auth/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## 0.1.0
+<sub>2026-08-06</sub>
+
+- [#1558](https://github.com/wisemen-digital/wisemen-core/pull/1558)  *(minor)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - Added basic auth for nestjs.
+- [#1558](https://github.com/wisemen-digital/wisemen-core/pull/1558)  *(minor)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - add basic auth
+
 ## 0.0.1
 <sub>2026-07-31</sub>
 

--- a/packages/api/nestjs-auth/package.json
+++ b/packages/api/nestjs-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-auth",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/nestjs-http-exception-filter/CHANGELOG.md
+++ b/packages/api/nestjs-http-exception-filter/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## 0.0.2
+<sub>2026-08-06</sub>
+
+- [#1558](https://github.com/wisemen-digital/wisemen-core/pull/1558)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - catch api error like errors that fail check because of version mismatches
+
 ## 0.0.1
 <sub>2026-07-31</sub>
 

--- a/packages/api/nestjs-http-exception-filter/package.json
+++ b/packages/api/nestjs-http-exception-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-http-exception-filter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/nests-api-status/CHANGELOG.md
+++ b/packages/api/nests-api-status/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## 0.1.0
+<sub>2026-08-06</sub>
+
+- *(minor)* Updated dependency `@wisemen/nestjs-auth` v0.1.0
+
 ## 0.0.1
 <sub>2026-07-31</sub>
 

--- a/packages/api/nests-api-status/package.json
+++ b/packages/api/nests-api-status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nests-api-status",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -31,6 +31,12 @@
 
 
 
+
+## 1.20.1
+<sub>2026-08-06</sub>
+
+- [#1556](https://github.com/wisemen-digital/wisemen-core/pull/1556)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Fixed NumberField not parsing unit, percent, or currency formatted values, causing edits to revert on blur.
+
 ## 1.20.0
 <sub>2026-08-05</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/nestjs-auth` 0.0.1 → **0.1.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1557/changes#diff-0399ec92cd04da80198d9d75031b622d401a8c2940095088e9327fcf8a84fc93)</sub>

- Added basic auth for nestjs. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1557/changes#diff-c8d08bdc97809474d04d0ccd3acbc19195e4154f4caf025b15196bacdb62f636))
- add basic auth ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1557/changes#diff-0d89bdfab55f3d4ff55cc415752b9d84eace795707b251485bd87f98a1900cae))

#### `@wisemen/nests-api-status` 0.0.1 → **0.1.0** _(dep)_ <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1557/changes#diff-7293c03455e5597e27f0ef8a037df4aecd68fba10c3189ed5b8a51b0e45acb58)</sub>

- Updated dependencies

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/nestjs-http-exception-filter` 0.0.1 → **0.0.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1557/changes#diff-486fddd3f387712139103666bbebbc27b3774368acf1671ccacd7adfe6dde02c)</sub>

- catch api error like errors that fail check because of version mismatches ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1557/changes#diff-fdc597cce00bb62f3b328026bca6da72da61eda7555255dc11e013577f19fc04))

#### `@wisemen/vue-core-design-system` 1.20.0 → **1.20.1** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1557/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Fixed NumberField not parsing unit, percent, or currency formatted values, causing edits to revert on blur. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1557/changes#diff-db5d0f0d23cfdd0ea08a1fda5effe7b8e8760f7652130ab932ed372f1f0ef693))
