### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/lively-tidy-goat.md
+++ b/.bumpy/lively-tidy-goat.md
@@ -1,5 +1,0 @@
----
-"@wisemen/payload-core-translate": patch
----
-
-Deepl now bulks texts per locale to improve performance

--- a/packages/payload/translate/CHANGELOG.md
+++ b/packages/payload/translate/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 
 
+
+## 0.0.10
+<sub>2026-08-11</sub>
+
+- [#1575](https://github.com/wisemen-digital/wisemen-core/pull/1575)  *(patch)* Thanks [@Robbe95](https://github.com/Robbe95)! - Deepl now bulks texts per locale to improve performance
+
 ## 0.0.9
 <sub>2026-08-11</sub>
 

--- a/packages/payload/translate/package.json
+++ b/packages/payload/translate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wisemen/payload-core-translate",
   "type": "module",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": false,
   "imports": {
     "#*": "./src/*"


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@wisemen/payload-core-translate` 0.0.9 → **0.0.10** <sub>[CHANGELOG.md](https://github.com/wisemen-digital/wisemen-core/pull/1576/changes#diff-a54dcc7b88d4691b865d70b05800c6ffeb2fadb2034d69d9e3bdcbcde47da224)</sub>

- Deepl now bulks texts per locale to improve performance ([bump file](https://github.com/wisemen-digital/wisemen-core/pull/1576/changes#diff-fd9858572303c563e1423fb220c0e2a0b7fb0755fd97e05fb73828a4dda62bfc))
