### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/fix-dialog-nested-popover-outside-click.md
+++ b/.bumpy/fix-dialog-nested-popover-outside-click.md
@@ -1,5 +1,0 @@
----
-"@wisemen/vue-core-design-system": patch
----
-
-Fixed Dialog closing at the same time as a nested open Popover/Autocomplete on outside click, which caused a visible position jump when the popover was near a viewport edge.

--- a/.bumpy/tough-swift-fox.md
+++ b/.bumpy/tough-swift-fox.md
@@ -1,6 +1,0 @@
----
-"@wisemen/nestjs-throttler": minor
-"@wisemen/opentelemetry": patch
----
-
-release @wisemen/nestjs-throttler

--- a/packages/api/nestjs-throttler/CHANGELOG.md
+++ b/packages/api/nestjs-throttler/CHANGELOG.md
@@ -1,3 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## 0.1.0
+<sub>2026-08-07</sub>
+
+- [#1563](https://github.com/wisemen-digital/wisemen-core/pull/1563)  *(minor)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - release @wisemen/nestjs-throttler

--- a/packages/api/nestjs-throttler/package.json
+++ b/packages/api/nestjs-throttler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/nestjs-throttler",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/opentelemetry/CHANGELOG.md
+++ b/packages/api/opentelemetry/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 
 
+
+## 0.2.8
+<sub>2026-08-07</sub>
+
+- [#1563](https://github.com/wisemen-digital/wisemen-core/pull/1563)  *(patch)* Thanks [@Kobe-Kwanten](https://github.com/Kobe-Kwanten)! - release @wisemen/nestjs-throttler
+
 ## 0.2.7
 <sub>2026-07-29</sub>
 

--- a/packages/api/opentelemetry/package.json
+++ b/packages/api/opentelemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisemen/opentelemetry",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/design-system/CHANGELOG.md
+++ b/packages/web/design-system/CHANGELOG.md
@@ -32,6 +32,12 @@
 
 
 
+
+## 1.20.2
+<sub>2026-08-07</sub>
+
+- [#1559](https://github.com/wisemen-digital/wisemen-core/pull/1559)  *(patch)* Thanks [@JeroenVanC](https://github.com/JeroenVanC)! - Fixed Dialog closing at the same time as a nested open Popover/Autocomplete on outside click, which caused a visible position jump when the popover was near a viewport edge.
+
 ## 1.20.1
 <sub>2026-08-06</sub>
 

--- a/packages/web/design-system/package.json
+++ b/packages/web/design-system/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "type": "module",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@wisemen/nestjs-throttler` 0.0.0 → **0.1.0** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1560/changes#diff-01226ede1ae069fe4b01d4e3cf9d5a48f1e6661a119ff2fddf1e68d4c3f042d0)</sub>

- release @wisemen/nestjs-throttler ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1560/changes#diff-a304e5bc4442ba807a1676398e33350fa17df9809fcc21d4948f28dffe7ec663))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/opentelemetry` 0.2.7 → **0.2.8** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1560/changes#diff-6304e36b5db5e7292f398c1066f7512b2d5b2eba9b324a87f1b646585c1aa49b)</sub>

- release @wisemen/nestjs-throttler ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1560/changes#diff-a304e5bc4442ba807a1676398e33350fa17df9809fcc21d4948f28dffe7ec663))

#### `@wisemen/vue-core-design-system` 1.20.1 → **1.20.2** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1560/changes#diff-f76e3eb47de374ba7db01e9952ae0b06bd44158b341a8073eb0a865c1cd8cea1)</sub>

- Fixed Dialog closing at the same time as a nested open Popover/Autocomplete on outside click, which caused a visible position jump when the popover was near a viewport edge. ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1560/changes#diff-e0383011e6a43565c381f43ef95b55b63b2051c621305d6cc623ed71c98516ed))
